### PR TITLE
add radio button for executorType in AddExecutorsModal.tsx and change condition of customExecutors filter 

### DIFF
--- a/src/components/custom-antd/Radio/Radio.styled.tsx
+++ b/src/components/custom-antd/Radio/Radio.styled.tsx
@@ -1,0 +1,10 @@
+import {Radio, RadioProps} from 'antd';
+
+import styled from 'styled-components';
+
+export interface ICustomRadioProps extends RadioProps {
+  checked?: boolean;
+}
+
+export const AntdCustomStyledRadio = styled(Radio)<ICustomRadioProps>`
+`;

--- a/src/components/custom-antd/Radio/Radio.tsx
+++ b/src/components/custom-antd/Radio/Radio.tsx
@@ -1,0 +1,7 @@
+import {AntdCustomStyledRadio, ICustomRadioProps} from './Radio.styled';
+
+const Radio: React.FC<ICustomRadioProps> = props => {
+  return <AntdCustomStyledRadio {...props} />;
+};
+
+export default Radio;

--- a/src/components/custom-antd/Radio/RadioGroup/RadioGroup.styled.tsx
+++ b/src/components/custom-antd/Radio/RadioGroup/RadioGroup.styled.tsx
@@ -1,0 +1,5 @@
+import {Radio} from 'antd';
+
+import styled from 'styled-components';
+
+export const AntdCustomStyledRadioGroup = styled(Radio.Group)``;

--- a/src/components/custom-antd/Radio/RadioGroup/RadioGroup.tsx
+++ b/src/components/custom-antd/Radio/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,15 @@
+import {RadioGroupProps} from 'antd';
+
+import { AntdCustomStyledRadioGroup } from './RadioGroup.styled';
+
+const RadioGroup: React.FC<RadioGroupProps> = props => {
+  const {children, ...rest} = props;
+
+  return (
+    <AntdCustomStyledRadioGroup {...props}>
+      {children}
+    </AntdCustomStyledRadioGroup>
+  );
+};
+
+export default RadioGroup;

--- a/src/components/custom-antd/Radio/RadioGroup/index.ts
+++ b/src/components/custom-antd/Radio/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export {default} from './RadioGroup';

--- a/src/components/custom-antd/Radio/index.ts
+++ b/src/components/custom-antd/Radio/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Radio';

--- a/src/components/custom-antd/index.ts
+++ b/src/components/custom-antd/index.ts
@@ -3,6 +3,8 @@ export {default as Button} from './Button';
 export {default as Title} from './Typography/Title';
 export {default as Text} from './Typography/Text';
 export {default as Input} from './Input';
+export {default as Radio} from './Radio';
+export {default as RadioGroup} from './Radio/RadioGroup';
 export {default as Tooltip} from './Tooltip';
 export {default as FormItem} from './Form/FormItem';
 export {default as Upload} from './Upload';

--- a/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
+++ b/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
@@ -5,7 +5,7 @@ import {Form} from 'antd';
 import {useAppSelector} from '@redux/hooks';
 import {selectNamespace} from '@redux/reducers/configSlice';
 
-import {Button, Input} from '@custom-antd';
+import {Button, Input, RadioGroup, Radio} from '@custom-antd';
 
 import {Hint} from '@molecules';
 
@@ -31,10 +31,12 @@ const AddExecutorsModal: React.FC = () => {
       ...values,
       namespace,
       types: [values.type],
-      executorType: 'container',
     };
 
     delete body.type;
+    if (body.executorType === 'job') {
+      delete body.executorType;
+    }
 
     createExecutor(body)
       .then((res: any) => {
@@ -51,6 +53,17 @@ const AddExecutorsModal: React.FC = () => {
     <AddExecutorsModalContainer>
       <Form style={{flex: 1}} layout="vertical" onFinish={onFinish}>
         <Form.Item
+          label="Executor type"
+          required
+          name="executorType"
+          rules={[required]}
+          initialValue="job">
+          <RadioGroup>
+            <Radio value="job">job</Radio>
+            <Radio value="container">container</Radio>
+          </RadioGroup>
+        </Form.Item>
+        <Form.Item
           label="Name"
           required
           name="name"
@@ -58,7 +71,7 @@ const AddExecutorsModal: React.FC = () => {
         >
           <Input placeholder="e.g.: my-container-executor" />
         </Form.Item>
-        <Form.Item label="Executor type" required name="type" rules={[required]}>
+        <Form.Item label="Type" required name="type" rules={[required]}>
           <Input placeholder="e.g.: my-executor/type" />
         </Form.Item>
         <Form.Item label="Container image" required name="image" rules={[required]}>

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -34,7 +34,7 @@ const Executors: React.FC = () => {
 
   const {data: executors, refetch, isLoading} = useGetExecutorsQuery();
 
-  const customExecutors = executors?.filter(executorItem => !executorItem.executor.image.startsWith("kubeshop/")) || [];
+  const customExecutors = executors?.filter(executorItem => !executorItem.executor.image || !executorItem.executor.image.startsWith("kubeshop/")) || [];
 
   const onNavigateToDetails = (name: string) => {
     navigate(`executors/${name}`);

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -34,7 +34,7 @@ const Executors: React.FC = () => {
 
   const {data: executors, refetch, isLoading} = useGetExecutorsQuery();
 
-  const customExecutors = executors?.filter(executorItem => executorItem.executor.executorType === 'container') || [];
+  const customExecutors = executors?.filter(executorItem => !executorItem.executor.image.startsWith("kubeshop/")) || [];
 
   const onNavigateToDetails = (name: string) => {
     navigate(`executors/${name}`);
@@ -73,7 +73,7 @@ const Executors: React.FC = () => {
         <CustomExecutorContainer onClick={() => onNavigateToDetails(executorItem.name)} key={executorItem.name}>
           <Text className="regular big">{executorItem.name}</Text>
           <Text className="regular small" color={Colors.slate500}>
-            {executorItem.executor.executorType}
+            {executorItem.executor.executorType ? executorItem.executor.executorType : 'job'}
           </Text>
           <Text className="regular small" color={Colors.slate500}>
             {executorItem.executor.image}


### PR DESCRIPTION
## Changes

I'm currently making executor for "playwright".
https://github.com/chooco13/testkube-executor-playwright

I found out that the definition value did not come out as I wanted
when creating an executor through the dashboard

The definition value I was expecting

```
spec:
   image: xxx.xxx.xxx.xxx:5000/playwright-executor
   types:
     -playwright/project
```

definition value that actually came out

```
spec:
   executor_type: container
   image: xxx.xxx.xxx.xxx:5000/playwright-executor
   types:
     -playwright/project
```

so I did

- add radio button for executorType in AddExecutorsModal.tsx
- change condition of customExecutors filter

However, even with this
it doesn't come out the way I want it to.

because of below code line
https://github.com/kubeshop/testkube/blob/main/internal/app/api/v1/executor.go#L28
So I also suggest adding ` && executor.Spec.Image == "" ` to the condition on that line.

## Fixes

-

## How to test it

- 

## screenshots

![Modal image](https://i.imgur.com/lCczf3s.png)
![customExecutors filter](https://i.imgur.com/0CPillj.png)

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test