### PR TITLE
fix: execution logs

### DIFF
--- a/src/components/molecules/ExecutionDetails/TestExecutionDetails/TestExecutionDetailsTabs.tsx
+++ b/src/components/molecules/ExecutionDetails/TestExecutionDetails/TestExecutionDetailsTabs.tsx
@@ -40,7 +40,7 @@ const TestExecutionDetailsTabs: React.FC = () => {
     <StyledTestExecutionDetailsTabsContainer>
       <StyledAntTabs>
         <StyledAntTabPane tab="Log Output" key="LogOutputPane">
-          <LogOutput logOutput={output} executionId={name} isRunning={isRunning} />
+          <LogOutput logOutput={output} executionId={id} isRunning={isRunning} />
         </StyledAntTabPane>
         {whetherToShowArtifactsTab ? (
           <StyledAntTabPane tab="Artifacts" key="ArtifactsPane">


### PR DESCRIPTION
LogOutput component seems to call `${localStorage.getItem('apiEndpoint')}/executions/${executionId}/logs`, which requires execution id not execution name?

https://github.com/kubeshop/testkube-dashboard/blob/26d68454f9fae4465acfff666d6bb3a72eaa770d/src/components/molecules/LogOutput/LogOutput.tsx#L37
## Changes

-

## Fixes

-

## How to test it

-

## screenshots

![image](https://user-images.githubusercontent.com/22289110/189873601-288f2fab-c7df-4a35-b04f-47349d1aa79e.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
