### PR TITLE
Add loader for execution details

### DIFF
--- a/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.tsx
+++ b/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.tsx
@@ -1,6 +1,7 @@
-import {useContext, useEffect, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 
 import {Drawer} from 'antd';
+import {LoadingOutlined} from '@ant-design/icons';
 
 import {Entity} from '@models/entity';
 
@@ -131,7 +132,18 @@ const ExecutionDetailsDrawer: React.FC = () => {
             {selectedRow ? components[entity] : null}
           </ExecutionDetailsDrawerWrapper>
         </Drawer>
-      ) : null}
+      ) : (
+        <Drawer
+          bodyStyle={{display: 'flex', alignItems: 'center', justifyContent: 'center', background: Colors.slate800, fontSize: '48px'}}
+          headerStyle={{borderBottom: 0, padding: '40px 30px 0', backgroundColor: Colors.slate800}}
+          closable={false}
+          open={isRowSelected}
+          width={drawerWidth}
+          onClose={unselectRow}
+        >
+          <LoadingOutlined />
+        </Drawer>
+      )}
     </ExecutionDetailsContext.Provider>
   );
 };

--- a/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.tsx
+++ b/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.tsx
@@ -66,6 +66,9 @@ const components: {[key in Entity]: any} = {
   tests: <TestExecutionDetailsTabs />,
 };
 
+const headerStyle = {borderBottom: 0, padding: '40px 30px 0', backgroundColor: Colors.slate800};
+const loaderBodyStyle = {display: 'flex', alignItems: 'center', justifyContent: 'center', background: Colors.slate800, fontSize: '48px'};
+
 const ExecutionDetailsDrawer: React.FC = () => {
   const {isRowSelected, selectedRow, unselectRow, entity, execId} = useContext(EntityDetailsContext);
 
@@ -115,7 +118,7 @@ const ExecutionDetailsDrawer: React.FC = () => {
       {data ? (
         <Drawer
           title={<ExecutionDetailsDrawerHeader data={data} />}
-          headerStyle={{borderBottom: 0, padding: '40px 30px 0', backgroundColor: Colors.slate800}}
+          headerStyle={headerStyle}
           closable={false}
           mask
           maskClosable
@@ -134,8 +137,8 @@ const ExecutionDetailsDrawer: React.FC = () => {
         </Drawer>
       ) : (
         <Drawer
-          bodyStyle={{display: 'flex', alignItems: 'center', justifyContent: 'center', background: Colors.slate800, fontSize: '48px'}}
-          headerStyle={{borderBottom: 0, padding: '40px 30px 0', backgroundColor: Colors.slate800}}
+          bodyStyle={loaderBodyStyle}
+          headerStyle={headerStyle}
           closable={false}
           open={isRowSelected}
           width={drawerWidth}


### PR DESCRIPTION
## Changes

- adds loader for the execution details drawer

## Fixes

- Partially https://github.com/kubeshop/testkube/issues/3627

## How to test it

- Open "Test" or "Test Suite" details
- Open execution - when loading for first time, it will show a loader

## screenshots

| <img width="1920" alt="Zrzut ekranu 2023-04-6 o 14 44 22" src="https://user-images.githubusercontent.com/3843526/230382723-bf047cd1-bf35-4a56-8b18-65925abb1b7a.png"> | <img width="1920" alt="Zrzut ekranu 2023-04-6 o 14 44 13" src="https://user-images.githubusercontent.com/3843526/230382768-efa9016b-80db-45cb-986a-a71e27fb5f02.png">| 
|-|-|

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
