### PR TITLE
execute clipboard.writeText, if isSecureContext

### DIFF
--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -14,7 +14,9 @@ export const useCopyToClipboard = (textToCopy: string, options: CopyToClipboardO
     let timeout: NodeJS.Timeout;
 
     if (isCopied) {
-      navigator.clipboard.writeText(textToCopy);
+      if (window.isSecureContext) {
+        navigator.clipboard.writeText(textToCopy);
+      }
       timeout = setTimeout(() => {
         setCopyToClipboardState(false);
       }, timeoutInMs);


### PR DESCRIPTION
in `tests` - `setting` - `Definition`
if you click code when insecure network (http),  the screen turn white with error in console
because of trying to write in clipboard in insecure network (http)

```
TypeError: Cannot read properties of undefined (reading 'writeText')
    at useCopyToClipboard.ts:22:27
    at eu (react-dom.production.min.js:242:332)
    at wl (react-dom.production.min.js:285:111)
    at react-dom.production.min.js:282:358
    at Ol (react-dom.production.min.js:280:398)
    at cl (react-dom.production.min.js:272:439)
    at Ho (react-dom.production.min.js:127:105)
    at react-dom.production.min.js:266:269
    
react-dom.production.min.js:127 Uncaught TypeError: Cannot read properties of undefined (reading 'writeText')
    at useCopyToClipboard.ts:22:27
    at eu (react-dom.production.min.js:242:332)
    at wl (react-dom.production.min.js:285:111)
    at react-dom.production.min.js:282:358
    at Ol (react-dom.production.min.js:280:398)
    at cl (react-dom.production.min.js:272:439)
    at Ho (react-dom.production.min.js:127:105)
    at react-dom.production.min.js:266:269
```

## Changes & Fixes
- check the network is secure(https) or insecure network (http), and skip if insecure

## How to test it
- if you click code when insecure network (http),  the screen not turn to white