### PR TITLE
Fix prettify button style and position

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -16,7 +16,7 @@ import Colors from '@styles/Colors';
 
 import {EntityDetailsContext} from '@contexts';
 
-import {ArgumentsWrapper, ButtonWrapper} from './Arguments.styled';
+import {ArgumentsWrapper} from './Arguments.styled';
 import {dash, doubleDash, space, stringSpace} from './utils';
 
 const Arguments: React.FC = () => {
@@ -162,11 +162,9 @@ value
 `}
               />
             </Form.Item>
-            <ButtonWrapper>
-              <Button onClick={prettifyArgs} disabled={isPrettified}>
-                Prettify
-              </Button>
-            </ButtonWrapper>
+            <Button onClick={prettifyArgs} $customType="secondary" disabled={isPrettified}>
+              Prettify
+            </Button>
           </Space>
         </Form>
       </ArgumentsWrapper>


### PR DESCRIPTION
## Changes

The prettify button had too much visual weight and was positioned "wrongly" :) 
We're reducing its visual load and place it to the left side

## screenshots

<img width="987" alt="image" src="https://user-images.githubusercontent.com/132332/197786095-0c083e7f-7c93-4fc1-831e-c3931981ffdb.png">

