### PR TITLE
Get rid of some errors in the console

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import {Suspense, lazy, useEffect, useState} from 'react';
+import {Suspense, lazy, useEffect, useState, useRef} from 'react';
 import {Navigate, Route, Routes, useLocation, useNavigate} from 'react-router-dom';
 import {CSSTransition} from 'react-transition-group';
 
@@ -71,6 +71,8 @@ const App: React.FC = () => {
   const {data: sources, refetch: refetchSources} = useGetSourcesQuery(null, {
     pollingInterval: PollingIntervals.long,
   });
+
+  const logRef = useRef<HTMLDivElement>(null);
 
   const onAcceptCookies = async () => {
     // @ts-ignore
@@ -172,8 +174,8 @@ const App: React.FC = () => {
               </ErrorBoundary>
             </Content>
             {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
-            <CSSTransition in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
-              <FullScreenLogOutput logOutput={logOutput} />
+            <CSSTransition nodeRef={logRef} in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
+              <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
             </CSSTransition>
           </StyledLayoutContentWrapper>
         </Layout>

--- a/src/components/custom-antd/Modal/Modal.tsx
+++ b/src/components/custom-antd/Modal/Modal.tsx
@@ -36,7 +36,7 @@ const CustomModal: React.FC<ModalProps> = props => {
       title={title}
       centered
       maskClosable={false}
-      visible={isModalVisible}
+      open={isModalVisible}
       onCancel={onCancel}
       width={width}
       footer={footer}

--- a/src/components/molecules/LogOutput/FullscreenLogOutput/FullScreenLogOutput.tsx
+++ b/src/components/molecules/LogOutput/FullscreenLogOutput/FullScreenLogOutput.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {forwardRef, useEffect, useRef} from 'react';
 import {useDebounce} from 'react-use';
 
 import Ansi from 'ansi-to-react';
@@ -10,7 +10,7 @@ import {LogOutputProps} from '../LogOutput';
 import {StyledLogTextContainer, StyledPreLogText} from '../LogOutput.styled';
 import {StyledFullscreenLogOutputContainer} from './FullscreenLogOutput.styled';
 
-const FullScreenLogOutput: React.FC<Pick<LogOutputProps, 'actions' | 'logOutput'>> = props => {
+const FullScreenLogOutput = forwardRef<HTMLDivElement, Pick<LogOutputProps, 'actions' | 'logOutput'>>((props, ref) => {
   const {logOutput} = props;
 
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -39,19 +39,17 @@ const FullScreenLogOutput: React.FC<Pick<LogOutputProps, 'actions' | 'logOutput'
   );
 
   return (
-    <>
-      <StyledFullscreenLogOutputContainer logOutputDOMRect={logOutputDOMRect}>
-        <StyledLogTextContainer>
-          {logOutput ? (
-            <StyledPreLogText>
-              <Ansi useClasses>{logOutput}</Ansi>
-            </StyledPreLogText>
-          ) : null}
-          <div ref={bottomRef} />
-        </StyledLogTextContainer>
-      </StyledFullscreenLogOutputContainer>
-    </>
+    <StyledFullscreenLogOutputContainer ref={ref} logOutputDOMRect={logOutputDOMRect}>
+      <StyledLogTextContainer>
+        {logOutput ? (
+          <StyledPreLogText>
+            <Ansi useClasses>{logOutput}</Ansi>
+          </StyledPreLogText>
+        ) : null}
+        <div ref={bottomRef} />
+      </StyledLogTextContainer>
+    </StyledFullscreenLogOutputContainer>
   );
-};
+});
 
 export default FullScreenLogOutput;

--- a/src/components/organisms/EntityList/EntityListFilters/LabelsFilter/LabelsFilter.tsx
+++ b/src/components/organisms/EntityList/EntityListFilters/LabelsFilter/LabelsFilter.tsx
@@ -188,8 +188,8 @@ const LabelsFilter: React.FC<FilterProps> = props => {
         overlay={menu}
         trigger={['click']}
         placement="bottom"
-        onVisibleChange={onVisibleChange}
-        visible={isVisible}
+        onOpenChange={onVisibleChange}
+        open={isVisible}
         disabled={isFiltersDisabled}
       >
         <StyledFilterLabel

--- a/src/components/organisms/EntityList/EntityListFilters/StatusFilter/StatusFilter.tsx
+++ b/src/components/organisms/EntityList/EntityListFilters/StatusFilter/StatusFilter.tsx
@@ -109,8 +109,8 @@ const StatusFilter: React.FC<FilterProps> = props => {
       overlay={menu}
       trigger={['click']}
       placement="bottom"
-      onVisibleChange={onVisibleChange}
-      visible={isVisible}
+      onOpenChange={onVisibleChange}
+      open={isVisible}
       disabled={isFiltersDisabled}
     >
       <StyledFilterLabel

--- a/src/components/organisms/Sider/Sider.styled.tsx
+++ b/src/components/organisms/Sider/Sider.styled.tsx
@@ -30,8 +30,8 @@ export const StyledOther = styled(Space)`
   padding-bottom: 40px;
 `;
 
-export const StyledSider = styled(Layout.Sider)<{isFullScreenLogOutput?: boolean}>`
-  z-index: ${({isFullScreenLogOutput}) => (isFullScreenLogOutput ? '1002' : '1')};
+export const StyledSider = styled(Layout.Sider)<{$isFullScreenLogOutput?: boolean}>`
+  z-index: ${({$isFullScreenLogOutput}) => ($isFullScreenLogOutput ? '1002' : '1')};
 `;
 
 export const StyledSiderChildContainer = styled.div`

--- a/src/components/organisms/Sider/Sider.tsx
+++ b/src/components/organisms/Sider/Sider.tsx
@@ -130,7 +130,7 @@ const Sider: React.FC = () => {
   }, []);
 
   return (
-    <StyledSider width={100} data-cy="navigation-sider" isFullScreenLogOutput={isFullScreenLogOutput}>
+    <StyledSider width={100} data-cy="navigation-sider" $isFullScreenLogOutput={isFullScreenLogOutput}>
       <EndpointModal visible={isModalVisible} setModalState={setModalState} />
       <StyledSiderChildContainer>
         <StyledNavigationMenu>


### PR DESCRIPTION
## Changes

- Use transient prop for passing prop for `Sider` styled component
- use `open` and `onOpenChange` instead of `visible` and `onVisibleChange` for `Modal` and `Dropdown`
- Use `nodeRef` to avoid deprecated `findDOMNode` for `react-transition-group`

## Fixes

- https://github.com/kubeshop/testkube/issues/3509

## How to test it

- Run dashboard and check DevTools console. There are still some errors, but these are resolved

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
