### PR TITLE
tech: use RTK to unify getting resource definitions

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsDefinition/SettingsDefinition.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsDefinition/SettingsDefinition.tsx
@@ -1,6 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
-
-import axios from 'axios';
+import {useContext} from 'react';
 
 import {CopyButton, DownloadButton, ExternalLink, Pre} from '@atoms';
 
@@ -9,44 +7,19 @@ import {ConfigurationCard, Definition} from '@molecules';
 import useLocation from '@hooks/useLocation';
 import useSecureContext from '@hooks/useSecureContext';
 
-import {EntityDetailsContext} from '@contexts';
+import {EntityDetailsContext, MainContext} from '@contexts';
 
 import {settingsDefinitionData} from './utils';
 
 const SettingsDefinition: React.FC = () => {
   const {entityDetails, entity} = useContext(EntityDetailsContext);
+  const {isClusterAvailable} = useContext(MainContext);
 
   const {name} = entityDetails;
   const sectionData = settingsDefinitionData[entity];
-  const [definition, setDefinition] = useState('');
-  const [isLoading, setLoading] = useState(false);
+  const {data: definition = '', isLoading} = sectionData.query(name, {skip: !isClusterAvailable});
   const isSecureContext = useSecureContext();
   const filename = useLocation().lastPathSegment;
-
-  const onGetTestCRD = async () => {
-    setLoading(true);
-
-    try {
-      setDefinition('');
-
-      const result = await axios(`${sectionData.apiEndpoint}${name}`, {
-        method: 'GET',
-        headers: {
-          Accept: 'text/yaml',
-        },
-      });
-
-      setDefinition(result.data);
-      // eslint-disable-next-line no-empty
-    } catch (err) {
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    onGetTestCRD();
-  }, [name]);
 
   return (
     <ConfigurationCard

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsDefinition/utils.ts
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsDefinition/utils.ts
@@ -1,16 +1,24 @@
+import {UseQuery} from '@reduxjs/toolkit/dist/query/react/buildHooks';
+import {QueryDefinition} from '@reduxjs/toolkit/src/query/endpointDefinitions';
+
 import {Entity} from '@models/entity';
 
-export const settingsDefinitionData: {
-  [key in Entity]: {description: string; helpLinkUrl: string; apiEndpoint: string};
-} = {
+import {useGetTestDefinitionQuery} from '@services/tests';
+import {useGetTestSuiteDefinitionQuery} from '@services/testSuites';
+
+export const settingsDefinitionData: Record<Entity, {
+  description: string;
+  helpLinkUrl: string;
+  query: UseQuery<QueryDefinition<string, any, any, string>>
+}> = {
   'test-suites': {
     description: 'Validate and export your test suite configuration',
     helpLinkUrl: 'https://kubeshop.github.io/testkube/using-testkube/test-suites/testsuites-creating/',
-    apiEndpoint: '/test-suite-with-executions/',
+    query: useGetTestSuiteDefinitionQuery,
   },
   tests: {
     description: 'Validate and export your test configuration',
     helpLinkUrl: 'https://kubeshop.github.io/testkube/using-testkube/tests/tests-creating/',
-    apiEndpoint: '/test-with-executions/',
+    query: useGetTestDefinitionQuery,
   },
 };

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorDefinition/ExecutorDefinition.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorDefinition/ExecutorDefinition.tsx
@@ -1,6 +1,4 @@
-import {useEffect, useState} from 'react';
-
-import axios from 'axios';
+import {useContext} from 'react';
 
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentExecutor} from '@redux/reducers/executorsSlice';
@@ -9,42 +7,20 @@ import {CopyButton, DownloadButton, Pre} from '@atoms';
 
 import {ConfigurationCard, Definition as DefinitionContent} from '@molecules';
 
+import {useGetExecutorDefinitionQuery} from '@services/executors';
+
+import {MainContext} from '@contexts';
+
 import useLocation from '@hooks/useLocation';
 import useSecureContext from '@hooks/useSecureContext';
 
 const ExecutorDefinition = () => {
+  const {isClusterAvailable} = useContext(MainContext);
+
   const executor = useAppSelector(selectCurrentExecutor);
-  const [definition, setDefinition] = useState('');
-  const [isLoading, setLoading] = useState(false);
+  const {data: definition = '', isLoading} = useGetExecutorDefinitionQuery(executor?.name, {skip: !isClusterAvailable});
   const isSecureContext = useSecureContext();
   const filename = useLocation().lastPathSegment;
-
-  const name = executor?.name;
-
-  const onGetExecutorCRD = async () => {
-    setLoading(true);
-
-    try {
-      setDefinition('');
-
-      const result = await axios(`/executors/${name}`, {
-        method: 'GET',
-        headers: {
-          Accept: 'text/yaml',
-        },
-      });
-
-      setDefinition(result.data);
-      // eslint-disable-next-line no-empty
-    } catch (err) {
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    onGetExecutorCRD();
-  }, [name]);
 
   return (
     <ConfigurationCard title="Definition" description="Validate and export your container executor configuration">

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/Definition/SourceSettingsDefinition.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/Definition/SourceSettingsDefinition.tsx
@@ -1,7 +1,4 @@
-import {useEffect, useState} from 'react';
-import {useParams} from 'react-router';
-
-import axios from 'axios';
+import {useContext} from 'react';
 
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentSource} from '@redux/reducers/sourcesSlice';
@@ -10,42 +7,20 @@ import {CopyButton, DownloadButton, Pre} from '@atoms';
 
 import {ConfigurationCard, Definition as DefinitionContent} from '@molecules';
 
+import {useGetSourceDefinitionQuery} from '@services/sources';
+
+import {MainContext} from '@contexts';
+
 import useLocation from '@hooks/useLocation';
 import useSecureContext from '@hooks/useSecureContext';
 
 const SourceSettingsDefinition = () => {
-  const source = useAppSelector(selectCurrentSource);
+  const {isClusterAvailable} = useContext(MainContext);
+
+  const source = useAppSelector(selectCurrentSource)!;
   const isSecureContext = useSecureContext();
-  const [definition, setDefinition] = useState('');
-  const [isLoading, setLoading] = useState(false);
+  const {data: definition = '', isLoading} = useGetSourceDefinitionQuery(source?.name, {skip: !isClusterAvailable});
   const filename = useLocation().lastPathSegment;
-  const params = useParams();
-  const name = source?.name;
-
-  const onGetSourceCRD = async () => {
-    setLoading(true);
-
-    try {
-      setDefinition('');
-
-      const result = await axios(`/test-sources/${name}`, {
-        method: 'GET',
-        headers: {
-          Accept: 'text/yaml',
-        },
-      });
-
-      setDefinition(result.data);
-      // eslint-disable-next-line no-empty
-    } catch (err) {
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    onGetSourceCRD();
-  }, [name]);
 
   return (
     <ConfigurationCard title="Definition" description="Validate and export your source configuration">

--- a/src/services/executors.ts
+++ b/src/services/executors.ts
@@ -25,6 +25,13 @@ export const executorsApi = createApi({
         body,
       }),
     }),
+    getExecutorDefinition: builder.query<string, string>({
+      query: id => ({
+        url: `/executors/${id}`,
+        responseHandler: 'text',
+        headers: {accept: 'text/yaml'},
+      }),
+    }),
     getExecutorDetails: builder.query<any, string>({
       query: id => `/executors/${id}`,
     }),
@@ -40,6 +47,7 @@ export const executorsApi = createApi({
 export const {
   useGetExecutorsQuery,
   useCreateExecutorMutation,
+  useGetExecutorDefinitionQuery,
   useGetExecutorDetailsQuery,
   useDeleteExecutorMutation,
   useUpdateCustomExecutorMutation,

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -27,6 +27,13 @@ export const sourcesApi = createApi({
         };
       },
     }),
+    getSourceDefinition: builder.query<string, string>({
+      query: id => ({
+        url: `/test-sources/${id}`,
+        responseHandler: 'text',
+        headers: {accept: 'text/yaml'},
+      }),
+    }),
     getSourceDetails: builder.query<SourceWithRepository, string>({
       query: id => `/test-sources/${id}`,
     }),
@@ -50,6 +57,7 @@ export const sourcesApi = createApi({
 
 export const {
   useGetSourcesQuery,
+  useGetSourceDefinitionQuery,
   useGetSourceDetailsQuery,
   useCreateSourceMutation,
   useDeleteSourceMutation,

--- a/src/services/testSuites.ts
+++ b/src/services/testSuites.ts
@@ -24,6 +24,13 @@ export const testSuitesApi = createApi({
     getTestSuiteExecution: builder.query<any, string>({
       query: executionId => `/test-suites-executions/${executionId}`,
     }),
+    getTestSuiteDefinition: builder.query<string, string>({
+      query: id => ({
+        url: `/test-suites/${id}`,
+        responseHandler: 'text',
+        headers: {accept: 'text/yaml'},
+      }),
+    }),
     getTestSuiteDetails: builder.query<any, string>({
       query: id => `/test-suites/${id}`,
     }),
@@ -63,6 +70,7 @@ export const {
   useGetTestSuitesQuery,
   useUpdateTestSuiteMutation,
   useGetTestSuiteExecutionQuery,
+  useGetTestSuiteDefinitionQuery,
   useGetTestSuiteDetailsQuery,
   useAddTestSuiteMutation,
   useDeleteTestSuiteMutation,

--- a/src/services/tests.ts
+++ b/src/services/tests.ts
@@ -15,6 +15,13 @@ export const testsApi = createApi({
     getAllTests: builder.query<TestWithExecution[], void | null>({
       query: () => `/test-with-executions`,
     }),
+    getTestDefinition: builder.query<string, string>({
+      query: testId => ({
+        url: `/tests/${testId}`,
+        responseHandler: 'text',
+        headers: {accept: 'text/yaml'},
+      }),
+    }),
     getTest: builder.query<TestWithExecution, string>({
       query: testId => `/tests/${testId}`,
     }),
@@ -83,6 +90,7 @@ export const testsApi = createApi({
 });
 
 export const {
+  useGetTestDefinitionQuery,
   useGetTestQuery,
   useGetTestsQuery,
   useGetAllTestsQuery,


### PR DESCRIPTION
## Changes

- use RTK to unify getting resource definitions
- related to https://github.com/kubeshop/testkube-cloud-ui/pull/222

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
