### PR TITLE
feat: add customLinkIcon to HelpCard

### DIFF
--- a/src/components/molecules/HelpCard/HelpCard.styled.tsx
+++ b/src/components/molecules/HelpCard/HelpCard.styled.tsx
@@ -5,12 +5,14 @@ import Colors from '@styles/Colors';
 export const StyledHelpCardContainer = styled.div<{isLink?: boolean}>`
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: 19px;
 
   transition: background-color 0.5s ease;
 
   border-radius: 4px;
   padding: 14px 15px;
+  width: 100%;
 
   background-color: ${Colors.slate800};
   cursor: ${props => (props.isLink ? 'pointer' : 'default')};
@@ -37,4 +39,15 @@ export const StyledHelpCardsContainer = styled.div`
 
 export const StyledLastHelpCardContainer = styled.div`
   margin-top: 32px;
+`;
+
+export const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  svg {
+    path {
+      fill: ${Colors.slate50};
+    }
+  }
 `;

--- a/src/components/molecules/HelpCard/HelpCard.tsx
+++ b/src/components/molecules/HelpCard/HelpCard.tsx
@@ -1,17 +1,19 @@
+import {PropsWithChildren} from 'react';
+
 import {ReactComponent as HelpLinkIcon} from '@assets/helpLinkIcon.svg';
 import {ReactComponent as LinkIcon} from '@assets/linkIcon.svg';
 import {ReactComponent as QuestionCircleIcon} from '@assets/questionCircleIcon.svg';
 
-import {StyledChildrenContainer, StyledHelpCardContainer} from './HelpCard.styled';
+import {IconWrapper, StyledChildrenContainer, StyledHelpCardContainer} from './HelpCard.styled';
 
-type HeypCardTypes = {
+type HelpCardTypes = {
   isLink?: boolean;
   isHelp?: boolean;
-  children: React.ReactNode;
   link?: string;
+  customLinkIcon?: any;
 };
-const HelpCard: React.FC<HeypCardTypes> = props => {
-  const {isLink, isHelp, children, link} = props;
+const HelpCard: React.FC<PropsWithChildren<HelpCardTypes>> = props => {
+  const {isLink, isHelp, children, link, customLinkIcon: CustomLinkIcon} = props;
 
   const redirectToLink = () => {
     window.open(link, '_blank');
@@ -19,10 +21,18 @@ const HelpCard: React.FC<HeypCardTypes> = props => {
 
   return (
     <StyledHelpCardContainer isLink={Boolean(link)} onClick={redirectToLink}>
-      {isLink ? <HelpLinkIcon /> : null}
-      {isHelp ? <QuestionCircleIcon /> : null}
+      {isLink && !CustomLinkIcon ? (
+        <IconWrapper>
+          <HelpLinkIcon />
+        </IconWrapper>
+      ) : null}
+      {isHelp ? (
+        <IconWrapper>
+          <QuestionCircleIcon />
+        </IconWrapper>
+      ) : null}
       <StyledChildrenContainer>{children}</StyledChildrenContainer>
-      {isLink ? <LinkIcon /> : null}
+      {isLink ? <IconWrapper>{CustomLinkIcon || <LinkIcon />}</IconWrapper> : null}
     </StyledHelpCardContainer>
   );
 };


### PR DESCRIPTION
## Changes

- add customLinkIcon to HelpCard
- while it's not used in OSS yet, it's to align OSS and Cloud implementation

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
