### PR TITLE
Disable plain text tab when there is none

### DIFF
--- a/src/components/molecules/ExecutionResultsOutputs/ExecutionResultsOutputs.styled.ts
+++ b/src/components/molecules/ExecutionResultsOutputs/ExecutionResultsOutputs.styled.ts
@@ -127,10 +127,11 @@ export const TestsWithoutStepsContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--font-size-md);
-  height: var(--space-x1l);
-  background: #ff4d4fb3;
+  font-size: 14px;
+  background: #DB5382;
   color: var(--color-light-primary);
+  border: 1px solid var(--color-gray-senary);
+  height: 38px;
   width: 550px;
 
   @media screen and (min-width: 2560px) {

--- a/src/components/molecules/ExecutionResultsOutputs/ExecutionResultsOutputs.tsx
+++ b/src/components/molecules/ExecutionResultsOutputs/ExecutionResultsOutputs.tsx
@@ -112,10 +112,6 @@ const ExecutionResultsOutputs = ({data}: {data: any}) => {
 
   const {TabPane} = Tabs;
 
-  const handleOnClick = () => {
-    setTogglePlainTestTest(!togglePlainTestTest);
-  };
-
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setShowOnlyFailedSteps(event.target.checked);
   };
@@ -180,7 +176,7 @@ const ExecutionResultsOutputs = ({data}: {data: any}) => {
           </StyledTestStepsOutPutContainer>
         </TabPane>
 
-        <TabPane tab="Plain Text" key="2">
+        <TabPane tab="Plain Text" key="2" disabled={!data?.executionResult?.steps}>
           <RenderPlainTestOutput {...data} />
         </TabPane>
         {artifacts && artifacts.length > 0 ? (


### PR DESCRIPTION
This PR...

## Changes

- Disable the plain text tab when there are no steps.

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
