### PR TITLE
feat: use skeleton when loading artifacts

### DIFF
--- a/src/components/custom-antd/Skeleton/Skeleton.styled.tsx
+++ b/src/components/custom-antd/Skeleton/Skeleton.styled.tsx
@@ -2,14 +2,34 @@ import {Skeleton} from 'antd';
 
 import styled from 'styled-components';
 
-export const StyledSkeleton = styled(Skeleton)<{additionalStyles?: any}>`
+import Colors from '@styles/Colors';
+
+import {AdditionalSkeletonStyles} from './Skeleton';
+
+export const StyledSkeleton = styled(Skeleton)<{additionalStyles?: AdditionalSkeletonStyles}>`
   &.testkube-skeleton {
     padding-top: ${props => `${props.additionalStyles?.container?.paddingTop || 0}px`};
+    padding-bottom: ${props => `${props.additionalStyles?.container?.paddingBottom || 0}px`};
 
     .ant-skeleton-content {
       .ant-skeleton-paragraph {
         li {
           height: ${props => `${props.additionalStyles?.lineHeight}px` || 'initial'};
+        }
+      }
+    }
+
+    &.ant-skeleton-active {
+      .ant-skeleton-paragraph {
+        & > li::after {
+          background: linear-gradient(
+            90deg,
+            ${props => `${props.additionalStyles?.color ? props.additionalStyles?.color : Colors.slate800}`} 25%,
+            ${props =>
+                `${props.additionalStyles?.contrastColor ? props.additionalStyles?.contrastColor : Colors.slate700}`}
+              37%,
+            ${props => `${props.additionalStyles?.color ? props.additionalStyles?.color : Colors.slate800}`} 63%
+          );
         }
       }
     }

--- a/src/components/custom-antd/Skeleton/Skeleton.tsx
+++ b/src/components/custom-antd/Skeleton/Skeleton.tsx
@@ -2,10 +2,13 @@ import {SkeletonProps as AntdSkeletonProps} from 'antd';
 
 import {StyledSkeleton} from './Skeleton.styled';
 
-type AdditionalSkeletonStyles = {
+export type AdditionalSkeletonStyles = {
   lineHeight?: number;
+  color?: string;
+  contrastColor?: string;
   container?: {
     paddingTop?: number;
+    paddingBottom?: number;
   };
 };
 
@@ -14,7 +17,7 @@ type CustomAntdSkeletonProps = {
 };
 
 const Skeleton: React.FC<AntdSkeletonProps & CustomAntdSkeletonProps> = props => {
-  const {children, active = false, title = false, paragraph = {rows: 1, width: '100%'}} = props;
+  const {children, active = true, title = false, paragraph = {rows: 1, width: '100%'}} = props;
 
   if (children) {
     return (

--- a/src/components/molecules/ArtifactsList/ArtifactsList.tsx
+++ b/src/components/molecules/ArtifactsList/ArtifactsList.tsx
@@ -4,7 +4,7 @@ import {FileOutlined} from '@ant-design/icons';
 
 import {Artifact} from '@models/artifact';
 
-import {Text} from '@custom-antd';
+import {Skeleton, Text} from '@custom-antd';
 
 import {downloadFile} from '@services/artifacts';
 
@@ -15,14 +15,24 @@ import {ArtifactsListContainer, ArtifactsListItem, StyledDownloadIcon, StyledSpa
 type ArtifactsListProps = {
   artifacts: Artifact[];
   testExecutionId: string;
+  isLoading?: boolean;
 };
 
 const ArtifactsList: React.FC<ArtifactsListProps> = props => {
-  const {artifacts, testExecutionId} = props;
+  const {artifacts, testExecutionId, isLoading} = props;
 
   const downloadArtifact = downloadFile(testExecutionId);
 
   const renderedArtifactsList = useMemo(() => {
+    if (isLoading) {
+      return (
+        <>
+          <Skeleton additionalStyles={{lineHeight: 40, color: Colors.slate900, contrastColor: Colors.slate700}} />
+          <Skeleton additionalStyles={{lineHeight: 40, color: Colors.slate900, contrastColor: Colors.slate700}} />
+          <Skeleton additionalStyles={{lineHeight: 40, color: Colors.slate900, contrastColor: Colors.slate700}} />
+        </>
+      );
+    }
     if (!artifacts || !artifacts.length) {
       return (
         <Text className="semibold middle" color={Colors.whitePure}>

--- a/src/components/molecules/ExecutionDetails/TestExecutionDetails/TestExecutionDetailsArtifacts.tsx
+++ b/src/components/molecules/ExecutionDetails/TestExecutionDetails/TestExecutionDetailsArtifacts.tsx
@@ -15,7 +15,7 @@ const TestExecutionDetailsArtifacts: React.FC<TestExecutionDetailsArtifactsProps
 
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
 
-  const {data, error} = useGetTestExecutionArtifactsQuery(id);
+  const {data, isLoading, error} = useGetTestExecutionArtifactsQuery(id);
 
   useEffect(() => {
     if (error) {
@@ -25,7 +25,7 @@ const TestExecutionDetailsArtifacts: React.FC<TestExecutionDetailsArtifactsProps
     }
   }, [data, error]);
 
-  return <ArtifactsList artifacts={artifacts} testExecutionId={id} />;
+  return <ArtifactsList artifacts={artifacts} testExecutionId={id} isLoading={isLoading} />;
 };
 
 export default TestExecutionDetailsArtifacts;


### PR DESCRIPTION
## Changes

- Add more customization options to custom Skeleton
- Use Skeleton when loading artifacts, same as in Cloud

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
