### PR TITLE
fix: allow scrolling the page content, while cursor is on sider

### DIFF
--- a/src/App.styled.tsx
+++ b/src/App.styled.tsx
@@ -3,7 +3,5 @@ import {Layout} from 'antd';
 import styled from 'styled-components';
 
 export const StyledLayoutContentWrapper = styled(Layout)`
-  height: 100vh;
-
   overflow: hidden;
 `;

--- a/src/components/organisms/Sider/Sider.styled.tsx
+++ b/src/components/organisms/Sider/Sider.styled.tsx
@@ -31,15 +31,24 @@ export const StyledOther = styled(Space)`
 `;
 
 export const StyledSider = styled(Layout.Sider)<{$isFullScreenLogOutput?: boolean}>`
+  height: 100vh;
   z-index: ${({$isFullScreenLogOutput}) => ($isFullScreenLogOutput ? '1002' : '1')};
+
+  .ant-layout-sider-children {
+    display: flex;
+    justify-content: center;
+  }
 `;
 
 export const StyledSiderChildContainer = styled.div`
+  position: fixed;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 
-  height: inherit;
+  width: 100px;
+  height: 100vh;
+  overflow: auto;
 `;
 
 export const StyledNavigationMenu = styled.div`


### PR DESCRIPTION
## Changes

- make the content with flexible height instead of 100vh
- keep the sidebar fixed anyway

## Fixes

- https://github.com/kubeshop/testkube/issues/3539

## How to test it

- move cursor to the sider and scroll

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
