### PR TITLE
Remove defer from env-config load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Testkube</title>
-    <script src="%PUBLIC_URL%/env-config.js" defer></script>
+    <script src="%PUBLIC_URL%/env-config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Hey,
with defer `REACT_APP_API_SERVER_ENDPOINT` was always null for me. You should be able to easily reproduce it by building the image on the main branch and running it with `REACT_APP_API_SERVER_ENDPOINT` set. It'll show you modal with empty url. Removing defer fixes it for me. 

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
