### PR TITLE
fix: expect that the executor might not be selected when creating test

### DIFF
--- a/src/components/wizards/AddTestWizard/steps/FirstStep.tsx
+++ b/src/components/wizards/AddTestWizard/steps/FirstStep.tsx
@@ -99,7 +99,7 @@ const FirstStep: React.FC<any> = props => {
             return (
               <StyledFormSpaceDropdown size={24} direction="vertical">
                 {renderFormItems(
-                  [...additionalFields[testSourceValue](selectedExecutor.executor.meta?.iconURI, uriState), labels],
+                  [...additionalFields[testSourceValue](selectedExecutor?.executor.meta?.iconURI, uriState), labels],
                   {onFileChange, onLabelsChange}
                 )}
               </StyledFormSpaceDropdown>


### PR DESCRIPTION
## Changes

- Expect `selectedExecutor` to be nullish

## Fixes

- https://github.com/kubeshop/testkube/issues/3523

## How to test it

- Steps to reproduce available in the task

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
