### PR TITLE
tech: add universal permissions mechanism

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -23,6 +23,7 @@
     "^@services",
     "^@styles",
     "^@types",
+    "^@permissions",
     "^@contexts",
     "^@src",
     "^(?!\\.+\\/styled)^[./]?.+$",

--- a/paths.json
+++ b/paths.json
@@ -38,7 +38,9 @@
       "@features": ["src/features/"],
       "@features/*": ["src/features/*"],
       "@redux": ["src/redux/"],
-      "@redux/*": ["src/redux/*"]
+      "@redux/*": ["src/redux/*"],
+      "@permissions": ["src/permissions/"],
+      "@permissions/*": ["src/permissions/*"]
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ import {useGetExecutorsQuery} from '@services/executors';
 import {useGetSourcesQuery} from '@services/sources';
 import {getApiDetails, getApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
 
+import {BasePermissionsResolver, PermissionsProvider} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 import {AnalyticsProvider} from './AnalyticsProvider';
@@ -178,41 +180,46 @@ const App: React.FC = () => {
     refetchClusterConfig();
   }, [apiEndpoint]);
 
+  const permissionsResolver = useMemo(() => new BasePermissionsResolver(), []);
+  const permissionsScope = useMemo(() => ({}), []);
+
   return (
-    <AnalyticsProvider disabled={!isTelemetryEnabled} privateKey={segmentIOKey} appVersion={pjson.version}>
-      <MainContext.Provider value={mainContextValue}>
-        <Layout>
-          <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
-          <Sider />
-          <StyledLayoutContentWrapper>
-            <Content>
-              <ErrorBoundary>
-                <Suspense fallback={<LoadingIcon />}>
-                  <Routes>
-                    <Route path="tests/*" element={<Tests />} />
-                    <Route path="test-suites/*" element={<TestSuites />} />
-                    <Route path="executors/*" element={<Executors />} />
-                    <Route path="sources/*" element={<Sources />} />
-                    <Route path="triggers" element={<Triggers />} />
-                    <Route path="settings" element={<GlobalSettings />} />
-                    <Route path="/apiEndpoint" element={<EndpointProcessing />} />
-                    <Route path="/" element={<Navigate to="/tests" replace />} />
-                    <Route path="*" element={<NotFound />} />
-                  </Routes>
-                </Suspense>
-              </ErrorBoundary>
-            </Content>
-            {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
-            <CSSTransition nodeRef={logRef} in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
-              <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
-            </CSSTransition>
-          </StyledLayoutContentWrapper>
-        </Layout>
-        {isCookiesVisible && clusterConfig?.enableTelemetry ? (
-          <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
-        ) : null}
-      </MainContext.Provider>
-    </AnalyticsProvider>
+    <PermissionsProvider scope={permissionsScope} resolver={permissionsResolver}>
+      <AnalyticsProvider disabled={!isTelemetryEnabled} privateKey={segmentIOKey} appVersion={pjson.version}>
+        <MainContext.Provider value={mainContextValue}>
+          <Layout>
+            <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
+            <Sider />
+            <StyledLayoutContentWrapper>
+              <Content>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingIcon />}>
+                    <Routes>
+                      <Route path="tests/*" element={<Tests />} />
+                      <Route path="test-suites/*" element={<TestSuites />} />
+                      <Route path="executors/*" element={<Executors />} />
+                      <Route path="sources/*" element={<Sources />} />
+                      <Route path="triggers" element={<Triggers />} />
+                      <Route path="settings" element={<GlobalSettings />} />
+                      <Route path="/apiEndpoint" element={<EndpointProcessing />} />
+                      <Route path="/" element={<Navigate to="/tests" replace />} />
+                      <Route path="*" element={<NotFound />} />
+                    </Routes>
+                  </Suspense>
+                </ErrorBoundary>
+              </Content>
+              {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
+              <CSSTransition nodeRef={logRef} in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
+                <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
+              </CSSTransition>
+            </StyledLayoutContentWrapper>
+          </Layout>
+          {isCookiesVisible && clusterConfig?.enableTelemetry ? (
+            <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
+          ) : null}
+        </MainContext.Provider>
+      </AnalyticsProvider>
+    </PermissionsProvider>
   );
 };
 

--- a/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.tsx
+++ b/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.tsx
@@ -26,6 +26,7 @@ type MultiSelectProps = {
   isLoading?: boolean;
   validation?: boolean;
   dataTest?: string;
+  disabled?: boolean;
   menuPlacement?: 'auto' | 'bottom' | 'top';
 };
 
@@ -42,6 +43,7 @@ const CreatableMultiSelect: React.FC<MultiSelectProps> = props => {
     isLoading = false,
     validation,
     dataTest,
+    disabled = false,
     menuPlacement = 'bottom',
   } = props;
 
@@ -86,6 +88,7 @@ const CreatableMultiSelect: React.FC<MultiSelectProps> = props => {
         DropdownIndicator: DefaultDropdownIndicator,
       }}
       data-test={dataTest}
+      isDisabled={disabled}
     />
   );
 };

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
@@ -20,8 +20,10 @@ export const StyledHeader = styled.div`
   border-bottom: 1px solid ${Colors.slate800};
 `;
 
-export const StyledChildren = styled.div`
+export const StyledChildren = styled.div<{$isActionsVisible: boolean}>`
   padding: 20px;
+
+  ${({$isActionsVisible}) => (!$isActionsVisible ? 'cursor: not-allowed' : '')}
 `;
 
 export const StyledFooter = styled.div`

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -26,6 +26,8 @@ type ConfigurationCardProps = {
   isButtonsDisabled?: boolean;
   forceEnableButtons?: boolean;
   children?: React.ReactNode;
+  isEditable?: boolean;
+  enabled?: boolean;
 };
 
 const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
@@ -40,6 +42,8 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
     confirmButtonText = 'Save',
     isButtonsDisabled,
     forceEnableButtons,
+    isEditable = true,
+    enabled = true,
   } = props;
 
   return (
@@ -52,8 +56,8 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
           {description}
         </Text>
       </StyledHeader>
-      {children ? <StyledChildren>{children}</StyledChildren> : null}
-      {(onConfirm || footerText) && (
+      {children ? <StyledChildren $isActionsVisible={enabled || !isEditable}>{children}</StyledChildren> : null}
+      {(enabled && onConfirm) || footerText ? (
         <StyledFooter>
           {footerText && (
             <StyledFooterText>
@@ -64,30 +68,26 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
           )}
           <Form.Item noStyle shouldUpdate>
             {({isFieldsTouched, getFieldsValue}) => {
-              let isDisabled = isButtonsDisabled || (getFieldsValue() && !isFieldsTouched());
+              let disabled = isButtonsDisabled || (getFieldsValue() && !isFieldsTouched());
 
               if (forceEnableButtons) {
-                isDisabled = false;
+                disabled = false;
               }
 
               return (
                 <StyledFooterButtonsContainer>
-                  {onCancel && !isDisabled && (
-                    <Button onClick={onCancel} $customType="secondary">
-                      Cancel
-                    </Button>
-                  )}
-                  {onConfirm ? (
-                    <Button onClick={onConfirm} $customType={isWarning ? 'warning' : 'primary'} disabled={isDisabled}>
-                      {confirmButtonText}
-                    </Button>
-                  ) : null}
+                  <Button onClick={onCancel} $customType="secondary" hidden={!onCancel || disabled}>
+                    Cancel
+                  </Button>
+                  <Button onClick={onConfirm} $customType={isWarning ? 'warning' : 'primary'} disabled={disabled} hidden={!onConfirm}>
+                    {confirmButtonText}
+                  </Button>
                 </StyledFooterButtonsContainer>
               );
             }}
           </Form.Item>
         </StyledFooter>
-      )}
+      ) : null}
     </StyledContainer>
   );
 };

--- a/src/components/molecules/DragNDropList/DragNDropList.tsx
+++ b/src/components/molecules/DragNDropList/DragNDropList.tsx
@@ -3,6 +3,8 @@ import {DragDropContext, Draggable} from 'react-beautiful-dnd';
 
 import {reorder} from '@utils/array';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import StrictModeDroppable from './StrictModeDroppable';
 
 type DragNDropListProps = {
@@ -16,6 +18,7 @@ type DragNDropListProps = {
 
 const DragNDropList: React.FC<DragNDropListProps> = props => {
   const {items = [], setItems, onDelete, scrollRef, ItemComponent, ContainerComponent} = props;
+  const isReadonly = !usePermission(Permissions.editEntity);
 
   const onDragEnd = (result: any) => {
     if (!result.destination || result.source.index === result.destination.index) {
@@ -37,11 +40,11 @@ const DragNDropList: React.FC<DragNDropListProps> = props => {
 
   return (
     <DragDropContext onDragEnd={onDragEnd} onDragStart={onDragStart}>
-      <StrictModeDroppable droppableId="droppable">
+      <StrictModeDroppable droppableId="droppable" isDropDisabled={isReadonly}>
         {(provided, snapshot) => (
           <ContainerComponent {...provided.droppableProps} ref={provided.innerRef} isDragging={snapshot.isDraggingOver}>
             {items.map((item: any, index: number) => (
-              <Draggable key={item.id} draggableId={item.id} index={index}>
+              <Draggable key={item.id} draggableId={item.id} index={index} isDragDisabled={isReadonly}>
                 {(providedDraggable, snapshotDraggable) => (
                   <div
                     ref={providedDraggable.innerRef}
@@ -53,6 +56,7 @@ const DragNDropList: React.FC<DragNDropListProps> = props => {
                       index={index}
                       isDragging={snapshotDraggable.isDragging}
                       onDelete={onDelete}
+                      isDragNDropAvailable={!isReadonly}
                     />
                   </div>
                 )}

--- a/src/components/molecules/EmptyListContent/EmptyListContent.tsx
+++ b/src/components/molecules/EmptyListContent/EmptyListContent.tsx
@@ -1,3 +1,5 @@
+import {ReactElement} from 'react';
+
 import {ExternalLink} from '@atoms';
 
 import {Button, Text, Title} from '@custom-antd';
@@ -9,37 +11,63 @@ import {ReactComponent as CreateTestIcon} from '@assets/create-test.svg';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {StyledEmptyListContainer} from './EmptyListContent.styled';
 
 type EmptyListContentProps = {
   title: string;
-  description: string;
+  description: string | ReactElement;
   buttonText: string;
-  onButtonClick: () => void;
+  onButtonClick?: () => void;
   children?: React.ReactNode;
+  emptyListReadonlyTitle?: string;
+  emptyListReadonlyDescription?: string;
 };
 
 const EmptyListContent: React.FC<EmptyListContentProps> = props => {
-  const {title, description, onButtonClick, children, buttonText} = props;
+  const {
+    title,
+    description,
+    onButtonClick,
+    children,
+    buttonText,
+    emptyListReadonlyTitle,
+    emptyListReadonlyDescription,
+  } = props;
+  const isActionAvailable = usePermission(Permissions.runEntity);
+
   return (
     <StyledEmptyListContainer size={24} direction="vertical">
-      <CreateTestIcon />
-      <Title className="text-center">{title}</Title>
-      <Text className="regular middle text-center" color={Colors.slate400}>
-        {description}
-      </Text>
-      <Button $customType="primary" onClick={onButtonClick}>
-        {buttonText}
-      </Button>
-      <StyledHelpCardsContainer>
-        {children}
-        <StyledLastHelpCardContainer>
-          <HelpCard isHelp link="https://discord.com/invite/hfq44wtR6Q">
-            Need help getting started? Want to talk to Testkube engineers?{' '}
-            <ExternalLink href="https://discord.com/invite/hfq44wtR6Q">Find us on Discord</ExternalLink>
-          </HelpCard>
-        </StyledLastHelpCardContainer>
-      </StyledHelpCardsContainer>
+      {isActionAvailable ? (
+        <>
+          <CreateTestIcon />
+          <Title className="text-center">{title}</Title>
+          <Text className="regular middle text-center" color={Colors.slate400}>
+            {description}
+          </Text>
+          <Button $customType="primary" onClick={onButtonClick}>
+            {buttonText}
+          </Button>
+          <StyledHelpCardsContainer>
+            {children}
+            <StyledLastHelpCardContainer>
+              <HelpCard isHelp link="https://discord.com/invite/hfq44wtR6Q">
+                Need help getting started? Want to talk to Testkube engineers?{' '}
+                <ExternalLink href="https://discord.com/invite/hfq44wtR6Q">Find us on Discord</ExternalLink>
+              </HelpCard>
+            </StyledLastHelpCardContainer>
+          </StyledHelpCardsContainer>
+        </>
+      ) : (
+        <>
+          <CreateTestIcon />
+          <Title className="text-center">{emptyListReadonlyTitle}</Title>
+          <Text className="regular middle text-center" color={Colors.slate400}>
+            {emptyListReadonlyDescription}
+          </Text>
+        </>
+      )}
     </StyledEmptyListContainer>
   );
 };

--- a/src/components/molecules/LabelsSelect/LabelsSelect.tsx
+++ b/src/components/molecules/LabelsSelect/LabelsSelect.tsx
@@ -9,6 +9,8 @@ import {PollingIntervals} from '@utils/numbers';
 
 import {useGetLabelsQuery} from '@services/labels';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {composeLabels} from './utils';
 
 type LabelsSelectProps = {
@@ -34,6 +36,8 @@ const isValidLabel = (value: string) => {
 
 const LabelsSelect: React.FC<LabelsSelectProps> = props => {
   const {onChange, defaultLabels, options, placeholder = 'Add or create new labels', validation, menuPlacement} = props;
+  // TODO: Check if it's actually expected, as it's used in multiple places
+  const isSelectDisabled = usePermission(Permissions.editEntity);
 
   const {data, isFetching} = useGetLabelsQuery(null, {
     pollingInterval: PollingIntervals.default,
@@ -76,6 +80,7 @@ const LabelsSelect: React.FC<LabelsSelectProps> = props => {
       validation={validation}
       menuPlacement={menuPlacement}
       dataTest="labels"
+      disabled={isSelectDisabled}
     />
   );
 };

--- a/src/components/molecules/VariablesFormList/VariablesFormList.styled.tsx
+++ b/src/components/molecules/VariablesFormList/VariablesFormList.styled.tsx
@@ -9,7 +9,7 @@ export const VariablesListContainer = styled.div`
   flex-direction: column;
 `;
 
-export const StyledLablesSpace = styled.div<{noGap?: boolean}>`
+export const StyledLabelsSpace = styled.div<{noGap?: boolean}>`
   display: flex;
   align-items: flex-start;
   gap: ${props => (props.noGap ? '0' : '16px')};

--- a/src/components/molecules/VariablesFormList/VariablesFormList.tsx
+++ b/src/components/molecules/VariablesFormList/VariablesFormList.tsx
@@ -4,18 +4,20 @@ import {DeleteOutlined, EyeInvisibleOutlined, EyeOutlined, PauseOutlined, RightO
 
 import {Variable} from '@models/variable';
 
-import {Button} from '@custom-antd';
+import {Button, Text} from '@custom-antd';
 
 import {validateDuplicateValueByKey} from '@utils';
 import {required} from '@utils/form';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {duplicateKeyMessage, emptyVariableObject, typeOptions} from './VariablesFormList.constants';
 import {
   StyledButtonsContainer,
   StyledKeyFormItem,
-  StyledLablesSpace,
+  StyledLabelsSpace,
   SymbolWrapper,
   VariablesListContainer,
 } from './VariablesFormList.styled';
@@ -28,104 +30,113 @@ type VariablesFormListProps = {
 
 const VariablesFormList: React.FC<VariablesFormListProps> = props => {
   const {data, form} = props;
+  const isButtonVisible = usePermission(Permissions.editEntity);
 
   return (
     <Form.List name="variables-list" initialValue={data}>
       {(fields, {add, remove}) => (
         <VariablesListContainer>
-          {fields.map(({key, name, ...restField}) => {
-            return (
-              <StyledLablesSpace key={key}>
-                <Form.Item
-                  {...restField}
-                  name={[name, 'type']}
-                  style={{minWidth: 160, maxWidth: 160, flex: 1, marginBottom: '0'}}
-                  rules={[required]}
-                >
-                  <Select options={typeOptions} />
-                </Form.Item>
-                <StyledKeyFormItem
-                  {...restField}
-                  name={[name, 'key']}
-                  style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
-                  rules={[
-                    required,
-                    {
-                      message: duplicateKeyMessage,
-                      validator: (_, value) => {
-                        const variables = form.getFieldValue('variables-list');
-                        return validateDuplicateValueByKey(value, variables, 'key')
-                          ? Promise.reject()
-                          : Promise.resolve();
+          {fields && fields.length ? (
+            fields.map(({key, name, ...restField}) => {
+              return (
+                <StyledLabelsSpace key={key}>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'type']}
+                    style={{minWidth: 160, maxWidth: 160, flex: 1, marginBottom: '0'}}
+                    rules={[required]}
+                  >
+                    <Select options={typeOptions} />
+                  </Form.Item>
+                  <StyledKeyFormItem
+                    {...restField}
+                    name={[name, 'key']}
+                    style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
+                    rules={[
+                      required,
+                      {
+                        message: duplicateKeyMessage,
+                        validator: (_, value) => {
+                          const variables = form.getFieldValue('variables-list');
+                          return validateDuplicateValueByKey(value, variables, 'key')
+                            ? Promise.reject()
+                            : Promise.resolve();
+                        },
                       },
-                    },
-                  ]}
-                  $showClearIcon={form.getFieldError(['variables-list', Number(key), 'key'])[0] === duplicateKeyMessage}
-                >
-                  <Input allowClear placeholder="Your variable name" />
-                </StyledKeyFormItem>
-                <SymbolWrapper>
-                  <PauseOutlined style={{transform: 'rotate(90deg)', color: Colors.slate500}} />
-                </SymbolWrapper>
-                <Form.Item noStyle shouldUpdate>
-                  {() => {
-                    const neededFieldValue = form.getFieldValue('variables-list');
+                    ]}
+                    $showClearIcon={form.getFieldError(['variables-list', Number(key), 'key'])[0] === duplicateKeyMessage}
+                  >
+                    <Input allowClear placeholder="Your variable name" />
+                  </StyledKeyFormItem>
+                  <SymbolWrapper>
+                    <PauseOutlined style={{transform: 'rotate(90deg)', color: Colors.slate500}} />
+                  </SymbolWrapper>
+                  <Form.Item noStyle shouldUpdate>
+                    {() => {
+                      const neededFieldValue = form.getFieldValue('variables-list');
 
-                    const inputType = neededFieldValue[name]?.type;
+                      const inputType = neededFieldValue[name]?.type;
 
-                    if (inputType === 'secretRef') {
+                      if (inputType === 'secretRef') {
+                        return (
+                          <>
+                            <Form.Item
+                              {...restField}
+                              name={[name, 'secretRefName']}
+                              style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
+                            >
+                              <Input placeholder="Referenced secret name" />
+                            </Form.Item>
+                            <SymbolWrapper>
+                              <RightOutlined style={{fontSize: 12, color: Colors.slate500}} />
+                            </SymbolWrapper>
+                            <Form.Item
+                              {...restField}
+                              name={[name, 'secretRefKey']}
+                              style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
+                            >
+                              <Input placeholder="Referenced secret key" />
+                            </Form.Item>
+                          </>
+                        );
+                      }
+
                       return (
-                        <>
-                          <Form.Item
-                            {...restField}
-                            name={[name, 'secretRefName']}
-                            style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
-                          >
-                            <Input placeholder="Referenced secret name" />
-                          </Form.Item>
-                          <SymbolWrapper>
-                            <RightOutlined style={{fontSize: 12, color: Colors.slate500}} />
-                          </SymbolWrapper>
-                          <Form.Item
-                            {...restField}
-                            name={[name, 'secretRefKey']}
-                            style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
-                          >
-                            <Input placeholder="Referenced secret key" />
-                          </Form.Item>
-                        </>
+                        <Form.Item
+                          {...restField}
+                          name={[name, 'value']}
+                          style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
+                        >
+                          {form.getFieldValue('variables-list')[name]?.type === 1 ? (
+                            <Input.Password
+                              iconRender={visible => (visible ? <EyeOutlined /> : <EyeInvisibleOutlined />)}
+                              placeholder="Your variable value"
+                            />
+                          ) : (
+                            <Input placeholder="Your variable value" />
+                          )}
+                        </Form.Item>
                       );
-                    }
-
-                    return (
-                      <Form.Item
-                        {...restField}
-                        name={[name, 'value']}
-                        style={{minWidth: '50px', flex: 2, marginBottom: '0'}}
-                      >
-                        {form.getFieldValue('variables-list')[name]?.type === 1 ? (
-                          <Input.Password
-                            iconRender={visible => (visible ? <EyeOutlined /> : <EyeInvisibleOutlined />)}
-                            placeholder="Your variable value"
-                          />
-                        ) : (
-                          <Input placeholder="Your variable value" />
-                        )}
-                      </Form.Item>
-                    );
-                  }}
-                </Form.Item>
-                <SymbolWrapper>
-                  <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
-                </SymbolWrapper>
-              </StyledLablesSpace>
-            );
-          })}
-          <StyledButtonsContainer>
-            <Button $customType="secondary" onClick={() => add(emptyVariableObject)}>
-              Add a new variable
-            </Button>
-          </StyledButtonsContainer>
+                    }}
+                  </Form.Item>
+                  {isButtonVisible ? (
+                    <SymbolWrapper>
+                      <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
+                    </SymbolWrapper>
+                  ) : null}
+                </StyledLabelsSpace>
+              );
+            })
+          ) : (
+            <Text className="regular">No existing variables or secrets in this test.</Text>
+          )}
+          {isButtonVisible ? (
+            <StyledButtonsContainer>
+              <Button $customType="secondary" onClick={() => add(emptyVariableObject)}>
+                Add a new variable
+              </Button>
+            </StyledButtonsContainer>
+          ) : null}
         </VariablesListContainer>
       )}
     </Form.List>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -25,6 +25,8 @@ import {useRunTestMutation} from '@services/tests';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {AnalyticsContext, EntityDetailsContext, MainContext} from '@contexts';
 
 import {EntityDetailsHeaderIcon, StyledContainer, StyledPageHeader} from './EntityDetailsContent.styled';
@@ -45,6 +47,7 @@ const EntityDetailsContent: React.FC = () => {
     useContext(EntityDetailsContext);
   const {analyticsTrack} = useContext(AnalyticsContext);
   const {navigate} = useContext(MainContext);
+  const mayRun = usePermission(Permissions.runEntity);
   const {isLoading, handleLoading} = useLoadingIndicator(2000);
 
   const {isSettingsTabConfig} = useAppSelector(selectRedirectTarget);
@@ -140,6 +143,7 @@ const EntityDetailsContent: React.FC = () => {
             onClick={onRunButtonClick}
             disabled={isPageDisabled}
             loading={isLoading}
+            hidden={!mayRun}
           >
             Run now
           </Button>,

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/EmptyExecutionsListContent/EmptyExecutionsListContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/EmptyExecutionsListContent/EmptyExecutionsListContent.tsx
@@ -4,6 +4,8 @@ import {openSettingsTabConfig} from '@redux/reducers/configSlice';
 
 import {EmptyListContent, HelpCard} from '@molecules';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext, MainContext} from '@contexts';
 
 type EmptyExecutionsListContentProps = {
@@ -15,10 +17,27 @@ const EmptyExecutionsListContent: React.FC<EmptyExecutionsListContentProps> = pr
 
   const {entity, entityDetails} = useContext(EntityDetailsContext);
   const {dispatch} = useContext(MainContext);
+  const mayRun = usePermission(Permissions.runEntity);
 
   if (!entityDetails) {
     return null;
   }
+
+  if (!mayRun) {
+  return (
+    <EmptyListContent
+      title="No executions found"
+      description={
+        <>
+          Your {entity === 'tests' ? 'test' : 'test suite'} has no past executions. We will update this list as soon
+          as the first execution was started. <br />
+          Since you do only have read permissions on this environments you can not trigger a test/test suite run
+        </>
+      }
+      buttonText="Run"
+    />
+  );
+}
 
   if (entity === 'tests') {
     return (

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/TableRow/TableRow.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/TableRow/TableRow.tsx
@@ -11,6 +11,8 @@ import useIsRunning from '@hooks/useIsRunning';
 import {displayTimeBetweenDates} from '@utils/displayTimeBetweenDates';
 import {formatDuration, formatExecutionDate} from '@utils/formatDate';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import Colors from '@styles/Colors';
 
 import {DetailsWrapper, ItemColumn, ItemRow, ItemWrapper} from './TableRow.styled';
@@ -20,6 +22,7 @@ const TableRow: React.FC<{data: any; onAbortExecution: any}> = props => {
   const {status, number, startTime, name, id, durationMs} = data;
 
   const isRunning = useIsRunning(status);
+  const mayManageExecution = usePermission(Permissions.manageEntityExecution);
 
   const abortExecution = () => {
     if (onAbortExecution) {
@@ -57,7 +60,9 @@ const TableRow: React.FC<{data: any; onAbortExecution: any}> = props => {
             <Text className="regular small" color={Colors.slate200}>
               {durationMs ? formatDuration(durationMs / 1000) : isRunning ? 'Running' : 'No data'}
             </Text>
-            {renderedExecutionActions && renderedExecutionActions.length ? (
+            {renderedExecutionActions &&
+            renderedExecutionActions.length &&
+            mayManageExecution ? (
               <div
                 onClick={e => {
                   e.stopPropagation();

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
@@ -10,6 +10,8 @@ import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@
 
 import {useUpdateTestMutation} from '@services/tests';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import Colors from '@styles/Colors';
 
 import {EntityDetailsContext} from '@contexts';
@@ -18,6 +20,8 @@ import {StyledFormItem, StyledSpace} from '../Settings.styled';
 
 const PreRun: React.FC = () => {
   const {entity, entityDetails} = useContext(EntityDetailsContext);
+  const isPreRunAvailable = usePermission(Permissions.editEntity);
+
   const [form] = Form.useForm();
 
   const [updateTest] = useUpdateTestMutation();
@@ -50,10 +54,16 @@ const PreRun: React.FC = () => {
   };
 
   return (
-    <Form form={form} onFinish={onSave} name="execution-settings-pre-run" initialValues={{command}}>
+    <Form
+      form={form}
+      onFinish={onSave}
+      name="execution-settings-pre-run"
+      initialValues={{command}}
+      disabled={!isPreRunAvailable}
+    >
       <ConfigurationCard
         title="Pre-Run phase"
-        description="You can run a command or a script (relative to your source root) which will be executed before the test itself is started. "
+        description="You can run a command or a script (relative to your source root) which will be executed before the test itself is started."
         onConfirm={() => {
           form.submit();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
@@ -10,6 +10,8 @@ import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@
 
 import {useUpdateTestMutation} from '@services/tests';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {StyledFormItem, StyledPopoverContainer, StyledQuestionCircleOutlined} from '../Settings.styled';
@@ -23,6 +25,7 @@ const popoverContent = (
 );
 const FailureHandling: React.FC = () => {
   const {entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [form] = Form.useForm();
 
@@ -56,7 +59,13 @@ const FailureHandling: React.FC = () => {
   };
 
   return (
-    <Form form={form} onFinish={onSave} initialValues={{negativeTest}} name="general-settings-failure-handling">
+    <Form
+      form={form}
+      onFinish={onSave}
+      initialValues={{negativeTest}}
+      name="general-settings-failure-handling"
+      disabled={!mayEdit}
+    >
       <ConfigurationCard
         title="Failure handling"
         description="Define how Testkube should treat occurring errors."
@@ -66,6 +75,7 @@ const FailureHandling: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <StyledFormItem name="negativeTest" valuePropName="checked">
           <Checkbox>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -10,12 +10,16 @@ import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {namingMap, updateRequestsMap} from '../utils';
 
 const Labels: React.FC = () => {
   const {entity, entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
+
   const [updateEntity] = updateRequestsMap[entity]();
 
   const [localLabels, setLocalLabels] = useState<readonly Option[]>([]);
@@ -68,6 +72,7 @@ const Labels: React.FC = () => {
       isButtonsDisabled={!wasTouched}
       onConfirm={onSave}
       onCancel={onCancel}
+      enabled={mayEdit}
     >
       <LabelsSelect key={`labels_${labelsKey}`} onChange={onChange} defaultLabels={entityLabels} />
     </ConfigurationCard>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
@@ -8,6 +8,8 @@ import {required} from '@utils/form';
 import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {StyledFormItem, StyledSpace} from '../Settings.styled';
@@ -17,6 +19,8 @@ const {TextArea} = Input;
 
 const NameNDescription: React.FC = () => {
   const {entity, entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
+
   const [form] = Form.useForm();
 
   const [updateEntity] = updateRequestsMap[entity]();
@@ -51,7 +55,13 @@ const NameNDescription: React.FC = () => {
   };
 
   return (
-    <Form form={form} onFinish={onSave} name="general-settings-name-description" initialValues={{name, description}}>
+    <Form
+      form={form}
+      onFinish={onSave}
+      name="general-settings-name-description"
+      initialValues={{name, description}}
+      disabled={!mayEdit}
+    >
       <ConfigurationCard
         title={`${uppercaseFirstSymbol(namingMap[entity])} name & description`}
         description="Define the name and description of the project which will be displayed across the Dashboard and CLI"
@@ -61,6 +71,7 @@ const NameNDescription: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <StyledSpace size={32} direction="vertical">
           <StyledFormItem name="name" rules={[required]}>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/SettingsGeneral.tsx
@@ -2,6 +2,8 @@ import {useContext} from 'react';
 
 import {Space} from 'antd';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import Delete from './Delete';
@@ -12,6 +14,7 @@ import Timeout from './Timeout';
 
 const SettingsGeneral: React.FC = () => {
   const {entity} = useContext(EntityDetailsContext);
+  const mayDelete = usePermission(Permissions.deleteEntity);
 
   return (
     <Space size={30} direction="vertical">
@@ -19,7 +22,7 @@ const SettingsGeneral: React.FC = () => {
       <Labels />
       {entity === 'tests' ? <Timeout /> : null}
       {entity === 'tests' ? <FailureHandling /> : null}
-      <Delete />
+      {mayDelete ? <Delete /> : null}
     </Space>
   );
 };

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -13,6 +13,8 @@ import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@
 
 import {useUpdateTestMutation} from '@services/tests';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {StyledFormItem, StyledSpace} from '../Settings.styled';
@@ -23,6 +25,7 @@ type TimeoutForm = {
 
 const Timeout: React.FC = () => {
   const {entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
   const {executionRequest, name} = entityDetails;
 
   const [form] = Form.useForm<TimeoutForm>();
@@ -58,6 +61,7 @@ const Timeout: React.FC = () => {
       onFinish={onSave}
       name="general-settings-name-description"
       initialValues={{activeDeadlineSeconds: executionRequest?.activeDeadlineSeconds}}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Timeout"
@@ -76,6 +80,7 @@ const Timeout: React.FC = () => {
             </ExternalLink>
           </Text>
         }
+        enabled={mayEdit}
       >
         <StyledSpace size={32} direction="vertical" style={{width: '100%'}}>
           <StyledFormItem name="activeDeadlineSeconds" rules={[digits]} style={{marginBottom: '0px'}}>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/CronInput.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/CronInput.tsx
@@ -3,15 +3,17 @@ import {Input, Tooltip} from 'antd';
 type CronInputProps = {
   value: string;
   title: string;
+  disabled?: boolean;
   onChange: (value: string) => void;
 };
 
 const CronInput: React.FC<CronInputProps> = props => {
-  const {value, title, onChange} = props;
+  const {value, title, disabled, onChange} = props;
 
   return (
     <Tooltip title={title}>
       <Input
+        disabled={disabled}
         placeholder={title}
         value={value === '*' ? '' : value}
         onChange={e => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -16,6 +16,8 @@ import {uppercaseFirstSymbol} from '@utils/strings';
 import Colors from '@styles/Colors';
 import Fonts from '@styles/Fonts';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {StyledSpace} from '../Settings.styled';
@@ -27,6 +29,7 @@ import {custom, quickOptions} from './utils';
 
 const Schedule: React.FC = () => {
   const {entity, entityDetails} = useContext(EntityDetailsContext);
+  const enabled = usePermission(Permissions.editEntity);
 
   const [updateEntity] = updateRequestsMap[entity]();
 
@@ -97,11 +100,13 @@ const Schedule: React.FC = () => {
       onConfirm={onSave}
       onCancel={onCancel}
       isButtonsDisabled={!wasTouched}
+      enabled={enabled}
     >
       <StyledSpace direction="vertical" size={32}>
         <StyledColumn>
           <Text className="middle regular">Schedule template</Text>
           <Select
+            disabled={!enabled}
             placeholder="Quick select a schedule template"
             style={{width: '100%'}}
             options={quickOptions}
@@ -117,11 +122,11 @@ const Schedule: React.FC = () => {
             <StyledColumn>
               <Text className="middle regular">Cron Format</Text>
               <StyledCronFormat>
-                <CronInput title="Minute" value={minute} onChange={value => onCronInput(value, 0)} />
-                <CronInput title="Hour" value={hour} onChange={value => onCronInput(value, 1)} />
-                <CronInput title="Day" value={day} onChange={value => onCronInput(value, 2)} />
-                <CronInput title="Month" value={month} onChange={value => onCronInput(value, 3)} />
-                <CronInput title="Day / Week" value={dayOfWeek} onChange={value => onCronInput(value, 4)} />
+                <CronInput title="Minute" disabled={!enabled} value={minute} onChange={value => onCronInput(value, 0)} />
+                <CronInput title="Hour" disabled={!enabled} value={hour} onChange={value => onCronInput(value, 1)} />
+                <CronInput title="Day" disabled={!enabled} value={day} onChange={value => onCronInput(value, 2)} />
+                <CronInput title="Month" disabled={!enabled} value={month} onChange={value => onCronInput(value, 3)} />
+                <CronInput title="Day / Week" disabled={!enabled} value={dayOfWeek} onChange={value => onCronInput(value, 4)} />
               </StyledCronFormat>
             </StyledColumn>
             <StyledRow>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/Source.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/Source.tsx
@@ -29,6 +29,8 @@ import {
   testSourceBaseOptions,
 } from '@utils/sources';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {StyledFormItem, StyledSpace} from '../Settings.styled';
 
 const additionalFields: {[key: string]: React.FC<any>} = {
@@ -45,6 +47,7 @@ type SourceProps = {
 
 const Source: React.FC<SourceProps> = props => {
   const {entityDetails, updateTest} = props;
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const {type} = entityDetails;
 
@@ -91,6 +94,7 @@ const Source: React.FC<SourceProps> = props => {
       layout="vertical"
       labelAlign="right"
       onFinish={onSave}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Source"
@@ -111,6 +115,7 @@ const Source: React.FC<SourceProps> = props => {
         forceEnableButtons={
           (isClearedToken && additionalFormValues.token) || (isClearedUsername && additionalFormValues.username)
         }
+        enabled={mayEdit}
       >
         <StyledSpace size={24} direction="vertical">
           <StyledFormItem name="testSource" rules={[required]}>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/TestType.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/TestType.tsx
@@ -12,6 +12,8 @@ import {ConfigurationCard} from '@molecules';
 import {remapExecutors} from '@utils/executors';
 import {required} from '@utils/form';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {StyledFormItem, StyledSpace} from '../Settings.styled';
 
 type TestTypeProps = {
@@ -24,6 +26,7 @@ const TestType: React.FC<TestTypeProps> = props => {
 
   const [form] = Form.useForm();
 
+  const mayEdit = usePermission(Permissions.editEntity);
   const executors = useAppSelector(selectExecutors);
   const remappedExecutors = remapExecutors(executors);
 
@@ -32,7 +35,13 @@ const TestType: React.FC<TestTypeProps> = props => {
   };
 
   return (
-    <Form form={form} onFinish={onSave} name="test-settings-test-type" initialValues={{type}}>
+    <Form
+      form={form}
+      onFinish={onSave}
+      name="test-settings-test-type"
+      initialValues={{type}}
+      disabled={!mayEdit}
+    >
       <ConfigurationCard
         title="Test type"
         description="Define the test type for this test."
@@ -50,6 +59,7 @@ const TestType: React.FC<TestTypeProps> = props => {
             </ExternalLink>
           </>
         }
+        enabled={mayEdit}
       >
         <StyledSpace size={32} direction="vertical">
           <StyledFormItem name="type" rules={[required]}>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -16,12 +16,14 @@ import {ExecutorIcon, ExternalLink} from '@atoms';
 
 import {Text, Title} from '@custom-antd';
 
-import {ConfigurationCard, DragNDropList, TestSuiteStepCard, notificationCall} from '@molecules';
+import {ConfigurationCard, DragNDropList, notificationCall, TestSuiteStepCard} from '@molecules';
 
 import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useGetTestsListForTestSuiteQuery, useUpdateTestSuiteMutation} from '@services/testSuites';
 import {useGetAllTestsQuery} from '@services/tests';
+
+import {Permissions, usePermission} from '@permissions/base';
 
 import {EntityDetailsContext} from '@contexts';
 
@@ -32,6 +34,7 @@ const {Option} = Select;
 
 const SettingsTests = () => {
   const {entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [isDelayModalVisible, setIsDelayModalVisible] = useState(false);
 
@@ -171,6 +174,8 @@ const SettingsTests = () => {
       onConfirm={saveSteps}
       onCancel={() => setCurrentSteps(undefined)}
       isButtonsDisabled={!wasTouched}
+      isEditable={mayEdit}
+      enabled={mayEdit}
     >
       <>
         {currentSteps?.length === 0 ? (
@@ -196,30 +201,32 @@ const SettingsTests = () => {
           setIsDelayModalVisible={setIsDelayModalVisible}
           addDelay={addDelay}
         />
-        <Select
-          placeholder="Add a test or delay"
-          showArrow
-          onChange={onSelectStep}
-          style={{width: '100%', marginBottom: '30px'}}
-          value={null}
-          showSearch
-          size="large"
-        >
-          <Option value="delay">
-            <StyledOptionWrapper>
-              <ClockCircleOutlined />
-              <Text className="regular middle">Delay</Text>
-            </StyledOptionWrapper>
-          </Option>
-          {allTestsData.map((item: any) => (
-            <Option value={JSON.stringify(item)} key={item.name}>
+        {mayEdit ? (
+          <Select
+            placeholder="Add a test or delay"
+            showArrow
+            onChange={onSelectStep}
+            style={{width: '100%', marginBottom: '30px'}}
+            value={null}
+            showSearch
+            size="large"
+          >
+            <Option value="delay">
               <StyledOptionWrapper>
-                <ExecutorIcon type={item.type} />
-                <Text className="regular middle">{item.name}</Text>
+                <ClockCircleOutlined />
+                <Text className="regular middle">Delay</Text>
               </StyledOptionWrapper>
             </Option>
-          ))}
-        </Select>
+            {allTestsData.map((item: any) => (
+              <Option value={JSON.stringify(item)} key={item.name}>
+                <StyledOptionWrapper>
+                  <ExecutorIcon type={item.type} />
+                  <Text className="regular middle">{item.name}</Text>
+                </StyledOptionWrapper>
+              </Option>
+            ))}
+          </Select>
+        ) : null}
       </>
     </ConfigurationCard>
   );

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -16,6 +16,8 @@ import {useUpdateTestMutation} from '@services/tests';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {ArgumentsWrapper} from './Arguments.styled';
@@ -24,6 +26,7 @@ import {dash, doubleDash, space, stringSpace} from './utils';
 const Arguments: React.FC = () => {
   const [form] = Form.useForm();
   const {entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateTest] = useUpdateTestMutation();
 
@@ -128,6 +131,7 @@ const Arguments: React.FC = () => {
       onChange={onChange}
       onFinish={onSaveForm}
       initialValues={{args: argsValue}}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Arguments"
@@ -149,6 +153,7 @@ const Arguments: React.FC = () => {
           form.setFieldValue(['args'], entityArgs.join(' '));
           setIsButtonsDisabled(true);
         }}
+        enabled={mayEdit}
       >
         <ArgumentsWrapper>
           <CopyCommand command={argsValue} isBordered additionalPrefix="executor-binary" />

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -6,10 +6,12 @@ import {Entity} from '@models/entity';
 
 import {ExternalLink} from '@atoms';
 
-import {ConfigurationCard, TestsVariablesList, notificationCall} from '@molecules';
+import {ConfigurationCard, notificationCall, TestsVariablesList} from '@molecules';
 
 import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@utils/notification';
 import {decomposeVariables, formatVariables} from '@utils/variables';
+
+import {Permissions, usePermission} from '@permissions/base';
 
 import {EntityDetailsContext} from '@contexts';
 
@@ -23,6 +25,7 @@ const descriptionMap: {[key in Entity]: string} = {
 
 const Variables: React.FC = () => {
   const {entity, entityDetails} = useContext(EntityDetailsContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateEntity] = updateRequestsMap[entity]();
   const [form] = Form.useForm();
@@ -87,6 +90,7 @@ const Variables: React.FC = () => {
           }
         }
       }}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Variables & Secrets"
@@ -103,6 +107,7 @@ const Variables: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <TestsVariablesList data={variables} form={form} />
       </ConfigurationCard>

--- a/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawerHeader.tsx
+++ b/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawerHeader.tsx
@@ -16,6 +16,8 @@ import {constructExecutedString, formatExecutionDate} from '@utils/formatDate';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {EntityDetailsContext} from '@contexts';
 
 import {DrawerHeader, HeaderContent, ItemColumn, ItemRow} from './ExecutionDetailsDrawer.styled';
@@ -27,6 +29,7 @@ type ExecutionDetailsDrawerHeaderProps = {
 
 const ExecutionDetailsDrawerHeader: React.FC<ExecutionDetailsDrawerHeaderProps> = props => {
   const {unselectRow, entity, execId, abortExecution} = useContext(EntityDetailsContext);
+  const mayManageExecution = usePermission(Permissions.manageEntityExecution);
 
   const {data} = props;
   // @ts-ignore
@@ -79,22 +82,24 @@ const ExecutionDetailsDrawerHeader: React.FC<ExecutionDetailsDrawerHeaderProps> 
               {name}
             </Text>
           </ItemColumn>
-          <ItemColumn className="flex-auto">
-            {renderedExecutionActions && renderedExecutionActions.length ? (
-              <div
-                onClick={e => {
-                  e.stopPropagation();
-                }}
-              >
-                <Dropdown overlay={menu} placement="bottom">
-                  <div style={{width: 20}}>
-                    <Dots color={Colors.grey450} />
-                  </div>
-                </Dropdown>
-              </div>
-            ) : null}
-            <CloseOutlined onClick={unselectRow} style={{color: Colors.slate400, fontSize: 20}} />
-          </ItemColumn>
+          {mayManageExecution ? (
+            <ItemColumn className="flex-auto">
+              {renderedExecutionActions && renderedExecutionActions.length ? (
+                <div
+                  onClick={e => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <Dropdown overlay={menu} placement="bottom">
+                    <div style={{width: 20}}>
+                      <Dots color={Colors.grey450} />
+                    </div>
+                  </Dropdown>
+                </div>
+              ) : null}
+              <CloseOutlined onClick={unselectRow} style={{color: Colors.slate400, fontSize: 20}} />
+            </ItemColumn>
+          ) : null}
         </ItemRow>
         <ItemRow $flex={1}>
           <ItemColumn>

--- a/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -21,13 +21,15 @@ import {useApiEndpoint} from '@services/apiEndpoint';
 
 import {compareFiltersObject} from '@utils/objects';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 import {TestModalConfig, TestSuiteModalConfig} from '../EntityCreationModal';
 import {EntityListContext} from '../EntityListContainer/EntityListContainer';
 import Filters from '../EntityListFilters';
 import EmptyDataWithFilters from './EmptyDataWithFilters';
-import {TestSuitesDataLayer, TestsDataLayer} from './EntityDataLayers';
+import {TestsDataLayer, TestSuitesDataLayer} from './EntityDataLayers';
 import {EmptyListWrapper, Header, StyledContainer, StyledFiltersSection} from './EntityListContent.styled';
 import EntityListTitle from './EntityListHeader';
 import EntityListSkeleton from './EntityListSkeleton';
@@ -58,6 +60,7 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
 
   const {dispatch, navigate} = useContext(MainContext);
   const apiEndpoint = useApiEndpoint();
+  const mayCreate = usePermission(Permissions.createEntity);
   const {queryFilters, dataSource, setQueryFilters} = useContext(EntityListContext);
   const prevQueryFilters = usePrevious(queryFilters) || queryFilters;
 
@@ -166,9 +169,11 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
               entity={entity}
               isFiltersDisabled={isEmptyData}
             />
-            <Button $customType="primary" onClick={addEntityAction} data-test={dataTestID}>
-              {addEntityButtonText}
-            </Button>
+            {mayCreate ? (
+              <Button $customType="primary" onClick={addEntityAction} data-test={dataTestID}>
+                {addEntityButtonText}
+              </Button>
+            ) : null}
           </StyledFiltersSection>
         ) : null}
       </Header>

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.styled.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.styled.tsx
@@ -30,7 +30,7 @@ export const Asterisk = styled.span`
   color: ${Colors.errorRed};
 `;
 
-export const StyledLablesSpace = styled.div<{noGap?: boolean}>`
+export const StyledLabelsSpace = styled.div<{noGap?: boolean}>`
   display: flex;
   align-items: flex-start;
   gap: ${props => (props.noGap ? '0' : '16px')};

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable unused-imports/no-unused-imports-ts */
 import {useContext, useEffect} from 'react';
 
 import {Form, Input} from 'antd';
@@ -10,19 +9,20 @@ import {Executor} from '@models/executors';
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentExecutor, updateExecutorArguments} from '@redux/reducers/executorsSlice';
 
-import {Button, Text} from '@custom-antd';
+import {Button} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
 import {displayDefaultErrorNotification} from '@utils/notification';
-import {uppercaseFirstSymbol} from '@utils/strings';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
-import {StyledButtonsContainer, StyledLablesSpace, SymbolWrapper, VariablesListContainer} from './Arguments.styled';
+import {StyledButtonsContainer, StyledLabelsSpace, SymbolWrapper, VariablesListContainer} from './Arguments.styled';
 
 type ArgumentsFormFields = {
   arguments: string[];
@@ -33,6 +33,7 @@ const Arguments: React.FC = () => {
   const {args} = executor;
 
   const {dispatch} = useContext(MainContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateCustomExecutor] = useUpdateCustomExecutorMutation();
 
@@ -69,6 +70,7 @@ const Arguments: React.FC = () => {
       initialValues={{arguments: args}}
       layout="vertical"
       onFinish={onSubmit}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Arguments for your command"
@@ -79,20 +81,21 @@ const Arguments: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <Form.List name="arguments">
           {(fields, {add, remove}) => (
             <VariablesListContainer>
               {fields.map(({key, name, ...restField}) => {
                 return (
-                  <StyledLablesSpace key={key}>
+                  <StyledLabelsSpace key={key}>
                     <Form.Item {...restField} name={[name]} style={{flex: 1, marginBottom: '0'}} rules={[required]}>
                       <Input placeholder="Your argument value" />
                     </Form.Item>
                     <SymbolWrapper>
                       <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
                     </SymbolWrapper>
-                  </StyledLablesSpace>
+                  </StyledLabelsSpace>
                 );
               })}
               <StyledButtonsContainer>

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -13,6 +13,8 @@ import {displayDefaultErrorNotification} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 type CommandFormFields = {
@@ -20,10 +22,11 @@ type CommandFormFields = {
 };
 
 const Command: React.FC = () => {
+  const {dispatch} = useContext(MainContext);
+  const mayEdit = usePermission(Permissions.editEntity);
+
   const {executor, name} = useAppSelector(selectCurrentExecutor) as Executor;
   const {command} = executor;
-
-  const {dispatch} = useContext(MainContext);
 
   const [updateCustomExecutor] = useUpdateCustomExecutorMutation();
 
@@ -60,6 +63,7 @@ const Command: React.FC = () => {
       initialValues={{command: command?.join(' ')}}
       layout="vertical"
       onFinish={onSubmit}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Command"
@@ -70,6 +74,7 @@ const Command: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <Form.Item label="Command" name="command">
           <Input placeholder="Command" />

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -14,6 +14,8 @@ import {displayDefaultErrorNotification} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 export type ContainerImageFormFields = {
@@ -21,10 +23,11 @@ export type ContainerImageFormFields = {
 };
 
 const ContainerImagePanel: React.FC = () => {
-  const {executor, name} = useAppSelector(selectCurrentExecutor) as Executor;
-  const {image} = executor;
+  const {executor, name} = useAppSelector(selectCurrentExecutor);
+  const image = executor?.image;
 
   const {dispatch} = useContext(MainContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateCustomExecutor] = useUpdateCustomExecutorMutation();
 
@@ -55,7 +58,14 @@ const ContainerImagePanel: React.FC = () => {
   }, [image]);
 
   return (
-    <Form form={form} name="general-settings-name-type" initialValues={{image}} layout="vertical" onFinish={onSubmit}>
+    <Form
+      form={form}
+      name="general-settings-name-type"
+      initialValues={{image}}
+      layout="vertical"
+      onFinish={onSubmit}
+      disabled={!mayEdit}
+    >
       <ConfigurationCard
         title="Container image"
         description="Define the image you want to use for this executor. We defer by default to Dockerhub – but you can also insert a URL to your very own image"
@@ -65,6 +75,7 @@ const ContainerImagePanel: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <Form.Item label="Container image" required name="image" rules={[required]}>
           <Input placeholder="Container image" />

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -12,6 +12,8 @@ import {displayDefaultErrorNotification} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 export type PrivateRegistryFormFields = {
@@ -23,6 +25,7 @@ const PrivateRegistry: React.FC = () => {
   const {imagePullSecrets} = executor;
 
   const {dispatch} = useContext(MainContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateCustomExecutor] = useUpdateCustomExecutorMutation();
 
@@ -62,6 +65,7 @@ const PrivateRegistry: React.FC = () => {
       initialValues={{privateRegistry}}
       layout="vertical"
       onFinish={onSubmit}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Private registry"
@@ -72,6 +76,7 @@ const PrivateRegistry: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <Form.Item label="Secret ref name" name="privateRegistry" rules={[required]}>
           <Input placeholder="Secret ref name" />

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/General.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/General.tsx
@@ -1,13 +1,17 @@
 import {Space} from 'antd';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import Delete from './Delete';
 import NameNType from './NameNType';
 
-const General = () => {
+const General: React.FC = () => {
+  const mayDelete = usePermission(Permissions.deleteEntity);
+
   return (
     <Space size={30} direction="vertical">
       <NameNType />
-      <Delete />
+      {mayDelete ? <Delete /> : null}
     </Space>
   );
 };

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/NameNType.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/NameNType.tsx
@@ -11,7 +11,10 @@ import {ConfigurationCard} from '@molecules';
 
 import {required} from '@utils/form';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 const NameNType: React.FC = () => {
+  const mayEdit = usePermission(Permissions.editEntity);
   const {name, executor} = useAppSelector(selectCurrentExecutor);
   const type = executor?.types?.[0] ?? '';
   const [form] = Form.useForm();
@@ -24,7 +27,13 @@ const NameNType: React.FC = () => {
   }, [name, type]);
 
   return (
-    <Form form={form} name="general-settings-name-type" initialValues={{name, type}} layout="vertical">
+    <Form
+      form={form}
+      name="general-settings-name-type"
+      initialValues={{name, type}}
+      layout="vertical"
+      disabled={!mayEdit}
+    >
       <ConfigurationCard
         title="Executor name & type"
         description="Define the name and type of the executor which will be displayed across the Dashboard and CLI"
@@ -35,6 +44,7 @@ const NameNType: React.FC = () => {
           form.resetFields();
         }}
         isButtonsDisabled
+        enabled={mayEdit}
       >
         <Form.Item label="Name" required name="name" rules={[required]}>
           <Input placeholder="e.g.: my-container-executor" disabled />

--- a/src/components/pages/Executors/ExecutorsList/EmptyCustomExecutors.tsx
+++ b/src/components/pages/Executors/ExecutorsList/EmptyCustomExecutors.tsx
@@ -14,6 +14,8 @@ const EmptyCustomExecutors: React.FC<EmptyCustomExecutorsProps> = props => {
       title="Create your first custom executor"
       description="Define your container image, customize your commands and arguments and start testing."
       buttonText="Create a new executor"
+      emptyListReadonlyDescription="We could not find any custom container executors in this environment."
+      emptyListReadonlyTitle="No custom executors found"
       onButtonClick={onButtonClick}
     >
       <HelpCard isLink link="https://kubeshop.github.io/testkube/test-types/executor-custom">

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -17,6 +17,8 @@ import {useGetExecutorsQuery} from '@services/executors';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 import {executorsList} from '../utils';
@@ -31,6 +33,7 @@ import {
 
 const Executors: React.FC = () => {
   const {navigate} = useContext(MainContext);
+  const mayCreate = usePermission(Permissions.createEntity);
   const apiEndpoint = useApiEndpoint();
 
   const [activeTabKey, setActiveTabKey] = useState('custom');
@@ -97,11 +100,11 @@ const Executors: React.FC = () => {
           <ExternalLink href="https://kubeshop.github.io/testkube/test-types/executor-custom">executors</ExternalLink>
         </>
       }
-      headerButton={
+      headerButton={mayCreate ? (
         <Button $customType="primary" onClick={() => setAddExecutorModalVisibility(true)}>
           Create a new executor
         </Button>
-      }
+      ) : null}
     >
       <Tabs activeKey={activeTabKey} onChange={setActiveTabKey} destroyInactiveTabPane defaultActiveKey="custom">
         <Tabs.TabPane tab="Custom executors" key="custom">

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
 
-import {Input as AntdInput, Form} from 'antd';
+import {Form, Input as AntdInput} from 'antd';
 
 import {EyeInvisibleOutlined, EyeOutlined} from '@ant-design/icons';
 
@@ -15,10 +15,13 @@ import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@
 
 import {useUpdateSourceMutation} from '@services/sources';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 const Authentication: React.FC = () => {
   const {dispatch} = useContext(MainContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const source = useAppSelector(selectCurrentSource);
 
@@ -66,6 +69,7 @@ const Authentication: React.FC = () => {
       initialValues={{username, token}}
       layout="vertical"
       onFinish={onFinish}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Authentication"
@@ -76,6 +80,7 @@ const Authentication: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <Form.Item label="Git username" name="username">
           <Input placeholder="e.g.: my-username" />

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/General.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/General.tsx
@@ -1,15 +1,19 @@
 import {Space} from 'antd';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import Authentication from './Authentication';
 import Delete from './Delete';
 import NameNType from './NameNUrl';
 
-const General = () => {
+const General: React.FC = () => {
+  const mayDelete = usePermission(Permissions.deleteEntity);
+
   return (
     <Space size={30} direction="vertical">
       <NameNType />
       <Authentication />
-      <Delete />
+      {mayDelete ? <Delete /> : null}
     </Space>
   );
 };

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -14,11 +14,14 @@ import {displayDefaultErrorNotification, displayDefaultNotificationFlow} from '@
 
 import {useUpdateSourceMutation} from '@services/sources';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 const NameNUrl: React.FC = () => {
   const source = useAppSelector(selectCurrentSource);
   const {dispatch} = useContext(MainContext);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateSource] = useUpdateSourceMutation();
 
@@ -61,6 +64,7 @@ const NameNUrl: React.FC = () => {
       initialValues={{name, uri}}
       layout="vertical"
       onFinish={onFinish}
+      disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Source name & repository URL"
@@ -71,6 +75,7 @@ const NameNUrl: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
+        enabled={mayEdit}
       >
         <Form.Item label="Name" required name="name" rules={[required]}>
           <Input placeholder="e.g.: my-git-test-repository" disabled />

--- a/src/components/pages/Sources/SourcesList/EmptySources.tsx
+++ b/src/components/pages/Sources/SourcesList/EmptySources.tsx
@@ -14,6 +14,8 @@ const EmptySources: React.FC<EmptySourcesProps> = props => {
       title="Create your first global source"
       description="Define your git respository to be able to reuse it later on when you create your tests."
       buttonText="Create a new source"
+      emptyListReadonlyTitle="No sources found"
+      emptyListReadonlyDescription="We could not find any global sources in this environment."
       onButtonClick={onButtonClick}
     >
       <HelpCard isLink link="https://kubeshop.github.io/testkube/openapi#tag/test-sources">

--- a/src/components/pages/Sources/SourcesList/SourcesList.tsx
+++ b/src/components/pages/Sources/SourcesList/SourcesList.tsx
@@ -13,6 +13,8 @@ import {useGetSourcesQuery} from '@services/sources';
 
 import Colors from '@styles/Colors';
 
+import {Permissions, usePermission} from '@permissions/base';
+
 import {MainContext} from '@contexts';
 
 import AddSourceModal from './AddSourceModal';
@@ -26,6 +28,7 @@ const Sources: React.FC = () => {
 
   const {dispatch, navigate, location} = useContext(MainContext);
   const [isAddSourceModalVisible, setAddSourceModalVisibility] = useState(false);
+  const mayCreate = usePermission(Permissions.createEntity);
 
   const onNavigateToDetails = (name: string) => {
     navigate(`sources/${name}`);
@@ -63,11 +66,11 @@ const Sources: React.FC = () => {
           <ExternalLink href="https://kubeshop.github.io/testkube/openapi/#tag/test-sources">Sources</ExternalLink>
         </>
       }
-      headerButton={
+      headerButton={mayCreate ? (
         <Button $customType="primary" onClick={() => setAddSourceModalVisibility(true)}>
           Create a new source
         </Button>
-      }
+      ) : null}
     >
       {isLoading ? (
         <SourcesListSkeletonWrapper>

--- a/src/components/pages/Triggers/TriggerItem.tsx
+++ b/src/components/pages/Triggers/TriggerItem.tsx
@@ -32,11 +32,23 @@ type TriggerItemProps = {
   events?: {[key: string]: string[]};
   testsData: any[];
   testSuitesData: any[];
+  isTriggersAvailable?: boolean;
   executors: Executor[];
 };
 
 const TriggerItem: React.FC<TriggerItemProps> = props => {
-  const {type, resources, actions, name, events, remove, testsData, testSuitesData, executors} = props;
+  const {
+    type,
+    resources,
+    actions,
+    name,
+    events,
+    remove,
+    testsData,
+    testSuitesData,
+    isTriggersAvailable = true,
+    executors,
+  } = props;
 
   const renderSelectResource = (placeholder: string, {tests, testSuites}: {tests: any[]; testSuites: any[]}) => {
     return (
@@ -70,7 +82,7 @@ const TriggerItem: React.FC<TriggerItemProps> = props => {
   };
 
   return (
-    <TriggerItemContainer>
+    <TriggerItemContainer $isTriggersAvailable={isTriggersAvailable}>
       <TextWrapper>
         <Text className="small uppercase" color={Colors.slate500}>
           When
@@ -125,7 +137,7 @@ const TriggerItem: React.FC<TriggerItemProps> = props => {
                 placeholder="Trigger a cluster event"
                 options={eventsOptions}
                 allowClear
-                disabled={!triggerResource}
+                disabled={!triggerResource || !isTriggersAvailable}
               />
             </TriggerFormItem>
           );
@@ -174,9 +186,11 @@ const TriggerItem: React.FC<TriggerItemProps> = props => {
           );
         }}
       </Form.Item>
-      <TextWrapper>
-        <DeleteOutlined style={{cursor: 'pointer', fontSize: '18px'}} onClick={() => remove(name)} />{' '}
-      </TextWrapper>
+      {isTriggersAvailable ? (
+        <TextWrapper>
+          <DeleteOutlined style={{cursor: 'pointer', fontSize: '18px'}} onClick={() => remove(name)} />
+        </TextWrapper>
+      ) : null}
     </TriggerItemContainer>
   );
 };

--- a/src/components/pages/Triggers/Triggers.styled.tsx
+++ b/src/components/pages/Triggers/Triggers.styled.tsx
@@ -16,14 +16,14 @@ export const Wrapper = styled.div`
   align-items: center;
 `;
 
-export const TriggerItemContainer = styled.div`
+export const TriggerItemContainer = styled.div<{$isTriggersAvailable: boolean}>`
   display: flex;
   flex-flow: row wrap;
   align-items: start;
   gap: 10px;
 
   width: 100%;
-  margin-bottom: 16px;
+  ${({$isTriggersAvailable}) => ($isTriggersAvailable ? 'margin-bottom: 16px;' : null)};
 `;
 
 export const TriggerFormItem = styled(Form.Item)<{flex: number}>`

--- a/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestSuitesListContent.tsx
+++ b/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestSuitesListContent.tsx
@@ -8,6 +8,8 @@ const EmptyTestSuitesListContent: React.FC<{action: () => void}> = props => {
       title="Create your first test suite in a few easy steps."
       description="Simply define your test suites, add any tests, execute it and view the results!"
       buttonText="Add a new test suite"
+      emptyListReadonlyDescription="We could not find any test suites in this environment."
+      emptyListReadonlyTitle="No test suites found"
       onButtonClick={action}
     >
       <HelpCard isLink link="https://kubeshop.github.io/testkube/using-testkube/test-suites/testsuites-creating/">

--- a/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestsListContent.tsx
+++ b/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestsListContent.tsx
@@ -8,6 +8,8 @@ const EmptyTestsListContent: React.FC<{action: () => void}> = props => {
       title="Create your first test in a few easy steps."
       description="Simply define your test, add any variables, execute it and view the results!"
       buttonText="Add a new test"
+      emptyListReadonlyTitle="No tests found"
+      emptyListReadonlyDescription="We could not find any tests in this environment."
       onButtonClick={action}
     >
       <HelpCard isLink link="https://kubeshop.github.io/testkube/using-testkube/tests/tests-creating/">

--- a/src/permissions/base.tsx
+++ b/src/permissions/base.tsx
@@ -1,0 +1,98 @@
+import React, {createContext, PropsWithChildren, ReactElement, useContext, useEffect, useMemo, useRef} from 'react';
+
+// Interface
+
+export enum Permissions {
+  // Tests, Test suites, Executors, Sources
+  createEntity = 'create-entity',
+  deleteEntity = 'delete-entity',
+  editEntity = 'edit-entity',
+  runEntity = 'run-entity',
+  manageEntityExecution = 'manage-entity-execution',
+}
+
+export interface PermissionsResolver<R, S extends Record<string, any> = {}> {
+  has(permission: Permissions | R, scope?: S): boolean;
+}
+
+type PermissionsResolverFn<T> = T extends PermissionsResolver<infer R, infer S>
+  ? (permission: Permissions | R, scope?: Partial<S>) => boolean
+  : never;
+
+// Base implementation
+
+export class BasePermissionsResolver implements PermissionsResolver<Permissions> {
+  // eslint-disable-next-line class-methods-use-this
+  public has(permission: Permissions): boolean {
+    return true;
+  }
+}
+
+// React implementation
+
+export const PermissionsContext = createContext<any>({});
+
+interface PermissionsProviderProps<T extends PermissionsResolver<any, any>> {
+  scope: T extends PermissionsResolver<any, infer S> ? S : never;
+  resolver: T;
+}
+
+export interface PermissionsContextData<T extends PermissionsResolver<any, any>> {
+  scope: T extends PermissionsResolver<any, infer S> ? S : never;
+  resolver: T;
+}
+
+export function PermissionsProvider<T extends PermissionsResolver<any, any>>(props: PropsWithChildren<PermissionsProviderProps<T>>): ReactElement | null {
+  const {scope, resolver, children} = props;
+  const value = useMemo<PermissionsContextData<T>>(() => ({scope, resolver}), [scope, resolver]);
+
+  return (
+    <PermissionsContext.Provider value={value}>
+      {children}
+    </PermissionsContext.Provider>
+  );
+}
+
+export function createUsePermissionHook<T extends PermissionsResolver<any, any>>(): PermissionsResolverFn<T> {
+  // @ts-ignore: FIXME later
+  return (permission, scope?): boolean => {
+    const {scope: baseScope, resolver} = useContext<PermissionsContextData<T>>(PermissionsContext);
+
+    // It's much more convenient to avoid caching the scope object in each component for comparison.
+    // To simplify that, the scope will be cached based on identity of the properties.
+    const localScope = useRef<typeof scope>(undefined);
+    useEffect(() => {
+      const prevScope = localScope.current;
+
+      // Speed up in case of empty local scope
+      if (scope === undefined || prevScope === undefined) {
+        localScope.current = scope;
+        return;
+      }
+
+      // for..in is faster than comparing Object.keys, even cached.
+      // for a single property, check takes ~0.2μs, so it should be efficient enough.
+      // eslint-disable-next-line no-restricted-syntax
+      for (let k in prevScope) {
+        if (prevScope[k] !== scope[k]) {
+          localScope.current = scope;
+          return;
+        }
+      }
+      // eslint-disable-next-line no-restricted-syntax
+      for (let k in scope) {
+        if (prevScope[k] !== scope[k]) {
+          localScope.current = scope;
+          return;
+        }
+      }
+    }, [scope]);
+
+    return useMemo(
+      () => resolver.has(permission, {...baseScope, ...localScope.current}),
+      [permission, localScope.current, baseScope, resolver],
+    );
+  };
+}
+
+export const usePermission = createUsePermissionHook<BasePermissionsResolver>();


### PR DESCRIPTION
## Changes

- Add permissions mechanism, same as in [**Cloud version**](https://github.com/kubeshop/testkube-cloud-ui/pull/203/files)
- Adjust some files to use the same code as in Cloud
   - Add option to disable `CreatableMultiSelect`
   - Add option to modify `enabled`/`isEditable` state of `ConfigurationCard`
   - Adjust `EmptyListContent` to display a different message when it can't add/run a new one

## Fixes

- OSS part of https://github.com/kubeshop/testkube/issues/3693

## How to test it

- Build app, check if everything works, change `has` method in `BasePermissionsResolver` for tests with specific permissions rule

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
