### PR TITLE
fix: clean up API endpoint code and resolve race conditions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,8 @@ module.exports = {
     'react/prop-types': 'off', // TODO re-enable
     'react/require-default-props': 'off', // TODO re-enable
     'no-nested-ternary': 'off', // warn
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': 'error',
     'consistent-return': 'off', // warn. Look at api calls closely before enabling this. api.ts.
     // Accessibility off for now to make speed a priority and avoid restructuring for now
     'jsx-a11y/click-events-have-key-events': 'off',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,11 @@ const App: React.FC = () => {
   }, [sources]);
 
   useEffect(() => {
+    // Do not fire the effect if new endpoint is just being set up
+    if (location.pathname === '/apiEndpoint') {
+      return;
+    }
+
     if (!apiEndpoint) {
       setEndpointModalState(true);
       return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,25 +62,7 @@ const App: React.FC = () => {
   const {isFullScreenLogOutput, logOutput} = useAppSelector(selectFullScreenLogOutput);
 
   const [isCookiesVisible, setCookiesVisibility] = useState(!localStorage.getItem('isGADisabled'));
-
   const [isEndpointModalVisible, setEndpointModalState] = useState(false);
-  useEffect(() => {
-    if (!apiEndpoint) {
-      setEndpointModalState(true);
-      return;
-    }
-
-    getApiDetails(apiEndpoint).catch((error) => {
-      // Handle race condition
-      if (getApiEndpoint() !== apiEndpoint) {
-        return;
-      }
-
-      // Display popup
-      notificationCall('failed', 'Could not receive data from the specified API endpoint');
-      setEndpointModalState(true);
-    });
-  }, [apiEndpoint]);
 
   const {data: clusterConfig, refetch: refetchClusterConfig} = useGetClusterConfigQuery();
 
@@ -133,6 +115,24 @@ const App: React.FC = () => {
   useEffect(() => {
     dispatch(setSources(sources || []));
   }, [sources]);
+
+  useEffect(() => {
+    if (!apiEndpoint) {
+      setEndpointModalState(true);
+      return;
+    }
+
+    getApiDetails(apiEndpoint).catch((error) => {
+      // Handle race condition
+      if (getApiEndpoint() !== apiEndpoint) {
+        return;
+      }
+
+      // Display popup
+      notificationCall('failed', 'Could not receive data from the specified API endpoint');
+      setEndpointModalState(true);
+    });
+  }, [apiEndpoint]);
 
   useEffect(() => {
     posthog.capture('$pageview');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import {setSources} from '@redux/reducers/sourcesSlice';
 import {CookiesBanner, EndpointModal} from '@molecules';
 import FullScreenLogOutput from '@molecules/LogOutput/FullscreenLogOutput';
 import LogOutputHeader from '@molecules/LogOutput/LogOutputHeader';
+import notificationCall from '@molecules/Notification';
 
 import {Sider} from '@organisms';
 
@@ -28,7 +29,7 @@ import {ReactComponent as LoadingIcon} from '@assets/loading.svg';
 import {useGetClusterConfigQuery} from '@services/config';
 import {useGetExecutorsQuery} from '@services/executors';
 import {useGetSourcesQuery} from '@services/sources';
-import {useApiEndpoint} from '@services/apiEndpoint';
+import {getApiDetails, getApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
 
 import {MainContext} from '@contexts';
 
@@ -61,7 +62,25 @@ const App: React.FC = () => {
   const {isFullScreenLogOutput, logOutput} = useAppSelector(selectFullScreenLogOutput);
 
   const [isCookiesVisible, setCookiesVisibility] = useState(!localStorage.getItem('isGADisabled'));
+
   const [isEndpointModalVisible, setEndpointModalState] = useState(false);
+  useEffect(() => {
+    if (!apiEndpoint) {
+      setEndpointModalState(true);
+      return;
+    }
+
+    getApiDetails(apiEndpoint).catch((error) => {
+      // Handle race condition
+      if (getApiEndpoint() !== apiEndpoint) {
+        return;
+      }
+
+      // Display popup
+      notificationCall('failed', 'Could not receive data from the specified API endpoint');
+      setEndpointModalState(true);
+    });
+  }, [apiEndpoint]);
 
   const {data: clusterConfig, refetch: refetchClusterConfig} = useGetClusterConfigQuery();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,6 @@ const App: React.FC = () => {
   const wsProtocol = isProtocolSecure ? 'wss://' : 'ws://';
 
   const apiEndpoint = useApiEndpoint();
-  const wsRoot = apiEndpoint ? apiEndpoint.replace(/https?:\/\//, wsProtocol) : '';
 
   const {isFullScreenLogOutput, logOutput} = useAppSelector(selectFullScreenLogOutput);
 
@@ -104,8 +103,6 @@ const App: React.FC = () => {
     dispatch,
     location,
     navigate,
-    apiEndpoint,
-    wsRoot,
     clusterConfig,
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import GA4React, {useGA4React} from 'ga-4-react';
 import posthog from 'posthog-js';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {selectApiEndpoint, selectFullScreenLogOutput, setIsFullScreenLogOutput} from '@redux/reducers/configSlice';
+import {selectFullScreenLogOutput, setIsFullScreenLogOutput} from '@redux/reducers/configSlice';
 import {setExecutors} from '@redux/reducers/executorsSlice';
 import {setSources} from '@redux/reducers/sourcesSlice';
 
@@ -28,6 +28,7 @@ import {ReactComponent as LoadingIcon} from '@assets/loading.svg';
 import {useGetClusterConfigQuery} from '@services/config';
 import {useGetExecutorsQuery} from '@services/executors';
 import {useGetSourcesQuery} from '@services/sources';
+import {useApiEndpoint} from '@services/apiEndpoint';
 
 import {MainContext} from '@contexts';
 
@@ -55,7 +56,7 @@ const App: React.FC = () => {
   const isProtocolSecure = protocol === 'https:';
   const wsProtocol = isProtocolSecure ? 'wss://' : 'ws://';
 
-  const apiEndpoint = useAppSelector(selectApiEndpoint);
+  const apiEndpoint = useApiEndpoint();
   const wsRoot = apiEndpoint ? apiEndpoint.replace(/https?:\/\//, wsProtocol) : '';
 
   const {isFullScreenLogOutput, logOutput} = useAppSelector(selectFullScreenLogOutput);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import {selectFullScreenLogOutput, setIsFullScreenLogOutput} from '@redux/reduce
 import {setExecutors} from '@redux/reducers/executorsSlice';
 import {setSources} from '@redux/reducers/sourcesSlice';
 
-import {CookiesBanner} from '@molecules';
+import {CookiesBanner, EndpointModal} from '@molecules';
 import FullScreenLogOutput from '@molecules/LogOutput/FullscreenLogOutput';
 import LogOutputHeader from '@molecules/LogOutput/LogOutputHeader';
 
@@ -61,6 +61,7 @@ const App: React.FC = () => {
   const {isFullScreenLogOutput, logOutput} = useAppSelector(selectFullScreenLogOutput);
 
   const [isCookiesVisible, setCookiesVisibility] = useState(!localStorage.getItem('isGADisabled'));
+  const [isEndpointModalVisible, setEndpointModalState] = useState(false);
 
   const {data: clusterConfig, refetch: refetchClusterConfig} = useGetClusterConfigQuery();
 
@@ -152,6 +153,7 @@ const App: React.FC = () => {
     <AnalyticsProvider privateKey={segmentIOKey} appVersion={pjson.version}>
       <MainContext.Provider value={mainContextValue}>
         <Layout>
+          <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
           <Sider />
           <StyledLayoutContentWrapper>
             <Content>

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -2,15 +2,13 @@ import React, {useContext, useEffect, useState} from 'react';
 
 import {Space} from 'antd';
 
-import {setNamespace} from '@redux/reducers/configSlice';
-
 import {Button, Input, Modal, Text} from '@custom-antd';
 
 import Colors from '@styles/Colors';
 
 import {MainContext} from '@contexts';
 
-import {getApiDetails, getApiEndpoint, saveApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
+import {useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
 
 import notificationCall from '../Notification/Notification';
 import {StyledSearchUrlForm} from './EndpointModal.styled';
@@ -25,32 +23,16 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
 
   const {dispatch} = useContext(MainContext);
   const currentApiEndpoint = useApiEndpoint();
+  const updateApiEndpoint = useUpdateApiEndpoint();
 
   const [value, setValue] = useState(currentApiEndpoint || '');
   const [isLoading, setLoading] = useState(false);
 
   const checkApiEndpoint = async (endpoint: string) => {
-    const prevApiEndpoint = currentApiEndpoint;
     try {
-      const {url, namespace} = await getApiDetails(endpoint);
-
-      // Handle race condition, when endpoint has been changed externally,
-      // i.e. via EndpointProcessing page.
-      if (getApiEndpoint() !== prevApiEndpoint) {
-        return;
-      }
-
-      saveApiEndpoint(url);
-      dispatch(setNamespace(namespace));
-
+      await updateApiEndpoint(endpoint);
       setModalState(false);
     } catch (error) {
-      // Handle race condition, when endpoint has been changed externally,
-      // i.e. via EndpointProcessing page.
-      if (getApiEndpoint() !== prevApiEndpoint) {
-        return;
-      }
-
       setModalState(true);
       notificationCall('failed', 'Could not receive data from the specified API endpoint');
     } finally {

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -10,7 +10,7 @@ import Colors from '@styles/Colors';
 
 import {MainContext} from '@contexts';
 
-import {getApiDetails, getApiEndpoint, saveApiEndpoint} from '@services/apiEndpoint';
+import {getApiDetails, getApiEndpoint, saveApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
 
 import notificationCall from '../Notification/Notification';
 import {StyledSearchUrlForm} from './EndpointModal.styled';
@@ -23,9 +23,10 @@ type EndpointModalProps = {
 const EndpointModal: React.FC<EndpointModalProps> = props => {
   const {setModalState, visible} = props;
 
-  const {dispatch, apiEndpoint: apiEndpointRedux} = useContext(MainContext);
+  const {dispatch} = useContext(MainContext);
+  const currentApiEndpoint = useApiEndpoint();
 
-  const defaultApiEndpoint = apiEndpointRedux || getApiEndpoint()!;
+  const defaultApiEndpoint = currentApiEndpoint || getApiEndpoint()!;
 
   const [apiEndpoint, setApiEndpointHook] = useState(defaultApiEndpoint);
   const [isLoading, setLoading] = useState(false);
@@ -62,10 +63,10 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   }, []);
 
   useEffect(() => {
-    if (apiEndpointRedux) {
-      setApiEndpointHook(apiEndpointRedux);
+    if (currentApiEndpoint) {
+      setApiEndpointHook(currentApiEndpoint);
     }
-  }, [apiEndpointRedux, visible]);
+  }, [currentApiEndpoint, visible]);
 
   useEffect(() => {
     if (!apiEndpoint) {

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -28,9 +28,11 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   const [value, setValue] = useState(currentApiEndpoint || '');
   const [isLoading, setLoading] = useState(false);
 
-  const checkApiEndpoint = async (endpoint: string) => {
+  const updateEndpoint = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
     try {
-      await updateApiEndpoint(endpoint);
+      await updateApiEndpoint(value);
       setModalState(false);
     } catch (error) {
       setModalState(true);
@@ -40,24 +42,9 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
     }
   };
 
-  const handleOpenUrl = (event: React.FormEvent) => {
-    event.preventDefault();
-    setLoading(true);
-    checkApiEndpoint(value);
-  };
-
   useEffect(() => {
     setValue(currentApiEndpoint || '');
   }, [currentApiEndpoint, visible]);
-
-  // FIXME: This component should not control that
-  useEffect(() => {
-    if (!currentApiEndpoint) {
-      setModalState(true);
-    } else {
-      checkApiEndpoint(currentApiEndpoint);
-    }
-  }, [currentApiEndpoint]);
 
   return (
     <Modal
@@ -68,7 +55,7 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
       dataTestCloseBtn="endpoint-modal-close-button"
       width={693}
       content={
-        <StyledSearchUrlForm onSubmit={handleOpenUrl} data-cy="modal-api-endpoint">
+        <StyledSearchUrlForm onSubmit={updateEndpoint} data-cy="modal-api-endpoint">
           <Text>
             We could not detect the right Testkube API endpoint for you. Please enter the API endpoint for your
             installation (e.g. from the output of the Testkube installer)&nbsp;

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -10,7 +10,7 @@ import Colors from '@styles/Colors';
 
 import {MainContext} from '@contexts';
 
-import {getApiDetails, getApiEndpoint, saveApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
+import {getApiDetails, saveApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
 
 import notificationCall from '../Notification/Notification';
 import {StyledSearchUrlForm} from './EndpointModal.styled';
@@ -26,9 +26,7 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   const {dispatch} = useContext(MainContext);
   const currentApiEndpoint = useApiEndpoint();
 
-  const defaultApiEndpoint = currentApiEndpoint || getApiEndpoint()!;
-
-  const [apiEndpoint, setApiEndpointHook] = useState(defaultApiEndpoint);
+  const [apiEndpoint, setApiEndpointHook] = useState(currentApiEndpoint || '');
   const [isLoading, setLoading] = useState(false);
 
   const checkApiEndpoint = async () => {
@@ -57,8 +55,8 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   };
 
   useEffect(() => {
-    if (defaultApiEndpoint) {
-      saveApiEndpoint(defaultApiEndpoint);
+    if (currentApiEndpoint) {
+      saveApiEndpoint(currentApiEndpoint);
     }
   }, []);
 
@@ -77,10 +75,10 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   }, []);
 
   useEffect(() => {
-    if (!getApiEndpoint()) {
+    if (!currentApiEndpoint) {
       setModalState(true);
     }
-  }, [getApiEndpoint()]);
+  }, [currentApiEndpoint]);
 
   return (
     <Modal

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -4,8 +4,6 @@ import {Space} from 'antd';
 
 import axios from 'axios';
 
-import {config} from '@constants/config';
-
 import {setApiEndpoint, setNamespace} from '@redux/reducers/configSlice';
 
 import {Button, Input, Modal, Text} from '@custom-antd';
@@ -16,7 +14,8 @@ import Colors from '@styles/Colors';
 
 import {MainContext} from '@contexts';
 
-import env from '../../../env';
+import {getApiEndpoint, saveApiEndpoint} from '@services/apiEndpoint';
+
 import notificationCall from '../Notification/Notification';
 import {StyledSearchUrlForm} from './EndpointModal.styled';
 
@@ -25,14 +24,14 @@ type EndpointModalProps = {
   visible: boolean;
 };
 
-axios.defaults.baseURL = localStorage.getItem('apiEndpoint') || env?.apiUrl;
+axios.defaults.baseURL = getApiEndpoint() || undefined;
 
 const EndpointModal: React.FC<EndpointModalProps> = props => {
   const {setModalState, visible} = props;
 
   const {dispatch, apiEndpoint: apiEndpointRedux} = useContext(MainContext);
 
-  const defaultApiEndpoint = apiEndpointRedux || localStorage.getItem('apiEndpoint') || env?.apiUrl;
+  const defaultApiEndpoint = apiEndpointRedux || getApiEndpoint()!;
 
   const [apiEndpoint, setApiEndpointHook] = useState(defaultApiEndpoint);
   const [isLoading, setLoading] = useState(false);
@@ -48,8 +47,7 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
             const targetUrl = url.replace('/info', '');
             axios.defaults.baseURL = targetUrl;
 
-            localStorage.setItem(config.apiEndpoint, targetUrl);
-
+            saveApiEndpoint(targetUrl);
             dispatch(setApiEndpoint(targetUrl));
 
             if (res.namespace) {
@@ -88,9 +86,8 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
 
   useEffect(() => {
     if (defaultApiEndpoint) {
+      saveApiEndpoint(defaultApiEndpoint);
       dispatch(setApiEndpoint(defaultApiEndpoint));
-
-      localStorage.setItem('apiEndpoint', defaultApiEndpoint);
     }
   }, []);
 
@@ -109,10 +106,10 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   }, []);
 
   useEffect(() => {
-    if (!localStorage.getItem('apiEndpoint')) {
+    if (!getApiEndpoint()) {
       setModalState(true);
     }
-  }, [localStorage.getItem('apiEndpoint')]);
+  }, [getApiEndpoint()]);
 
   return (
     <Modal

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -26,17 +26,16 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   const {dispatch} = useContext(MainContext);
   const currentApiEndpoint = useApiEndpoint();
 
-  const [apiEndpoint, setApiEndpointHook] = useState(currentApiEndpoint || '');
+  const [value, setValue] = useState(currentApiEndpoint || '');
   const [isLoading, setLoading] = useState(false);
 
-  const checkApiEndpoint = async () => {
+  const checkApiEndpoint = async (endpoint: string) => {
     try {
-      const {url, namespace} = await getApiDetails(apiEndpoint);
+      const {url, namespace} = await getApiDetails(endpoint);
 
       saveApiEndpoint(url);
       dispatch(setNamespace(namespace));
 
-      setApiEndpointHook(url);
       setModalState(false);
     } catch (error) {
       setModalState(true);
@@ -48,35 +47,20 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
 
   const handleOpenUrl = (event: React.FormEvent) => {
     event.preventDefault();
-
     setLoading(true);
-
-    checkApiEndpoint();
+    checkApiEndpoint(value);
   };
 
   useEffect(() => {
-    if (currentApiEndpoint) {
-      saveApiEndpoint(currentApiEndpoint);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (currentApiEndpoint) {
-      setApiEndpointHook(currentApiEndpoint);
-    }
+    setValue(currentApiEndpoint || '');
   }, [currentApiEndpoint, visible]);
 
-  useEffect(() => {
-    if (!apiEndpoint) {
-      setModalState(true);
-    } else {
-      checkApiEndpoint();
-    }
-  }, []);
-
+  // FIXME: This component should not control that
   useEffect(() => {
     if (!currentApiEndpoint) {
       setModalState(true);
+    } else {
+      checkApiEndpoint(currentApiEndpoint);
     }
   }, [currentApiEndpoint]);
 
@@ -106,9 +90,9 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
               id="url"
               name="url"
               onChange={event => {
-                setApiEndpointHook(event.target.value);
+                setValue(event.target.value);
               }}
-              value={apiEndpoint}
+              value={value}
               width="550px"
               data-test="endpoint-modal-input"
               placeholder="e.g.: https://my.domain/results/v1"

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -4,7 +4,7 @@ import {Space} from 'antd';
 
 import axios from 'axios';
 
-import {setApiEndpoint, setNamespace} from '@redux/reducers/configSlice';
+import {setNamespace} from '@redux/reducers/configSlice';
 
 import {Button, Input, Modal, Text} from '@custom-antd';
 
@@ -46,9 +46,7 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
           if (res.version && res.commit) {
             const targetUrl = url.replace('/info', '');
             axios.defaults.baseURL = targetUrl;
-
             saveApiEndpoint(targetUrl);
-            dispatch(setApiEndpoint(targetUrl));
 
             if (res.namespace) {
               dispatch(setNamespace(res.namespace));
@@ -87,7 +85,6 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
   useEffect(() => {
     if (defaultApiEndpoint) {
       saveApiEndpoint(defaultApiEndpoint);
-      dispatch(setApiEndpoint(defaultApiEndpoint));
     }
   }, []);
 

--- a/src/components/molecules/LogOutput/LogOutput.tsx
+++ b/src/components/molecules/LogOutput/LogOutput.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useContext, useEffect, useRef, useState} from 'react';
+import {memo, useCallback, useEffect, useRef, useState} from 'react';
 import useWebSocket from 'react-use-websocket';
 
 import Ansi from 'ansi-to-react';
@@ -8,7 +8,7 @@ import {LogAction} from '@models/log';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectFullScreenLogOutput, setLogOutput, setLogOutputDOMRect} from '@redux/reducers/configSlice';
 
-import {MainContext} from '@contexts';
+import {useWsEndpoint} from '@services/apiEndpoint';
 
 import {StyledLogOutputContainer, StyledLogTextContainer, StyledPreLogText} from './LogOutput.styled';
 import LogOutputHeader from './LogOutputHeader';
@@ -42,7 +42,7 @@ const LogOutput: React.FC<LogOutputProps> = props => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const {wsRoot} = useContext(MainContext);
+  const wsRoot = useWsEndpoint();
 
   const {isFullScreenLogOutput} = useAppSelector(selectFullScreenLogOutput);
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
@@ -13,6 +13,8 @@ import {getTestExecutorIcon} from '@redux/utils/executorIcon';
 
 import useStateCallback from '@hooks/useStateCallback';
 
+import {useWsEndpoint} from '@services/apiEndpoint';
+
 import {PollingIntervals} from '@utils/numbers';
 
 import {EntityDetailsContext, MainContext} from '@contexts';
@@ -32,8 +34,9 @@ const EntityDetailsContainer: React.FC<EntityDetailsBlueprint> = props => {
     useAbortExecution,
   } = props;
 
-  const {navigate, location, wsRoot} = useContext(MainContext);
+  const {navigate, location} = useContext(MainContext);
   const {daysFilterValue: defaultDaysFilterValue, currentPage: defaultCurrentPage} = useContext(EntityDetailsContext);
+  const wsRoot = useWsEndpoint();
 
   const {pathname} = location;
 

--- a/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -17,6 +17,8 @@ import {EntityGrid} from '@molecules';
 
 import useTrackTimeAnalytics from '@hooks/useTrackTimeAnalytics';
 
+import {useApiEndpoint} from '@services/apiEndpoint';
+
 import {compareFiltersObject} from '@utils/objects';
 
 import {MainContext} from '@contexts';
@@ -54,7 +56,8 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
   const [isApplyingFilters, setIsApplyingFilters] = useState(false);
   const [isLoadingNext, setIsLoadingNext] = useState(false);
 
-  const {dispatch, navigate, apiEndpoint} = useContext(MainContext);
+  const {dispatch, navigate} = useContext(MainContext);
+  const apiEndpoint = useApiEndpoint();
   const {queryFilters, dataSource, setQueryFilters} = useContext(EntityListContext);
   const prevQueryFilters = usePrevious(queryFilters) || queryFilters;
 

--- a/src/components/organisms/Sider/Sider.tsx
+++ b/src/components/organisms/Sider/Sider.tsx
@@ -1,4 +1,4 @@
-import {useContext, useMemo, useState} from 'react';
+import {useContext, useMemo} from 'react';
 import {NavLink} from 'react-router-dom';
 
 import {Space, Tooltip} from 'antd';
@@ -7,8 +7,6 @@ import {useAppSelector} from '@redux/hooks';
 import {selectFullScreenLogOutput} from '@redux/reducers/configSlice';
 
 import {Icon} from '@atoms';
-
-import {EndpointModal} from '@molecules';
 
 import {openDiscord, openDocumentation, openGithub} from '@utils/externalLinks';
 
@@ -79,7 +77,6 @@ const routes = [
 ];
 
 const Sider: React.FC = () => {
-  const [isModalVisible, setModalState] = useState(false);
   const {navigate} = useContext(MainContext);
 
   const {isFullScreenLogOutput} = useAppSelector(selectFullScreenLogOutput);
@@ -129,7 +126,6 @@ const Sider: React.FC = () => {
 
   return (
     <StyledSider width={100} data-cy="navigation-sider" $isFullScreenLogOutput={isFullScreenLogOutput}>
-      <EndpointModal visible={isModalVisible} setModalState={setModalState} />
       <StyledSiderChildContainer>
         <StyledNavigationMenu>
           <Space size={30} direction="vertical">

--- a/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
+++ b/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
@@ -11,7 +11,7 @@ import {saveApiEndpoint} from '@services/apiEndpoint';
 import {EndpointProcessingContainer} from './EndpointProcessing.styled';
 
 const EndpointProcessing: React.FC = () => {
-  const {dispatch, navigate} = useContext(MainContext);
+  const {navigate} = useContext(MainContext);
 
   const searchParams = useURLSearchParams();
 

--- a/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
+++ b/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
@@ -1,7 +1,5 @@
 import {useContext, useEffect} from 'react';
 
-import {setApiEndpoint} from '@redux/reducers/configSlice';
-
 import {Title} from '@custom-antd';
 
 import useURLSearchParams from '@hooks/useURLSearchParams';
@@ -35,7 +33,6 @@ const EndpointProcessing: React.FC = () => {
     if (searchParams.apiEndpoint) {
       const validatedApiEndpoint = validateApiEndpoint(searchParams.apiEndpoint.toString());
       saveApiEndpoint(validatedApiEndpoint);
-      dispatch(setApiEndpoint(validatedApiEndpoint));
     }
 
     navigate('/');

--- a/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
+++ b/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
@@ -1,7 +1,5 @@
 import {useContext, useEffect} from 'react';
 
-import {config} from '@constants/config';
-
 import {setApiEndpoint} from '@redux/reducers/configSlice';
 
 import {Title} from '@custom-antd';
@@ -11,6 +9,8 @@ import useURLSearchParams from '@hooks/useURLSearchParams';
 import {hasProtocol} from '@utils/strings';
 
 import {MainContext} from '@contexts';
+
+import {saveApiEndpoint} from '@services/apiEndpoint';
 
 import {EndpointProcessingContainer} from './EndpointProcessing.styled';
 
@@ -34,9 +34,7 @@ const EndpointProcessing: React.FC = () => {
   useEffect(() => {
     if (searchParams.apiEndpoint) {
       const validatedApiEndpoint = validateApiEndpoint(searchParams.apiEndpoint.toString());
-
-      localStorage.setItem(config.apiEndpoint, validatedApiEndpoint);
-
+      saveApiEndpoint(validatedApiEndpoint);
       dispatch(setApiEndpoint(validatedApiEndpoint));
     }
 

--- a/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
+++ b/src/components/pages/EndpointProcessing/EndpointProcessing.tsx
@@ -4,8 +4,6 @@ import {Title} from '@custom-antd';
 
 import useURLSearchParams from '@hooks/useURLSearchParams';
 
-import {hasProtocol} from '@utils/strings';
-
 import {MainContext} from '@contexts';
 
 import {saveApiEndpoint} from '@services/apiEndpoint';
@@ -17,22 +15,9 @@ const EndpointProcessing: React.FC = () => {
 
   const searchParams = useURLSearchParams();
 
-  const validateApiEndpoint = (apiEndpoint: string) => {
-    if (hasProtocol(apiEndpoint)) {
-      return apiEndpoint;
-    }
-
-    if (apiEndpoint.startsWith('localhost')) {
-      return `http://${apiEndpoint}`;
-    }
-
-    return apiEndpoint;
-  };
-
   useEffect(() => {
     if (searchParams.apiEndpoint) {
-      const validatedApiEndpoint = validateApiEndpoint(searchParams.apiEndpoint.toString());
-      saveApiEndpoint(validatedApiEndpoint);
+      saveApiEndpoint(searchParams.apiEndpoint.toString());
     }
 
     navigate('/');

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -12,6 +12,7 @@ import {PageBlueprint} from '@organisms';
 
 import {ReactComponent as ExecutorsIcon} from '@assets/executor.svg';
 
+import {useApiEndpoint} from '@services/apiEndpoint';
 import {useGetExecutorsQuery} from '@services/executors';
 
 import Colors from '@styles/Colors';
@@ -29,7 +30,8 @@ import {
 } from './ExecutorsList.styled';
 
 const Executors: React.FC = () => {
-  const {navigate, apiEndpoint} = useContext(MainContext);
+  const {navigate} = useContext(MainContext);
+  const apiEndpoint = useApiEndpoint();
 
   const [activeTabKey, setActiveTabKey] = useState('custom');
   const [isAddExecutorModalVisible, setAddExecutorModalVisibility] = useState(false);

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -2,15 +2,13 @@ import {useContext, useState} from 'react';
 
 import {Form, Input, Space} from 'antd';
 
-import {setNamespace} from '@redux/reducers/configSlice';
-
 import {FormItem, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {MainContext} from '@contexts';
 
-import {getApiDetails, saveApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
+import {useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
 
 const ApiEndpoint = () => {
   const [form] = Form.useForm();
@@ -19,17 +17,16 @@ const ApiEndpoint = () => {
 
   const {dispatch} = useContext(MainContext);
   const apiEndpoint = useApiEndpoint();
+  const updateApiEndpoint = useUpdateApiEndpoint();
 
   const checkApiEndpoint = async (endpoint: string) => {
     try {
-      const {url, namespace} = await getApiDetails(endpoint);
-
-      saveApiEndpoint(url);
-      dispatch(setNamespace(namespace));
-      setTimeout(() => {
-        notificationCall('passed', 'API endpoint set up  successfully');
-        form.resetFields();
-      });
+      if (await updateApiEndpoint(endpoint)) {
+        setTimeout(() => {
+          notificationCall('passed', 'API endpoint set up successfully');
+          form.resetFields();
+        });
+      }
     } catch (error) {
       notificationCall('failed', 'Could not receive data from the specified API endpoint');
     } finally {

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -20,9 +20,9 @@ const ApiEndpoint = () => {
   const {dispatch} = useContext(MainContext);
   const apiEndpoint = useApiEndpoint();
 
-  const checkApiEndpoint = async (newApiEndpoint: string) => {
+  const checkApiEndpoint = async (endpoint: string) => {
     try {
-      const {url, namespace} = await getApiDetails(newApiEndpoint);
+      const {url, namespace} = await getApiDetails(endpoint);
 
       saveApiEndpoint(url);
       dispatch(setNamespace(namespace));

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -4,7 +4,7 @@ import {Form, Input, Space} from 'antd';
 
 import axios from 'axios';
 
-import {setApiEndpoint, setNamespace} from '@redux/reducers/configSlice';
+import {setNamespace} from '@redux/reducers/configSlice';
 
 import {FormItem, Text} from '@custom-antd';
 
@@ -33,9 +33,7 @@ const ApiEndpoint = () => {
           if (res.version && res.commit) {
             const targetUrl = url.replace('/info', '');
             axios.defaults.baseURL = targetUrl;
-
             saveApiEndpoint(targetUrl);
-            dispatch(setApiEndpoint(targetUrl));
 
             if (res.namespace) {
               dispatch(setNamespace(res.namespace));

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -10,14 +10,15 @@ import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {MainContext} from '@contexts';
 
-import {getApiDetails, saveApiEndpoint} from '@services/apiEndpoint';
+import {getApiDetails, saveApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
 
 const ApiEndpoint = () => {
   const [form] = Form.useForm();
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const {dispatch, apiEndpoint} = useContext(MainContext);
+  const {dispatch} = useContext(MainContext);
+  const apiEndpoint = useApiEndpoint();
 
   const checkApiEndpoint = async (newApiEndpoint: string) => {
     try {

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -4,8 +4,6 @@ import {Form, Input, Space} from 'antd';
 
 import axios from 'axios';
 
-import {config} from '@constants/config';
-
 import {setApiEndpoint, setNamespace} from '@redux/reducers/configSlice';
 
 import {FormItem, Text} from '@custom-antd';
@@ -15,6 +13,8 @@ import {ConfigurationCard, notificationCall} from '@molecules';
 import {checkAPIEndpoint} from '@utils/endpoint';
 
 import {MainContext} from '@contexts';
+
+import {saveApiEndpoint} from '@services/apiEndpoint';
 
 const ApiEndpoint = () => {
   const [form] = Form.useForm();
@@ -34,13 +34,12 @@ const ApiEndpoint = () => {
             const targetUrl = url.replace('/info', '');
             axios.defaults.baseURL = targetUrl;
 
-            localStorage.setItem(config.apiEndpoint, targetUrl);
+            saveApiEndpoint(targetUrl);
+            dispatch(setApiEndpoint(targetUrl));
 
             if (res.namespace) {
               dispatch(setNamespace(res.namespace));
             }
-
-            dispatch(setApiEndpoint(targetUrl));
 
             setTimeout(() => {
               notificationCall('passed', 'API endpoint set up  successfully');

--- a/src/contexts/MainContext.ts
+++ b/src/contexts/MainContext.ts
@@ -12,8 +12,6 @@ export type MainContextProps = {
   navigate: ReturnType<typeof useNavigate>;
   ga4React: ReturnType<typeof useGA4React>;
   location: ReturnType<typeof useLocation>;
-  apiEndpoint: string | null;
-  wsRoot: string;
   clusterConfig?: ClusterConfig;
 };
 

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,5 +1,4 @@
 interface ConfigState {
-  apiEndpoint: string | null;
   namespace: string;
   redirectTarget: {
     runTarget: boolean;

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -93,7 +93,6 @@ const initialExecutorsState: ExecutorsState = {
 };
 
 const initialConfigState: ConfigState = {
-  apiEndpoint: null,
   namespace: 'testkube',
   redirectTarget: {
     runTarget: false,

--- a/src/redux/reducers/configSlice.ts
+++ b/src/redux/reducers/configSlice.ts
@@ -10,9 +10,6 @@ export const configSlice = createSlice({
   name: 'configSlice',
   initialState: initialState.config,
   reducers: {
-    setApiEndpoint: (state: Draft<ConfigState>, action: PayloadAction<string>) => {
-      state.apiEndpoint = action.payload;
-    },
     setNamespace: (state: Draft<ConfigState>, action: PayloadAction<string>) => {
       state.namespace = action.payload;
     },
@@ -53,13 +50,11 @@ export const configSlice = createSlice({
   },
 });
 
-export const selectApiEndpoint = (state: RootState) => state.config.apiEndpoint;
 export const selectNamespace = (state: RootState) => state.config.namespace;
 export const selectRedirectTarget = (state: RootState) => state.config.redirectTarget;
 export const selectFullScreenLogOutput = (state: RootState) => state.config.fullScreenLogOutput;
 
 export const {
-  setApiEndpoint,
   setIsFullScreenLogOutput,
   openFullScreenLogOutput,
   closeFullScreenLogOutput,

--- a/src/services/apiEndpoint.spec.ts
+++ b/src/services/apiEndpoint.spec.ts
@@ -95,7 +95,7 @@ describe('services', () => {
           saveApiEndpoint('http://abc/v1');
           expect(getApiEndpoint()).toBe('http://abc/v1');
         });
-      })
+      });
 
       describe('Falling back when no environment is set', () => {
         replaceEnvEach('apiUrl', null);

--- a/src/services/apiEndpoint.spec.ts
+++ b/src/services/apiEndpoint.spec.ts
@@ -1,0 +1,280 @@
+import {createElement} from 'react';
+import {act, renderHook} from '@testing-library/react';
+
+import axios from 'axios';
+
+import {config} from '@constants/config';
+
+import MainContext from '@contexts/MainContext';
+
+import env from '../env';
+
+import {
+  getApiDetails,
+  getApiEndpoint,
+  sanitizeApiEndpoint,
+  saveApiEndpoint,
+  useApiEndpoint,
+  useUpdateApiEndpoint,
+  useWsEndpoint,
+} from './apiEndpoint';
+
+function replaceEnvEach<K extends keyof typeof env>(name: K, value: (typeof env)[K]): void {
+  let restore: typeof value;
+  beforeEach(() => {
+    restore = env[name];
+    env[name] = value;
+  });
+  afterEach(() => {
+    env[name] = restore;
+  });
+}
+
+function createAutoResetSpy(): jest.SpyInstance {
+  const fetchMock = jest.fn();
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+  return fetchMock;
+}
+
+function mockFetchEach(): jest.SpyInstance {
+  const prevFetch = global.fetch;
+  const fetchMock = createAutoResetSpy();
+  beforeEach(() => {
+    // @ts-ignore: mocking
+    global.fetch = fetchMock;
+  });
+  afterEach(() => {
+    global.fetch = prevFetch;
+  });
+
+  return fetchMock;
+}
+
+describe('services', () => {
+  describe('apiEndpoint', () => {
+    // Test data
+    const version = 'v1.10.20';
+    const commit = '2074e2d0310c357dfc6a6ab5dd326b4877d2eadf';
+    const namespace = 'test-namespace';
+
+    describe('sanitizeApiEndpoint', () => {
+      it('should correctly build endpoint without protocol', () => {
+        expect(sanitizeApiEndpoint('localhost:8080/v1')).toBe('http://localhost:8080/v1');
+      });
+
+      it('should correctly add missing /v1 on the end', () => {
+        expect(sanitizeApiEndpoint('https://localhost:8080/')).toBe('https://localhost:8080/v1');
+        expect(sanitizeApiEndpoint('http://localhost:8080')).toBe('http://localhost:8080/v1');
+      });
+
+      it('should ignore ending slashes', () => {
+        expect(sanitizeApiEndpoint('http://localhost:8080/v1')).toBe('http://localhost:8080/v1');
+        expect(sanitizeApiEndpoint('http://localhost:8080/v1/')).toBe('http://localhost:8080/v1');
+        expect(sanitizeApiEndpoint('http://localhost:8080/v1///')).toBe('http://localhost:8080/v1');
+      });
+
+      it('should return null for empty values', () => {
+        expect(sanitizeApiEndpoint(undefined)).toBe(null);
+        expect(sanitizeApiEndpoint(null)).toBe(null);
+        expect(sanitizeApiEndpoint('')).toBe(null);
+      });
+    });
+
+    describe('getApiEndpoint', () => {
+      describe('Environment variable', () => {
+        replaceEnvEach('apiUrl', 'test-api-url');
+
+        it('should sanitize endpoint from environment variable', () => {
+          saveApiEndpoint('');
+          expect(getApiEndpoint()).toBe('http://test-api-url/v1');
+        });
+
+        it('should prioritize local storage over environment variable', () => {
+          saveApiEndpoint('http://abc/v1');
+          expect(getApiEndpoint()).toBe('http://abc/v1');
+        });
+      })
+
+      describe('Falling back when no environment is set', () => {
+        replaceEnvEach('apiUrl', null);
+
+        it('should be null', () => {
+          saveApiEndpoint('');
+          expect(getApiEndpoint()).toBe(null);
+        });
+      });
+    });
+
+    describe('saveApiEndpoint', () => {
+      let prevBaseURL: string | undefined;
+      beforeEach(() => {
+        prevBaseURL = axios.defaults.baseURL;
+      });
+      afterEach(() => {
+        axios.defaults.baseURL = prevBaseURL;
+      });
+
+      it('should allow to set the endpoint', () => {
+        saveApiEndpoint('http://abc/v1');
+        expect(getApiEndpoint()).toBe('http://abc/v1');
+      });
+
+      it('should allow to replace the endpoint', () => {
+        saveApiEndpoint('http://abc/v1');
+        saveApiEndpoint('http://def/v1');
+        expect(getApiEndpoint()).toBe('http://def/v1');
+      });
+
+      it('should save the value in the localStorage', () => {
+        saveApiEndpoint('abc');
+        expect(localStorage.getItem(config.apiEndpoint)).toBe('http://abc/v1');
+      });
+
+      it('should change Axios\' base URL to the endpoint', () => {
+        saveApiEndpoint('abc');
+        expect(axios.defaults.baseURL).toBe('http://abc/v1');
+      });
+
+      it('should empty Axios\' base URL when no endpoint provided', () => {
+        saveApiEndpoint('');
+        expect(axios.defaults.baseURL).toBe(undefined);
+      });
+    });
+
+    describe('useApiEndpoint', () => {
+      it('should return the API endpoint correctly', () => {
+        saveApiEndpoint('api/v1');
+        const {result} = renderHook(() => useApiEndpoint());
+        expect(result.current).toBe('http://api/v1');
+      });
+
+      it('should react to the API endpoint change', () => {
+        saveApiEndpoint('api/v1');
+        const {result, rerender} = renderHook(() => useApiEndpoint());
+        act(() => {
+          saveApiEndpoint('another-api/v1');
+        });
+        expect(result.current).toBe('http://another-api/v1');
+      });
+    });
+
+    describe('useWsEndpoint', () => {
+      it('should return the WS endpoint correctly', () => {
+        saveApiEndpoint('api/v1');
+        const {result} = renderHook(() => useWsEndpoint());
+        expect(result.current).toBe('ws://api/v1');
+      });
+
+      it('should support secured connection', () => {
+        saveApiEndpoint('https://api/v1');
+        const {result} = renderHook(() => useWsEndpoint());
+        expect(result.current).toBe('wss://api/v1');
+      });
+
+      it('should react to the API endpoint change', () => {
+        saveApiEndpoint('api/v1');
+        const {result, rerender} = renderHook(() => useWsEndpoint());
+        act(() => {
+          saveApiEndpoint('another-api/v1');
+        });
+        expect(result.current).toBe('ws://another-api/v1');
+      });
+    });
+
+    describe('getApiDetails', () => {
+      const fetchMock = mockFetchEach();
+
+      it('should successfully obtain server info', async () => {
+        fetchMock.mockImplementationOnce(async () => ({
+          json: async () => ({ version, commit, namespace }),
+        }));
+        expect(await getApiDetails('api')).toEqual({ url: 'http://api/v1', namespace });
+      });
+
+      it('should fall back namespace to the "testkube"', async () => {
+        fetchMock.mockImplementationOnce(async () => ({
+          json: async () => ({ version, commit }),
+        }));
+        expect(await getApiDetails('api')).toEqual({ url: 'http://api/v1', namespace: 'testkube' });
+      });
+
+      it('should detect problems with server connection', async () => {
+        fetchMock.mockImplementationOnce(() => Promise.reject(new Error('Server connection problem!')));
+
+        const spy = jest.fn();
+        await getApiDetails('api').catch(spy);
+
+        expect(spy).toBeCalledWith(new Error('Server connection problem!'));
+      });
+
+      it('should detect invalid response schema from the server', async () => {
+        fetchMock.mockImplementationOnce(async () => ({
+          json: async () => ({ hello: 'world' }),
+        }));
+        const spy = jest.fn();
+        await getApiDetails('api').catch(spy);
+        expect(spy).toBeCalledWith(new Error('Received invalid data from the provided API endpoint'));
+      });
+    });
+
+    describe('useUpdateApiEndpoint', () => {
+      const fetchMock = mockFetchEach();
+      const dispatch = createAutoResetSpy();
+      const initialEndpoint = 'http://initial/v1';
+
+      const wrapper = ({ children }) => createElement(MainContext.Provider, {value: {dispatch}}, children);
+      const {result: {current: update}} = renderHook(() => useUpdateApiEndpoint(), {wrapper});
+
+      beforeEach(() => {
+        saveApiEndpoint(initialEndpoint);
+      });
+
+      it('should throw error when there is a problem with server', async () => {
+        fetchMock.mockImplementationOnce(() => Promise.reject(new Error('Server connection problem!')));
+
+        const spy = jest.fn();
+        await update('new').catch(spy);
+
+        expect(spy).toBeCalledWith(new Error('Server connection problem!'));
+        expect(getApiEndpoint()).toBe(initialEndpoint);
+        expect(dispatch).not.toBeCalled();
+      });
+
+      it('should save namespace & endpoint when the server is fine', async () => {
+        fetchMock.mockImplementationOnce(async () => ({
+          json: async () => ({ version, commit, namespace }),
+        }));
+
+        expect(await update('new')).toBe(true);
+        expect(getApiEndpoint()).toBe('http://new/v1');
+        expect(dispatch).toBeCalledWith({payload: namespace, type: 'configSlice/setNamespace'});
+      });
+
+      it('should ignore server error when race condition occurs', async () => {
+        fetchMock.mockImplementationOnce(() => Promise.reject(new Error('Server connection problem!')));
+
+        const promise = update('new');
+        saveApiEndpoint('race');
+
+        expect(await promise).toBe(false);
+        expect(getApiEndpoint()).toBe('http://race/v1');
+        expect(dispatch).not.toBeCalled();
+      });
+
+      it('should ignore server success when race condition occurs', async () => {
+        fetchMock.mockImplementationOnce(async () => ({
+          json: async () => ({ version, commit, namespace }),
+        }));
+
+        const promise = update('new');
+        saveApiEndpoint('race');
+
+        expect(await promise).toBe(false);
+        expect(getApiEndpoint()).toBe('http://race/v1');
+        expect(dispatch).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -80,6 +80,16 @@ export function useApiEndpoint(): string | null {
   return getApiEndpoint();
 }
 
+export function useWsEndpoint(): string | null {
+  const apiEndpoint = useApiEndpoint();
+  return useMemo(() => {
+    if (apiEndpoint === null) {
+      return null;
+    }
+    return apiEndpoint.replace(/^http(?=s?:\/\/)/, 'ws');
+  }, [apiEndpoint]);
+}
+
 export async function getApiDetails(apiEndpoint: string): Promise<ApiDetails> {
   const url = sanitizeApiEndpoint(apiEndpoint);
 

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -3,6 +3,8 @@ import {useUnmount, useUpdate} from 'react-use';
 
 import {config} from '@constants/config';
 
+import {hasProtocol} from '@utils/strings';
+
 import env from '../env';
 
 type ApiEndpointListener = (apiEndpoint: string | null) => void;
@@ -13,11 +15,28 @@ const listeners = new Set<ApiEndpointListener>();
 // When localStorage is not working,
 // we'd like to keep it at least for the current session.
 // TODO: Consider storing it in cookie or URL params as a fallback.
-let cachedApiEndpoint: string | null = localStorage.getItem(config.apiEndpoint);
+let cachedApiEndpoint: string | null = sanitizeApiEndpoint(localStorage.getItem(config.apiEndpoint));
 
 function notifySubscriptions(): void {
   const endpoint = getApiEndpoint();
   listeners.forEach((listener) => listener(endpoint));
+}
+
+export function sanitizeApiEndpoint(apiEndpoint: string): string;
+export function sanitizeApiEndpoint(apiEndpoint: null | undefined): null;
+export function sanitizeApiEndpoint(apiEndpoint: string | null | undefined): string | null;
+export function sanitizeApiEndpoint<T>(apiEndpoint: string | null | undefined): string | null {
+  if (apiEndpoint == null) {
+    return null;
+  }
+
+  if (!hasProtocol(apiEndpoint)) {
+    apiEndpoint = `${window.location.protocol}//${apiEndpoint}`;
+  }
+
+  return apiEndpoint
+    .replace(/\/+$/, '')
+    .replace(/(\/v1)?$/, '/v1');
 }
 
 export function getApiEndpoint(): string | null {
@@ -26,8 +45,8 @@ export function getApiEndpoint(): string | null {
 
 export function saveApiEndpoint(apiEndpoint: string): boolean {
   try {
-    cachedApiEndpoint = apiEndpoint;
-    localStorage.setItem(config.apiEndpoint, apiEndpoint);
+    cachedApiEndpoint = sanitizeApiEndpoint(apiEndpoint);
+    localStorage.setItem(config.apiEndpoint, cachedApiEndpoint);
     notifySubscriptions();
     return true;
   } catch (e) {

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -1,0 +1,27 @@
+import {config} from '@constants/config';
+
+import env from '../env';
+
+// When localStorage is not working,
+// we'd like to keep it at least for the current session.
+// TODO: Consider storing it in cookie or URL params as a fallback.
+let cachedApiEndpoint: string | null = localStorage.getItem(config.apiEndpoint);
+
+export function isApiEndpointSaved(): boolean {
+  return getApiEndpoint() === localStorage.getItem(config.apiEndpoint);
+}
+
+export function getApiEndpoint(): string | null {
+  return cachedApiEndpoint || env?.apiUrl || null;
+}
+
+export function saveApiEndpoint(apiEndpoint: string): boolean {
+  try {
+    cachedApiEndpoint = apiEndpoint;
+    localStorage.setItem(config.apiEndpoint, apiEndpoint);
+    return true;
+  } catch (e) {
+    // Safari in private mode may throw QuotaExceeded error
+    return false;
+  }
+}

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -7,10 +7,6 @@ import env from '../env';
 // TODO: Consider storing it in cookie or URL params as a fallback.
 let cachedApiEndpoint: string | null = localStorage.getItem(config.apiEndpoint);
 
-export function isApiEndpointSaved(): boolean {
-  return getApiEndpoint() === localStorage.getItem(config.apiEndpoint);
-}
-
 export function getApiEndpoint(): string | null {
   return cachedApiEndpoint || env?.apiUrl || null;
 }

--- a/src/services/artifacts.ts
+++ b/src/services/artifacts.ts
@@ -1,11 +1,11 @@
-import {config} from '@constants/config';
+import {getApiEndpoint} from '@services/apiEndpoint';
 
 export const downloadFileName = (filename: string, executionId: string) => {
   const encodedFileName = encodeURIComponent(filename);
   const doubleEncodedFileName = encodeURIComponent(encodedFileName);
 
   return fetch(
-    `${localStorage.getItem(config.apiEndpoint)}/executions/${executionId}/artifacts/${doubleEncodedFileName}`
+    `${getApiEndpoint()}/executions/${executionId}/artifacts/${doubleEncodedFileName}`
   ).then(response => {
     return response.blob().then(blob => {
       const url = window.URL.createObjectURL(blob);
@@ -26,7 +26,7 @@ export const downloadFile = (executionId: string) => {
     const doubleEncodedFileName = encodeURIComponent(encodedFileName);
 
     return fetch(
-      `${localStorage.getItem(config.apiEndpoint)}/executions/${executionId}/artifacts/${doubleEncodedFileName}`
+      `${getApiEndpoint()}/executions/${executionId}/artifacts/${doubleEncodedFileName}`
     ).then(response => {
       return response.blob().then(blob => {
         const url = window.URL.createObjectURL(blob);

--- a/src/utils/endpoint.ts
+++ b/src/utils/endpoint.ts
@@ -1,21 +1,5 @@
-import {hasProtocol} from '@utils/strings';
+import {sanitizeApiEndpoint} from '@services/apiEndpoint';
 
 export const checkAPIEndpoint = (apiEndpoint: string, checkURLWorkingState: (apiEndpoint: string) => void) => {
-  const endsWithV1 = apiEndpoint.endsWith('/v1');
-
-  if (hasProtocol(apiEndpoint)) {
-    if (endsWithV1) {
-      checkURLWorkingState(`${apiEndpoint}/info`);
-    } else {
-      checkURLWorkingState(`${apiEndpoint}/v1/info`);
-    }
-  } else {
-    const targetProtocol = `${window.location.protocol}//`;
-
-    if (endsWithV1) {
-      checkURLWorkingState(`${targetProtocol}${apiEndpoint}/info`);
-    } else {
-      checkURLWorkingState(`${targetProtocol}${apiEndpoint}/v1/info`);
-    }
-  }
+  checkURLWorkingState(`${sanitizeApiEndpoint(apiEndpoint)}/info`);
 };

--- a/src/utils/endpoint.ts
+++ b/src/utils/endpoint.ts
@@ -1,5 +1,0 @@
-import {sanitizeApiEndpoint} from '@services/apiEndpoint';
-
-export const checkAPIEndpoint = (apiEndpoint: string, checkURLWorkingState: (apiEndpoint: string) => void) => {
-  checkURLWorkingState(`${sanitizeApiEndpoint(apiEndpoint)}/info`);
-};

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -2,12 +2,13 @@ import {BaseQueryFn, FetchArgs, FetchBaseQueryError, fetchBaseQuery} from '@redu
 
 import {ParsedQuery} from 'query-string';
 
-import {config} from '@constants/config';
 import {searchParamsLists} from '@constants/searchParams';
 
 import {SearchParamKey, SearchParamsKeys, SearchParamsType, ValidatedSearchParams} from '@models/searchParams';
 
 import {isArraylikeQueryParam} from '@utils/strings';
+
+import {getApiEndpoint} from '@services/apiEndpoint';
 
 const prohibitedValues = ['undefined', 'null'];
 
@@ -78,7 +79,7 @@ export const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBas
   api,
   extraOptions
 ) => {
-  const baseUrl = localStorage.getItem(config.apiEndpoint);
+  const baseUrl = getApiEndpoint();
 
   if (!baseUrl) {
     return {


### PR DESCRIPTION
## Changes

- `apiEndpoint` is taken only from `services/apiEndpoint.ts` - cached or `localStorage`
   - before, depending on the function, it's been taken from `MainContext`, Redux store, or directly from `localStorage`
- Race conditions have been solved
   - Before, when `apiEndpoint` query parameter was used, there was a race between setting `apiEndpoint` from query param, and saving the verified one from the `localStorage`. The query param from `apiEndpoint` was replaced, as it was saved earlier.
- Clean up the code related to the API endpoint
   - Unify `EndpointModal.tsx` and `ApiEndpoint.tsx` logic
   - Move `<EndpointModal>` rendering from `<Sider>` to `<App>`
   - Move logic for sanity API endpoint check from `EndpointModal` to the `App` component
      - Keeping that logic in the `EndpointModal` was obscure, as it was global logic
      - It helped to avoid saving in the `localStorage` when the user took it from the environment variables

## Fixes

- https://github.com/kubeshop/testkube/issues/2779

## How to test it

- There are some unit tests added
- Check if everything works well
- Check if `apiEndpoint` query param replaces value from the `localStorage`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
