### PR TITLE
Fix Dashboard - Custom container executor - command is required - can't be removed

### DIFF
--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -72,7 +72,7 @@ const Command: React.FC = () => {
           form.resetFields();
         }}
       >
-        <Form.Item label="Command" required name="command" >
+        <Form.Item label="Command" name="command">
           <Input placeholder="Command" />
         </Form.Item>
       </ConfigurationCard>

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -72,7 +72,7 @@ const Command: React.FC = () => {
           form.resetFields();
         }}
       >
-        <Form.Item label="Command" required name="command">
+        <Form.Item label="Command" required name="command" >
           <Input placeholder="Command" />
         </Form.Item>
       </ConfigurationCard>

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -72,7 +72,7 @@ const Command: React.FC = () => {
           form.resetFields();
         }}
       >
-        <Form.Item label="Command" required name="command" rules={[required]}>
+        <Form.Item label="Command" required name="command">
           <Input placeholder="Command" />
         </Form.Item>
       </ConfigurationCard>

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -9,7 +9,6 @@ import {selectCurrentExecutor, updateExecutorCommand} from '@redux/reducers/exec
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {required} from '@utils/form';
 import {displayDefaultErrorNotification} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';


### PR DESCRIPTION
This PR...

## Changes
Updated the field to not be mandatory
-

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
