### PR TITLE
chore: use PropsWithChildren instead of manually typing `children` property

### DIFF
--- a/src/AnalyticsProvider.tsx
+++ b/src/AnalyticsProvider.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo} from 'react';
+import {PropsWithChildren, useEffect, useMemo} from 'react';
 
 import {AnalyticsBrowser, Context, Plugin} from '@segment/analytics-next';
 
@@ -9,7 +9,6 @@ import FingerprintJS from '@fingerprintjs/fingerprintjs';
 type AnalyticsProviderProps = {
   disabled?: boolean;
   privateKey: string;
-  children: React.ReactNode;
   appVersion: string;
 };
 
@@ -34,7 +33,7 @@ const CleanSensitiveDataPlugin: Plugin = {
   screen: maskSensitiveData,
 };
 
-export const AnalyticsProvider: React.FC<AnalyticsProviderProps> = props => {
+export const AnalyticsProvider: React.FC<PropsWithChildren<AnalyticsProviderProps>> = props => {
   const {disabled, privateKey, children, appVersion} = props;
 
   const notDevEnv = process.env.NODE_ENV !== 'development';

--- a/src/components/atoms/Pre/Pre.tsx
+++ b/src/components/atoms/Pre/Pre.tsx
@@ -1,10 +1,8 @@
+import {PropsWithChildren} from 'react';
+
 import {StyledPre} from './Pre.styled';
 
-type PreProps = {
-  children: any;
-};
-
-const Pre: React.FC<PreProps> = props => {
+const Pre: React.FC<PropsWithChildren<{}>> = props => {
   const {children} = props;
 
   return <StyledPre>{children}</StyledPre>;

--- a/src/components/molecules/Definition/Definition.tsx
+++ b/src/components/molecules/Definition/Definition.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode} from 'react';
+import React, {PropsWithChildren} from 'react';
 import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
 
 import {TestkubeCodeTheme} from '@atoms';
@@ -7,10 +7,9 @@ import {DefinitionContainer} from './Definition.styled';
 
 type DefinitionProps = {
   content: string;
-  children?: ReactNode;
 };
 
-const Definition: React.FC<DefinitionProps> = props => {
+const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
   const {content, children} = props;
 
   return (

--- a/src/components/molecules/EmptyListContent/EmptyListContent.tsx
+++ b/src/components/molecules/EmptyListContent/EmptyListContent.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, useContext} from 'react';
+import {PropsWithChildren, ReactElement, useContext} from 'react';
 
 import {ExternalLink} from '@atoms';
 
@@ -22,12 +22,11 @@ type EmptyListContentProps = {
   description: string | ReactElement;
   buttonText: string;
   onButtonClick?: () => void;
-  children?: React.ReactNode;
   emptyListReadonlyTitle?: string;
   emptyListReadonlyDescription?: string;
 };
 
-const EmptyListContent: React.FC<EmptyListContentProps> = props => {
+const EmptyListContent: React.FC<PropsWithChildren<EmptyListContentProps>> = props => {
   const {
     title,
     description,

--- a/src/components/organisms/EntityList/EntityListContent/EntityListHeader.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropsWithChildren} from 'react';
 
 import {Space} from 'antd';
 
@@ -8,7 +8,11 @@ import Colors from '@styles/Colors';
 
 import {HeaderContainer} from './EntityListContent.styled';
 
-const EntityListHeader: React.FC<{pageTitle: React.ReactNode | string; children: React.ReactNode}> = props => {
+type EntityListHeaderProps = {
+  pageTitle: React.ReactNode | string;
+};
+
+const EntityListHeader: React.FC<PropsWithChildren<EntityListHeaderProps>> = props => {
   const {pageTitle, children} = props;
   return (
     <HeaderContainer>

--- a/src/components/organisms/PageBlueprint/PageBlueprint.tsx
+++ b/src/components/organisms/PageBlueprint/PageBlueprint.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {PropsWithChildren, useContext} from 'react';
 import {Helmet} from 'react-helmet';
 
 import {Space} from 'antd';
@@ -12,13 +12,12 @@ import {ConfigContext} from '@contexts';
 import {PageBlueprintHeader, PageBlueprintWrapper} from './PageBlueprint.styled';
 
 type PageBlueprintProps = {
-  children: React.ReactNode;
   title: string;
   description: React.ReactNode;
   headerButton?: React.ReactNode;
 };
 
-const PageBlueprint: React.FC<PageBlueprintProps> = props => {
+const PageBlueprint: React.FC<PropsWithChildren<PageBlueprintProps>> = props => {
   const {children, title, description, headerButton} = props;
   const {pageTitle} = useContext(ConfigContext);
 

--- a/src/components/pages/ErrorBoundary/ErrorBoundaryInner.tsx
+++ b/src/components/pages/ErrorBoundary/ErrorBoundaryInner.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
+import React, {PropsWithChildren} from 'react';
 
 import ErrorBoundaryFallback from './ErrorBoundaryFallback';
 
 type ErrorBoundaryInnerProps = {
-  children: React.ReactNode;
   hasError: boolean;
   setHasError: (has: boolean) => void;
 };
 
-class ErrorBoundary extends React.Component<ErrorBoundaryInnerProps, {hasError: boolean}> {
+class ErrorBoundary extends React.Component<PropsWithChildren<ErrorBoundaryInnerProps>, {hasError: boolean}> {
   constructor(props: any) {
     super(props);
     this.state = {hasError: false};


### PR DESCRIPTION
## Changes

- same as in Cloud

## Fixes

- Part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
