### PR TITLE
Don't use PostHog when telemetry is disabled, limit its data

### DIFF
--- a/src/AnalyticsProvider.tsx
+++ b/src/AnalyticsProvider.tsx
@@ -7,21 +7,22 @@ import {AnalyticsContext} from '@contexts';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 
 type AnalyticsProviderProps = {
+  disabled?: boolean;
   privateKey: string;
   children: React.ReactNode;
   appVersion: string;
 };
 
 export const AnalyticsProvider: React.FC<AnalyticsProviderProps> = props => {
-  const {privateKey, children, appVersion} = props;
+  const {disabled, privateKey, children, appVersion} = props;
 
   const notDevEnv = process.env.NODE_ENV !== 'development';
 
   const analytics = useMemo(() => {
-    if (privateKey && notDevEnv) {
+    if (!disabled && privateKey && notDevEnv) {
       return AnalyticsBrowser.load({writeKey: privateKey});
     }
-  }, [privateKey]);
+  }, [disabled, privateKey]);
 
   const hostname = window.location.hostname;
 
@@ -41,7 +42,7 @@ export const AnalyticsProvider: React.FC<AnalyticsProviderProps> = props => {
   }, []);
 
   const analyticsTrack = (type: string, data: any) => {
-    if (notDevEnv) {
+    if (!disabled && notDevEnv) {
       analytics?.track(type, {...data, hostname, appVersion});
     }
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,7 +179,7 @@ const App: React.FC = () => {
   }, [apiEndpoint]);
 
   return (
-    <AnalyticsProvider privateKey={segmentIOKey} appVersion={pjson.version}>
+    <AnalyticsProvider disabled={!isTelemetryEnabled} privateKey={segmentIOKey} appVersion={pjson.version}>
       <MainContext.Provider value={mainContextValue}>
         <Layout>
           <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />

--- a/src/components/molecules/CookiesBanner/CookiesBanner.types.ts
+++ b/src/components/molecules/CookiesBanner/CookiesBanner.types.ts
@@ -1,4 +1,4 @@
 export interface CookiesBannerProps {
   onAcceptCookies: () => void;
-  onDeclineCookies: (args?: {skipGAEvent?: boolean}) => void;
+  onDeclineCookies: () => void;
 }


### PR DESCRIPTION
## Changes

- Limit data sent to PostHog - the referrer and the host will not be sent, and captured text will be masked
- Initialize PostHog only when the telemetry is not disabled

## Fixes

- https://github.com/kubeshop/testkube/issues/3609

## How to test it

- To show the cookies banner: enable telemetry in the backend and delete `isGADisabled` property from `localStorage`
- See what is happening without any button clicked, or after accepting/canceling

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
