### PR TITLE
Trigger deploy to stage

### DIFF
--- a/.github/workflows/deployment-stage.yml
+++ b/.github/workflows/deployment-stage.yml
@@ -3,8 +3,7 @@ name: Publish Docker image with a commit hash tag
 on:
   push:
     branches:
-#      - main
-      - trigger_deploy-to-stage
+      - main
 
 jobs:
   push_to_registry:

--- a/.github/workflows/deployment-stage.yml
+++ b/.github/workflows/deployment-stage.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image with a commit hash tag
+
+on:
+  push:
+    branches:
+#      - main
+      - trigger_deploy-to-stage
+
+jobs:
+  push_to_registry:
+    name: Build and push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out GitHub repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+#      - name: Docker meta for API Server
+#        id: meta_dashboard
+#        uses: docker/metadata-action@v3
+#        with:
+#          images: kubeshop/testkube-dashboard
+#          tags: type=sha
+
+      - name: Step
+        id: github_sha
+        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+
+      - name: Build image and push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ github.sha }}

--- a/.github/workflows/deployment-stage.yml
+++ b/.github/workflows/deployment-stage.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: sha-${{ steps.github_sha.outputs.sha_short }}
+          tags: ${{ github.repository }}:sha-${{ steps.github_sha.outputs.sha_short }}
 
       #Trigger Helm repo workflow to deploy Dashboard to Stage cluster
       - name: Repository Dispatch

--- a/.github/workflows/deployment-stage.yml
+++ b/.github/workflows/deployment-stage.yml
@@ -20,14 +20,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-#      - name: Docker meta for API Server
-#        id: meta_dashboard
-#        uses: docker/metadata-action@v3
-#        with:
-#          images: kubeshop/testkube-dashboard
-#          tags: type=sha
-
-      - name: Step
+      - name: Output commit sha
         id: github_sha
         run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
 
@@ -35,4 +28,13 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ github.sha }}
+          tags: sha-${{ steps.github_sha.outputs.sha_short }}
+
+      #Trigger Helm repo workflow to deploy Dashboard to Stage cluster
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.DEVOPS_GITHUB_TOKEN }}
+          repository: kubeshop/helm-charts
+          event-type: trigger-workflow-dashboard
+          client-payload: '{"image_tag_dashboard": "sha-${{ steps.github_sha.outputs.sha_short }}"}'


### PR DESCRIPTION
This PR added another GH workflow to build a Docker image with commit hash tag and to trigger helm-charts deployment to `Stage` cluster in `helm-charts` repo.

## Changes

-

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] tested in GH
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
