### PR TITLE
feat: cut LogOutput to show only (expandable) 300 lines

### DIFF
--- a/src/components/molecules/LogOutput/LogOutput.styled.tsx
+++ b/src/components/molecules/LogOutput/LogOutput.styled.tsx
@@ -12,7 +12,7 @@ export const BaseLogOutputStyles = `
   flex-direction: column;
 
   overflow: auto;
-  
+
   ${invisibleScroll}
 `;
 
@@ -35,6 +35,7 @@ export const StyledLogText = styled.span``;
 
 export const StyledPreLogText = styled.pre`
   display: flex;
+  flex-direction: column;
 
   padding: 10px;
   font-size: 12px;
@@ -58,7 +59,7 @@ export const StyledLogOutputHeaderContainer = styled.div<{$isFullScreen?: boolea
   ${({$isFullScreen}) =>
     $isFullScreen
       ? `
-  position: absolute; 
+  position: absolute;
   right: 0;
 
   z-index: 1002;
@@ -87,10 +88,10 @@ const FullscreenIconBaseStyles = `
   right: 35px;
 
   border-radius: 2px;
-  
+
   padding: 4px;
   margin: 6px;
-  
+
   font-size: 22px;
 `;
 

--- a/src/components/molecules/LogOutput/utils.spec.ts
+++ b/src/components/molecules/LogOutput/utils.spec.ts
@@ -1,0 +1,85 @@
+import {renderHook} from '@testing-library/react';
+
+import {countLines, getLastLines, useCountLines, useLastLines} from './utils';
+
+describe('molecules', () => {
+  describe('LogOutput', () => {
+    describe('countLines', () => {
+      it('should always have at least single line', () => {
+        expect(countLines('')).toBe(1);
+        expect(countLines('there is some text')).toBe(1);
+      });
+
+      it('should ignore carriage returns', () => {
+        expect(countLines('there is\rsome\rother')).toBe(1);
+      });
+
+      it('should count empty lines', () => {
+        expect(countLines('\n')).toBe(2);
+        expect(countLines('there\n\n')).toBe(3);
+      });
+
+      it('should count many lines', () => {
+        expect(countLines('abc\n'.repeat(100))).toBe(101);
+        expect(countLines('\nabc'.repeat(100))).toBe(101);
+        expect(countLines('\nabc'.repeat(100).substring(1))).toBe(100);
+      });
+    });
+
+    describe('getLastLines', () => {
+      it('should return whole text when does not have enough lines', () => {
+        expect(getLastLines('abc', 1)).toBe('abc');
+        expect(getLastLines('abc', 10)).toBe('abc');
+        expect(getLastLines('abc\ndef', 10)).toBe('abc\ndef');
+      });
+
+      it('should cut text to last lines', () => {
+        expect(getLastLines('abc\n'.repeat(100), 10)).toBe('abc\n'.repeat(9));
+        expect(getLastLines('\nabc'.repeat(100), 10)).toBe('\nabc'.repeat(10).substring(1));
+      });
+    });
+
+    describe('useCountLines', () => {
+      it('should return number of lines', () => {
+        const { result } = renderHook(() => useCountLines('\nabc'.repeat(100)));
+        expect(result.current).toBe(101);
+      });
+
+      it('should react to text change', () => {
+        const { result, rerender } = renderHook(({text}) => useCountLines(text), {
+          initialProps: {text: '\nabc'.repeat(100)},
+        });
+        rerender({text: '\nabc'.repeat(1000)});
+        expect(result.current).toBe(1001);
+      });
+    });
+
+    describe('useLastLines', () => {
+      it('should return all text when there is less lines', () => {
+        const { result } = renderHook(() => useLastLines('\nabc'.repeat(100), 1000));
+        expect(result.current).toBe('\nabc'.repeat(100));
+      });
+
+      it('should cut text to last lines', () => {
+        const { result } = renderHook(() => useLastLines('abc\n'.repeat(100), 10));
+        expect(result.current).toBe('abc\n'.repeat(9));
+      });
+
+      it('should react to text change', () => {
+        const { result, rerender } = renderHook(({text}) => useLastLines(text, 200), {
+          initialProps: {text: '\nabc'.repeat(100)},
+        });
+        rerender({text: 'abc\n'.repeat(1000)});
+        expect(result.current).toBe('abc\n'.repeat(199));
+      });
+
+      it('should react to lines change', () => {
+        const { result, rerender } = renderHook(({max}) => useLastLines('abc\n'.repeat(1000), max), {
+          initialProps: {max: 100},
+        });
+        rerender({max: 200});
+        expect(result.current).toBe('abc\n'.repeat(199));
+      });
+    });
+  });
+});

--- a/src/components/molecules/LogOutput/utils.ts
+++ b/src/components/molecules/LogOutput/utils.ts
@@ -1,0 +1,30 @@
+import {useMemo} from 'react';
+
+export const countLines = (text: string): number => {
+  let count = 1;
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+export const getLastLines = (text: string, lines: number): string => {
+  let count = 0;
+  for (let i = text.length - 1; i >= 0; i -= 1) {
+    if (text[i] === '\n') {
+      count += 1;
+      if (lines === count) {
+        return text.substring(i + 1);
+      }
+    }
+  }
+  return text;
+};
+
+export const useCountLines = (text: string) => useMemo(() => countLines(text), [text]);
+
+export const useLastLines = (text: string, maxLines: number): string => {
+  return useMemo(() => countLines(text) <= maxLines ? text : getLastLines(text, maxLines), [text, maxLines]);
+};


### PR DESCRIPTION
## Changes

- Add an option to show only the last lines of the log (defaults to 300)

## Fixes

- Partially https://github.com/kubeshop/testkube/issues/3627

## How to test it

- Unit tests
- Manually: open some execution details

## screenshots

| <img width="1920" alt="Zrzut ekranu 2023-04-6 o 14 32 35" src="https://user-images.githubusercontent.com/3843526/230379902-be70ada8-9399-45c4-b8d3-5ab028f5e320.png"> |
|-|

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
