### PR TITLE
fix: show cookies banner when telemetry is enabled in cluster

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -208,7 +208,7 @@ const App: React.FC = () => {
             </CSSTransition>
           </StyledLayoutContentWrapper>
         </Layout>
-        {isCookiesVisible && !clusterConfig?.enableTelemetry ? (
+        {isCookiesVisible && clusterConfig?.enableTelemetry ? (
           <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
         ) : null}
       </MainContext.Provider>


### PR DESCRIPTION
## Changes

- Fix typo, to show the cookies banner when it should be visible

## Fixes

- https://github.com/kubeshop/testkube/issues/3609

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
