### PR TITLE
fix: ignore refetching error when no initial fetching was there

### DIFF
--- a/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -123,10 +123,17 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
       setIsLoadingNext(true);
     }
 
-    contentProps.refetch().then(() => {
-      setIsApplyingFilters(false);
-      setIsLoadingNext(false);
-    });
+    try {
+      contentProps.refetch().then(() => {
+        setIsApplyingFilters(false);
+        setIsLoadingNext(false);
+      });
+    } catch (err: any) {
+      // RTK is failing synchronously if there was it was skipped
+      if (!err?.message.includes('not been started yet')) {
+        throw err;
+      }
+    }
   }, [queryFilters, contentProps.refetch]);
 
   const isFiltersEmpty = compareFiltersObject(initialFiltersState, queryFilters);
@@ -151,7 +158,7 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
         <EntityListTitle
           pageTitle={
             <>
-              {pageTitle} {isApplyingFilters ? <LoadingOutlined /> : null}
+              {pageTitle} {isApplyingFilters && !isFirstTimeLoading ? <LoadingOutlined /> : null}
             </>
           }
         >


### PR DESCRIPTION
## Changes

- This change is to conform the Cloud code more to the OSS, and fix the problem that may happen in future
- When the query was not done yet (i.e. because it was skipped) and refetch was requested, it may fail synchronously

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
