### PR TITLE
fix: avoid parsing pathname and use absolute paths

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
@@ -149,39 +149,18 @@ const EntityDetailsContainer: React.FC<EntityDetailsBlueprint> = props => {
     },
   });
 
-  const getDefaultUrl = () => {
-    const clarifyTargetUrl = pathname.split('/').slice(0, 4);
-
-    return clarifyTargetUrl.join('/');
-  };
+  const defaultUrl = `/${entity}/executions/${entityDetails?.name}`;
 
   const onRowSelect = (dataItem: any, isManual?: boolean) => {
     selectRow(dataItem);
 
     if (isManual) {
-      if (execId) {
-        const defaultUrl = getDefaultUrl();
-
-        const targetUrl = `${defaultUrl}/execution/${dataItem?.id}`;
-
-        navigate(targetUrl);
-      } else {
-        const targetUrl = `${pathname}/execution/${dataItem?.id}`;
-
-        navigate(targetUrl);
-      }
-    } else if (!execId) {
-      const targetUrl = `${pathname}/execution/${dataItem?.id}`;
-
-      navigate(targetUrl);
+      navigate(`${defaultUrl}/execution/${dataItem?.id}`);
     }
   };
 
   const unselectRow = () => {
     selectRow(undefined);
-
-    const defaultUrl = getDefaultUrl();
-
     navigate(defaultUrl);
   };
 

--- a/src/components/organisms/EntityList/EntityCreationModal/TestSuiteCreationModalContent.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestSuiteCreationModalContent.tsx
@@ -59,7 +59,7 @@ const TestSuiteCreationModalContent: React.FC = () => {
           });
 
           dispatch(openSettingsTabConfig());
-          navigate(`test-suites/executions/${res?.data?.metadata?.name}`);
+          navigate(`/test-suites/executions/${res?.data?.metadata?.name}`);
         });
       })
       .catch(err => displayDefaultErrorNotification(err));

--- a/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -85,7 +85,7 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
   };
 
   const onNavigateToDetails = (item: any) => {
-    navigate(`${entity}/executions/${item.dataItem.name}`);
+    navigate(`/${entity}/executions/${item.dataItem.name}`);
   };
 
   const onScrollBottom = () => {

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -44,7 +44,7 @@ const Executors: React.FC = () => {
   const customExecutors = executors?.filter(executorItem => executorItem.executor.executorType === 'container') || [];
 
   const onNavigateToDetails = (name: string) => {
-    navigate(`executors/${name}`);
+    navigate(`/executors/${name}`);
   };
 
   useEffect(() => {

--- a/src/components/pages/Sources/SourcesList/SourcesList.tsx
+++ b/src/components/pages/Sources/SourcesList/SourcesList.tsx
@@ -31,7 +31,7 @@ const Sources: React.FC = () => {
   const mayCreate = usePermission(Permissions.createEntity);
 
   const onNavigateToDetails = (name: string) => {
-    navigate(`sources/${name}`);
+    navigate(`/sources/${name}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Changes

- avoid parsing pathname (`.split('/').slice(0, 4).join('/')`)
- use absolute paths
- related to https://github.com/kubeshop/testkube-cloud-ui/pull/217

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
