### PR TITLE
Run Lint job when the files are changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,4 +56,4 @@ jobs:
 
       - name: StyleLint Checking
         if: always()
-        run: npm run style:lint
+        run: npm run stylelint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,18 @@ name: Linting
 on:
   push:
     branches: [main]
+    paths:
+      - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
   pull_request:
     branches: [main]
+    paths:
+      - '**.js'
+      - '**.jsx'
+      - '**.ts'
+      - '**.tsx'
 
 jobs:
   Lint:
@@ -41,9 +51,9 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: ESLint Checking
-        if: ${{ always() && (steps.get_file_changes.outputs.files_added || steps.get_file_changes.outputs.files_modified) }}
+        if: always()
         run: npm run lint
 
       - name: StyleLint Checking
-        if: ${{ always() && (steps.get_file_changes.outputs.files_added || steps.get_file_changes.outputs.files_modified) }}
+        if: always()
         run: npm run style:lint


### PR DESCRIPTION
This PR will ignore the linting job when the files are changed.

## Changes

- The Lint job will be run always when changes are detected
- The Stylelint command had a typo, so it was never run

## Fixes

- [Linting was not performed on PR](https://github.com/kubeshop/testkube/issues/3453)

## How to test it

- Examples
  - This PR - has no changes to the source code - linting is not running
  - [`3058918a`](https://github.com/kubeshop/testkube-dashboard/pull/555/commits/3058918a2790605d9af95a8b91ef481a3eabe424) - has TS changes - linting is running
  - [`9d18cda5`](https://github.com/kubeshop/testkube-dashboard/pull/555/commits/9d18cda5f0449b3b4c1b71a29f024cd4f7d23423) - has no TS changes, but the commit before has - linting is running

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
