### PR TITLE
fix: typo: labels disabled when user has permissions

### DIFF
--- a/src/components/molecules/LabelsSelect/LabelsSelect.tsx
+++ b/src/components/molecules/LabelsSelect/LabelsSelect.tsx
@@ -39,7 +39,7 @@ const isValidLabel = (value: string) => {
 const LabelsSelect: React.FC<LabelsSelectProps> = props => {
   const {onChange, defaultLabels, options, placeholder = 'Add or create new labels', validation, menuPlacement} = props;
   // TODO: Check if it's actually expected, as it's used in multiple places
-  const isSelectDisabled = usePermission(Permissions.editEntity);
+  const isSelectDisabled = !usePermission(Permissions.editEntity);
 
   const {isClusterAvailable} = useContext(MainContext);
 


### PR DESCRIPTION
## Changes

- typo for checking the permission in LabelsSelect

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
