### PR TITLE
Allow running GitHub actions for PRs from forked repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,7 @@ jobs:
         node-version: [16]
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,7 @@ jobs:
         node-version: [16]
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
         node-version: [16]
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1


### PR DESCRIPTION
This PR allows running GitHub actions for PRs from forked repositories.

## Changes

- Do not set `ref` manually for `actions/checkout`
- Upgrade `actions/checkout` to v3

## Fixes

- https://github.com/kubeshop/testkube/issues/3452

## How to test it

- This PR is created from the forked repository, so if GitHub Actions work - it's fine

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
