### PR TITLE
chore: unify RTK implementation with Cloud version

### DIFF
--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -9,7 +9,9 @@ export const configApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getClusterConfig: builder.query<ClusterConfig, void>({
-      query: () => '/config',
+      query: () => ({
+        url: `/config`,
+      }),
     }),
   }),
 });

--- a/src/services/executions.ts
+++ b/src/services/executions.ts
@@ -7,15 +7,17 @@ export const executionsApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getExecutions: builder.query({
-      query: (filters: any) => {
-        return `${filters.testName ? `/tests/${filters.testName}` : ''}/executions?${paramsSerializer(filters)}`;
-      },
+      query: (filters: any) => ({
+        url: `${filters.testName ? `/tests/${filters.testName}` : ''}/executions?${paramsSerializer(filters)}`,
+      }),
     }),
     getScriptExecutionById: builder.query({
-      query: scriptExecutionId => `/executions/${scriptExecutionId}`,
+      query: scriptExecutionId => ({url: `/executions/${scriptExecutionId}`}),
     }),
     getScriptExecutionArtifacts: builder.query({
-      query: testId => `/executions/${testId}/artifacts`,
+      query: testId => ({
+        url: `/executions/${testId}/artifacts`,
+      }),
     }),
   }),
 });

--- a/src/services/executors.ts
+++ b/src/services/executors.ts
@@ -9,7 +9,9 @@ export const executorsApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getExecutors: builder.query<Executor[], null | void>({
-      query: () => '/executors',
+      query: () => ({
+        url: `/executors`,
+      }),
     }),
     createExecutor: builder.mutation<void, any>({
       query: body => ({
@@ -33,7 +35,9 @@ export const executorsApi = createApi({
       }),
     }),
     getExecutorDetails: builder.query<any, string>({
-      query: id => `/executors/${id}`,
+      query: id => ({
+        url: `/executors/${id}`,
+      }),
     }),
     deleteExecutor: builder.mutation<void, any>({
       query: id => ({

--- a/src/services/labels.ts
+++ b/src/services/labels.ts
@@ -7,7 +7,9 @@ export const labelsApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getLabels: builder.query<{[key: string]: string[]}, null>({
-      query: () => `/labels`,
+      query: () => ({
+        url: `/labels`,
+      }),
     }),
   }),
 });

--- a/src/services/repository.ts
+++ b/src/services/repository.ts
@@ -7,13 +7,11 @@ export const repositoryApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     validateRepository: builder.mutation<any, any>({
-      query: body => {
-        return {
-          url: '/repositories',
-          method: 'POST',
-          body,
-        };
-      },
+      query: body => ({
+        url: '/repositories',
+        method: 'POST',
+        body,
+      }),
     }),
   }),
 });

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -16,16 +16,23 @@ export const sourcesApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getSources: builder.query<SourceWithRepository[], null>({
-      query: () => '/test-sources',
+      query: () => ({
+        url: '/test-sources',
+      }),
+    }),
+    addSources: builder.mutation<any, AddSourcesPayload>({
+      query: body => ({
+        url: '/test-sources',
+        method: 'PATCH',
+        body,
+      }),
     }),
     createSource: builder.mutation<any, SourceWithRepository>({
-      query: body => {
-        return {
-          url: '/test-sources',
-          method: 'POST',
-          body,
-        };
-      },
+      query: body => ({
+        url: '/test-sources',
+        method: 'POST',
+        body,
+      }),
     }),
     getSourceDefinition: builder.query<string, string>({
       query: id => ({
@@ -35,7 +42,9 @@ export const sourcesApi = createApi({
       }),
     }),
     getSourceDetails: builder.query<SourceWithRepository, string>({
-      query: id => `/test-sources/${id}`,
+      query: id => ({
+        url: `/test-sources/${id}`,
+      }),
     }),
     deleteSource: builder.mutation<void, any>({
       query: id => ({
@@ -44,13 +53,11 @@ export const sourcesApi = createApi({
       }),
     }),
     updateSource: builder.mutation<any, SourceWithRepository>({
-      query: body => {
-        return {
-          url: `/test-sources/${body.name}`,
-          method: 'PATCH',
-          body,
-        };
-      },
+      query: body => ({
+        url: `/test-sources/${body.name}`,
+        method: 'PATCH',
+        body,
+      }),
     }),
   }),
 });

--- a/src/services/testSuiteExecutions.ts
+++ b/src/services/testSuiteExecutions.ts
@@ -13,11 +13,16 @@ export const testSuiteExecutionsApi = createApi({
           last,
           pageSize,
         });
-        return `/test-suite-executions?${queryParams.toString()}`;
+
+        return {
+          url: `/test-suite-executions?${queryParams.toString()}`,
+        };
       },
     }),
     getTestSuiteExecutionById: builder.query({
-      query: (testSuiteExecutionId: string) => `/test-suite-executions/${testSuiteExecutionId}`,
+      query: (testSuiteExecutionId: string) => ({
+        url: `/test-suite-executions/${testSuiteExecutionId}`,
+      }),
     }),
     getTestSuiteExecutionMetrics: builder.query({
       query: ({id, last = 7, limit = Number.MAX_SAFE_INTEGER}) => {
@@ -25,7 +30,10 @@ export const testSuiteExecutionsApi = createApi({
           last,
           limit,
         });
-        return `/test-suites/${id}/metrics?${queryParams.toString()}`;
+
+        return {
+          url: `/test-suites/${id}/metrics?${queryParams.toString()}`,
+        };
       },
     }),
   }),

--- a/src/services/testSuites.ts
+++ b/src/services/testSuites.ts
@@ -9,20 +9,26 @@ export const testSuitesApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getTestSuites: builder.query<TestSuiteWithExecution[], TestSuiteFilters>({
-      query: filters => `/test-suite-with-executions?${paramsSerializer(filters)}`,
+      query: filters => ({
+        url: `/test-suite-with-executions?${paramsSerializer(filters)}`,
+      }),
     }),
     getAllTestSuites: builder.query<TestSuiteWithExecution[], void | null>({
-      query: () => `/test-suite-with-executions`,
+      query: () => ({
+        url: `/test-suite-with-executions`,
+      }),
     }),
     updateTestSuite: builder.mutation<void, any>({
       query: body => ({
         url: `/test-suites/${body.id}`,
         method: 'PATCH',
-        body: body.data,
+        data: body.data,
       }),
     }),
     getTestSuiteExecution: builder.query<any, string>({
-      query: executionId => `/test-suites-executions/${executionId}`,
+      query: executionId => ({
+        url: `/test-suites-executions/${executionId}`,
+      }),
     }),
     getTestSuiteDefinition: builder.query<string, string>({
       query: id => ({
@@ -32,16 +38,20 @@ export const testSuitesApi = createApi({
       }),
     }),
     getTestSuiteDetails: builder.query<any, string>({
-      query: id => `/test-suites/${id}`,
+      query: id => ({
+        url: `/test-suites/${id}`,
+      }),
     }),
     getTestsListForTestSuite: builder.query<any, string>({
-      query: id => `/test-suites/${id}/tests`,
+      query: id => ({
+        url: `/test-suites/${id}/tests`,
+      }),
     }),
     addTestSuite: builder.mutation<any, any>({
-      query: body => ({
+      query: data => ({
         url: `/test-suites`,
         method: 'POST',
-        body,
+        data,
       }),
     }),
     deleteTestSuite: builder.mutation<void, any>({
@@ -54,7 +64,7 @@ export const testSuitesApi = createApi({
       query: body => ({
         url: `/test-suites/${body.id}/executions`,
         method: 'POST',
-        body: body.data,
+        data: body.data,
       }),
     }),
     abortTestSuiteExecution: builder.mutation<void, any>({

--- a/src/services/testSuites.ts
+++ b/src/services/testSuites.ts
@@ -22,7 +22,7 @@ export const testSuitesApi = createApi({
       query: body => ({
         url: `/test-suites/${body.id}`,
         method: 'PATCH',
-        data: body.data,
+        body: body.data,
       }),
     }),
     getTestSuiteExecution: builder.query<any, string>({
@@ -48,10 +48,10 @@ export const testSuitesApi = createApi({
       }),
     }),
     addTestSuite: builder.mutation<any, any>({
-      query: data => ({
+      query: body => ({
         url: `/test-suites`,
         method: 'POST',
-        data,
+        body,
       }),
     }),
     deleteTestSuite: builder.mutation<void, any>({
@@ -64,7 +64,7 @@ export const testSuitesApi = createApi({
       query: body => ({
         url: `/test-suites/${body.id}/executions`,
         method: 'POST',
-        data: body.data,
+        body: body.data,
       }),
     }),
     abortTestSuiteExecution: builder.mutation<void, any>({

--- a/src/services/tests.ts
+++ b/src/services/tests.ts
@@ -10,10 +10,14 @@ export const testsApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getTests: builder.query<TestWithExecution[], TestFilters>({
-      query: filters => `/test-with-executions?${paramsSerializer(filters)}`,
+      query: filters => ({
+        url: `/test-with-executions?${paramsSerializer(filters)}`,
+      }),
     }),
     getAllTests: builder.query<TestWithExecution[], void | null>({
-      query: () => `/test-with-executions`,
+      query: () => ({
+        url: `/test-with-executions`,
+      }),
     }),
     getTestDefinition: builder.query<string, string>({
       query: testId => ({
@@ -23,7 +27,9 @@ export const testsApi = createApi({
       }),
     }),
     getTest: builder.query<TestWithExecution, string>({
-      query: testId => `/tests/${testId}`,
+      query: testId => ({
+        url: `/tests/${testId}`,
+      }),
     }),
     getTestExecutionsById: builder.query({
       query: ({id, last = 7, pageSize = Number.MAX_SAFE_INTEGER}) => {
@@ -32,14 +38,20 @@ export const testsApi = createApi({
           pageSize,
         });
 
-        return `/tests/${id}/executions?${queryParams.toString()}`;
+        return {
+          url: `/tests/${id}/executions?${queryParams.toString()}`,
+        };
       },
     }),
     getTestExecutionById: builder.query<any, string>({
-      query: testExecutionId => `/executions/${testExecutionId}`,
+      query: testExecutionId => ({
+        url: `/executions/${testExecutionId}`,
+      }),
     }),
     getTestExecutionArtifacts: builder.query<Artifact[], string>({
-      query: testExecutionId => `/executions/${testExecutionId}/artifacts`,
+      query: testExecutionId => ({
+        url: `/executions/${testExecutionId}/artifacts`,
+      }),
     }),
     getTestExecutionMetrics: builder.query({
       query: ({id, last = 7, limit = Number.MAX_SAFE_INTEGER}) => {
@@ -47,7 +59,10 @@ export const testsApi = createApi({
           last,
           limit,
         });
-        return `/tests/${id}/metrics?${queryParams.toString()}`;
+
+        return {
+          url: `/tests/${id}/metrics?${queryParams.toString()}`,
+        };
       },
     }),
     addTest: builder.mutation<any, any>({

--- a/src/services/triggers.ts
+++ b/src/services/triggers.ts
@@ -9,10 +9,10 @@ export const triggersApi = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: builder => ({
     getTriggersKeyMap: builder.query<TriggersKeyMap, void | null>({
-      query: () => `/keymap/triggers`,
+      query: () => ({url: `/keymap/triggers`}),
     }),
     getTriggersList: builder.query<TestTrigger[], void | null>({
-      query: () => `/triggers`,
+      query: () => ({url: `/triggers`}),
     }),
     createTrigger: builder.mutation<any, any>({
       query: body => ({

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -72,7 +72,7 @@ export const paramsSerializer = (params: object) => {
 type IdTokenResolver = () => Promise<string | null>;
 let resolveIdToken: IdTokenResolver = () => Promise.resolve(null);
 
-type BaseUrlResolver = (routeToRequest: string | null) => string;
+type BaseUrlResolver = (routeToRequest: string | undefined) => string;
 let resolveBaseUrl: BaseUrlResolver = () => '';
 export const setRtkIdTokenResolver = (resolver: IdTokenResolver): void => {
   resolveIdToken = resolver;
@@ -116,7 +116,7 @@ export const dynamicBaseQuery: BaseQueryFn<string | DynamicFetchArgs, unknown, F
   }
 
   const idToken = await resolveIdToken();
-  const baseUrl = resolveBaseUrl(args.routeToRequest || null) || '';
+  const baseUrl = resolveBaseUrl(args.routeToRequest) || '';
 
   return rawBaseQuery(`${apiEndpoint}${baseUrl}`, idToken)(args, api, extraOptions);
 };

--- a/src/utils/fetchUtils.ts
+++ b/src/utils/fetchUtils.ts
@@ -81,6 +81,15 @@ export const setRtkBaseUrlResolver = (resolver: BaseUrlResolver): void => {
   resolveBaseUrl = resolver;
 };
 
+// TODO: Delete these when not needed.
+//       It's temporarily used to unify ID token and base url strategy.
+export const getRtkBaseUrl = (routeToRequest: string | undefined): string => {
+  return resolveBaseUrl(routeToRequest) || '';
+};
+export const getRtkIdToken = (): Promise<string | null> => {
+  return resolveIdToken();
+};
+
 const rawBaseQuery = (baseUrl: string, idToken?: string | null) =>
   fetchBaseQuery({
     baseUrl,


### PR DESCRIPTION
## Changes

- Allow providing ID Token and Base URL strategy for RTK, to align with Cloud version
- Align the code style
- Related to https://github.com/kubeshop/testkube-cloud-ui/pull/231

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
