### PR TITLE
fix: typo: cluster availability check for source details

### DIFF
--- a/src/components/pages/Sources/SourceDetails/SourceDetails.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceDetails.tsx
@@ -26,7 +26,7 @@ const SourceDetails = () => {
 
   const [activeTabKey, setActiveTabKey] = useState('Settings');
 
-  const {data: sourceDetails, refetch} = useGetSourceDetailsQuery(name, {skip: isClusterAvailable});
+  const {data: sourceDetails, refetch} = useGetSourceDetailsQuery(name, {skip: !isClusterAvailable});
 
   const isPageDisabled = !name;
 


### PR DESCRIPTION
## Changes

- Typo: it was skipping getting source details when the agent was available (instead unavailable)

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
