### PR TITLE
chore: update wording on timeframe selector

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -29,13 +29,13 @@ import {StyledContainer, StyledPageHeader} from './EntityDetailsContent.styled';
 import ExecutionsTable from './ExecutionsTable';
 import Settings from './Settings';
 import SummaryGrid from './SummaryGrid';
-
+  
 const filterOptions: OptionType[] = [
-  {value: 7, label: 'Last 7 days', key: 'last7Days'},
-  {value: 30, label: 'Last 30 days', key: 'last30Days'},
-  {value: 90, label: 'Last 90 days', key: 'last90Days'},
-  {value: 365, label: 'This year', key: 'thisYear'},
-  {value: 0, label: 'All days', key: 'allDays'},
+  {value: 7, label: 'Timeframe: last 7 days', key: 'last7Days'},
+  {value: 30, label: 'Timeframe: last 30 days', key: 'last30Days'},
+  {value: 90, label: 'Timeframe: last 90 days', key: 'last90Days'},
+  {value: 365, label: 'Timeframe: this year', key: 'thisYear'},
+  {value: 0, label: 'See all executions', key: 'allDays'},
 ];
 
 const EntityDetailsContent: React.FC = () => {


### PR DESCRIPTION
We're updating the wording on the timeframe selector to have more context 

## From

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/132332/197725073-923a07bc-2532-4ec6-b003-3017d5326861.png">


## To

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/132332/197725036-f2a030db-86b3-41db-a307-0a233e934866.png">

