### PR TITLE
Remove text from inside chart

### DIFF
--- a/src/components/atoms/Charts/PieChart/PieChart.tsx
+++ b/src/components/atoms/Charts/PieChart/PieChart.tsx
@@ -1,9 +1,9 @@
 // @ts-nocheck
-import React, { useEffect } from 'react';
-import { Pie } from '@ant-design/charts';
+import React, {useEffect} from 'react';
+import {Pie} from '@ant-design/charts';
 
-import { useAppSelector } from '@src/redux/hooks';
-import { selectTotals } from '@src/redux/reducers/testsListSlice';
+import {useAppSelector} from '@src/redux/hooks';
+import {selectTotals} from '@src/redux/reducers/testsListSlice';
 
 const PieChart = () => {
   const [chartTestStatusData, setChartTestStatusData] = React.useState({
@@ -17,9 +17,14 @@ const PieChart = () => {
   useEffect(() => {
     function getPercentage(): void {
       if (totals) {
-        setChartTestStatusData({ success: totals.passed, error: totals.failed, queued: totals.queued, pending: totals.pending });
+        setChartTestStatusData({
+          success: totals.passed,
+          error: totals.failed,
+          queued: totals.queued,
+          pending: totals.pending,
+        });
       }
-    };
+    }
     getPercentage();
   }, [totals]);
 
@@ -54,13 +59,13 @@ const PieChart = () => {
       content: '{value}',
       style: {
         textAlign: 'center',
-        fontSize: 14,
+        fontSize: 0,
       },
     },
 
     showMarkers: false,
     colorField: 'type',
-    color: ({ type }: any) => {
+    color: ({type}: any) => {
       if (type === 'Success') {
         return '#94D89C';
       }


### PR DESCRIPTION
This PR...

## Changes

- In case of we have so many tests like `1000` or `123454` the text will go out from the chart, so we need to hide it.

## Fixes

- Remove the text from inside the chart.
- close https://github.com/kubeshop/testkube-dashboard/issues/144

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
