### PR TITLE
Fix API help link in Modal

### DIFF
--- a/src/components/atoms/Modal/Modal.tsx
+++ b/src/components/atoms/Modal/Modal.tsx
@@ -89,7 +89,7 @@ const CustomModal: React.FC<ModalProps> = props => {
             Please provide the TestKube API endpoint for your installation, which will have been provided to you by the
             TestKube installer -{' '}
             <a
-              href="https://kubeshop.github.io/testkube/dashboard/#dashboard-results-endpoint"
+              href="https://kubeshop.github.io/testkube/UI/#ui-results-endpoint"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
This PR...

## Fixes

- Incorrect help link in API Model Dialog: https://github.com/kubeshop/testkube/issues/1419 

## How to test it

- Bring up API Model "Settings"
- Ensure the "Read More" link goes to the correct page.

## Checklist

- [X] tested locally
