### PR TITLE
fix: adjust variables list to set initial value correctly

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useContext, useEffect, useMemo} from 'react';
 
 import {Form} from 'antd';
 
@@ -33,6 +33,13 @@ const Variables: React.FC = () => {
   const variables = useMemo(() => {
     return decomposeVariables(entityDetails?.executionRequest?.variables) || [];
   }, [entityDetails?.executionRequest?.variables]);
+
+  useEffect(() => {
+    form.setFieldsValue({
+      'variables-list': variables,
+    });
+    form.resetFields();
+  }, [variables]);
 
   const onSaveForm = (value: any) => {
     const successRecord = {


### PR DESCRIPTION
## Changes

- correctly detect the initial untouched state
- align to Cloud more
- related to https://github.com/kubeshop/testkube-cloud-ui/pull/223

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
