### PR TITLE
feat: improve CopyCommand

### DIFF
--- a/src/components/molecules/CLICommands/CLICommands.tsx
+++ b/src/components/molecules/CLICommands/CLICommands.tsx
@@ -9,7 +9,7 @@ import {selectExecutorsFeaturesMap} from '@redux/reducers/executorsSlice';
 
 import {Permissions, usePermission} from '@permissions/base';
 
-import {EntityDetailsContext} from '@contexts';
+import {EntityDetailsContext, MainContext} from '@contexts';
 
 import CopyCommand from './CopyCommand';
 
@@ -114,6 +114,7 @@ const CLICommands: React.FC<CLICommandsProps> = props => {
   const mayDelete = usePermission(Permissions.deleteEntity);
 
   const {entity} = useContext(EntityDetailsContext);
+  const {ga4React} = useContext(MainContext);
 
   const executorsFeaturesMap = useAppSelector(selectExecutorsFeaturesMap);
 
@@ -146,7 +147,13 @@ const CLICommands: React.FC<CLICommandsProps> = props => {
 
       const commandString = command(testTarget);
 
-      return <CopyCommand key={label} command={commandString} label={label} bg={bg} />;
+      const onCopy = () => {
+        if (ga4React) {
+          ga4React.gtag('event', 'copy_command', {command: label});
+        }
+      };
+
+      return <CopyCommand key={label} command={commandString} label={label} bg={bg} onCopy={onCopy} highlightSyntax />;
     }).filter(cliCommand => cliCommand);
   }, [id, name, type, modifyMap]);
 

--- a/src/components/molecules/CLICommands/CopyCommand.styled.tsx
+++ b/src/components/molecules/CLICommands/CopyCommand.styled.tsx
@@ -38,8 +38,11 @@ export const StyledCopyCommandCode = styled.code`
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 
-  span {
-    margin-right: 5px;
+  > span {
     color: ${Colors.slate500};
+
+    &:not(:last-child)::after {
+      content: ' ';
+    }
   }
 `;

--- a/src/models/command.ts
+++ b/src/models/command.ts
@@ -1,0 +1,23 @@
+import Colors from '@styles/Colors';
+
+export const literalToColor: Record<string, Colors> = {
+  kubectl: Colors.indigo300,
+  testkube: Colors.indigo300,
+  helm: Colors.indigo300,
+  install: Colors.amber300,
+  repo: Colors.amber300,
+  context: Colors.amber300,
+  apply: Colors.amber300,
+  update: Colors.amber300,
+  add: Colors.slate400,
+  get: Colors.slate400,
+  set: Colors.slate400,
+  run: Colors.slate400,
+  download: Colors.slate400,
+  delete: Colors.slate400,
+  upgrade: Colors.slate400,
+};
+
+export const getLiteralColor = (literal: string): Colors => {
+  return literalToColor[literal] || Colors.whitePure;
+};


### PR DESCRIPTION
## Changes

- highlight literals in CLI command
- allow quick selection on double click
- align with Cloud version
- related to https://github.com/kubeshop/testkube-cloud-ui/pull/225

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

