### PR TITLE
feat: simplify composing providers, add ModalContext, use it same way as in Cloud

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import {Sider} from '@organisms';
 import {EndpointProcessing, ErrorBoundary, NotFound} from '@pages';
 
 import {PollingIntervals} from '@utils/numbers';
+import {composeProviders} from '@utils/composeProviders';
 
 import {ReactComponent as LoadingIcon} from '@assets/loading.svg';
 
@@ -159,7 +160,7 @@ const App: React.FC = () => {
       notificationCall('failed', 'Could not receive data from the specified API endpoint');
 
       // Allow changing API endpoint if there is none in environment variables
-      if (isApiEndpointLocked()) {
+      if (!isApiEndpointLocked()) {
         setEndpointModalState(true);
       }
     });
@@ -203,51 +204,49 @@ const App: React.FC = () => {
     showSocialLinksInSider: true,
   }), [navigate, location]);
 
-  return (
-    <ConfigContext.Provider value={config}>
-      <DashboardContext.Provider value={dashboardValue}>
-        <PermissionsProvider scope={permissionsScope} resolver={permissionsResolver}>
-          <AnalyticsProvider disabled={!isTelemetryEnabled} privateKey={segmentIOKey} appVersion={pjson.version}>
-            <MainContext.Provider value={mainContextValue}>
-              <Layout>
-                <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
-                <Sider />
-                <StyledLayoutContentWrapper>
-                  <Content>
-                    <ErrorBoundary>
-                      <Suspense fallback={<LoadingIcon />}>
-                        <Routes>
-                          <Route path="tests/*" element={<Tests />} />
-                          <Route path="test-suites/*" element={<TestSuites />} />
-                          <Route path="executors/*" element={<Executors />} />
-                          <Route path="sources/*" element={<Sources />} />
-                          <Route path="triggers" element={<Triggers />} />
-                          <Route path="settings" element={<GlobalSettings />} />
-                          <Route
-                            path="/apiEndpoint"
-                            element={isApiEndpointLocked() ? <EndpointProcessing /> : <Navigate to="/" replace />}
-                          />
-                          <Route path="/" element={<Navigate to="/tests" replace />} />
-                          <Route path="*" element={<NotFound />} />
-                        </Routes>
-                      </Suspense>
-                    </ErrorBoundary>
-                  </Content>
-                  {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
-                  <CSSTransition nodeRef={logRef} in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
-                    <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
-                  </CSSTransition>
-                </StyledLayoutContentWrapper>
-              </Layout>
-              {isCookiesVisible && clusterConfig?.enableTelemetry ? (
-                <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
-              ) : null}
-            </MainContext.Provider>
-          </AnalyticsProvider>
-        </PermissionsProvider>
-      </DashboardContext.Provider>
-    </ConfigContext.Provider>
-  );
+  return composeProviders()
+    .append(ConfigContext.Provider, {value: config})
+    .append(DashboardContext.Provider, {value: dashboardValue})
+    .append(PermissionsProvider, {scope: permissionsScope, resolver: permissionsResolver})
+    .append(AnalyticsProvider, {disabled: !isTelemetryEnabled, privateKey: segmentIOKey, appVersion: pjson.version})
+    .append(MainContext.Provider, {value: mainContextValue})
+    .render(
+      <>
+        <Layout>
+          <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
+          <Sider />
+          <StyledLayoutContentWrapper>
+            <Content>
+              <ErrorBoundary>
+                <Suspense fallback={<LoadingIcon />}>
+                  <Routes>
+                    <Route path="tests/*" element={<Tests />} />
+                    <Route path="test-suites/*" element={<TestSuites />} />
+                    <Route path="executors/*" element={<Executors />} />
+                    <Route path="sources/*" element={<Sources />} />
+                    <Route path="triggers" element={<Triggers />} />
+                    <Route path="settings" element={<GlobalSettings />} />
+                    <Route
+                      path="/apiEndpoint"
+                      element={isApiEndpointLocked() ? <Navigate to="/" replace /> : <EndpointProcessing />}
+                    />
+                    <Route path="/" element={<Navigate to="/tests" replace />} />
+                    <Route path="*" element={<NotFound />} />
+                  </Routes>
+                </Suspense>
+              </ErrorBoundary>
+            </Content>
+            {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
+            <CSSTransition nodeRef={logRef} in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
+              <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
+            </CSSTransition>
+          </StyledLayoutContentWrapper>
+        </Layout>
+        {isCookiesVisible && clusterConfig?.enableTelemetry ? (
+          <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
+        ) : null}
+      </>
+    );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {useAxiosInterceptors} from '@hooks/useAxiosInterceptors';
 import {BasePermissionsResolver, PermissionsProvider} from '@permissions/base';
 
 import {ConfigContext, DashboardContext, MainContext} from '@contexts';
+import {ModalHandler, ModalOutlet} from '@contexts/ModalContext';
 
 import {AnalyticsProvider} from './AnalyticsProvider';
 import {StyledLayoutContentWrapper} from './App.styled';
@@ -210,6 +211,7 @@ const App: React.FC = () => {
     .append(PermissionsProvider, {scope: permissionsScope, resolver: permissionsResolver})
     .append(AnalyticsProvider, {disabled: !isTelemetryEnabled, privateKey: segmentIOKey, appVersion: pjson.version})
     .append(MainContext.Provider, {value: mainContextValue})
+    .append(ModalHandler, {})
     .render(
       <>
         <Layout>
@@ -245,6 +247,7 @@ const App: React.FC = () => {
         {isCookiesVisible && clusterConfig?.enableTelemetry ? (
           <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
         ) : null}
+        <ModalOutlet />
       </>
     );
 };

--- a/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
+++ b/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
@@ -2,7 +2,7 @@ import {useContext, useState} from 'react';
 
 import {Input, Space} from 'antd';
 
-import {UseMutationType} from '@models/rtk';
+import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 
 import {Button, Text} from '@custom-antd';
 
@@ -15,21 +15,25 @@ import {uppercaseFirstSymbol} from '@utils/strings';
 
 import Colors from '@styles/Colors';
 
-import {DashboardContext} from '@contexts';
+import {DashboardContext, ModalContext} from '@contexts';
 
 import {FooterSpace} from './DeleteEntityModal.styled';
 
+// TODO: refactor using DeleteModal
 const DeleteEntityModal: React.FC<{
   // onCancel is passed from parent component <Modal />.
   // Do not pass it directly
   onCancel?: any;
-  useDeleteMutation: UseMutationType;
+  useDeleteMutation: UseMutation<any>;
   name: string;
   entityLabel: string;
   defaultStackRoute: string;
+  idToDelete?: string;
+  onConfirm?: any;
 }> = props => {
-  const {onCancel, useDeleteMutation, name, entityLabel, defaultStackRoute} = props;
+  const {onCancel, useDeleteMutation, name, onConfirm, entityLabel, defaultStackRoute, idToDelete} = props;
 
+  const {setModalOpen} = useContext(ModalContext);
   const {navigate} = useContext(DashboardContext);
 
   const onEvent = usePressEnter();
@@ -39,11 +43,17 @@ const DeleteEntityModal: React.FC<{
   const [checkName, setName] = useState('');
 
   const onDelete = () => {
-    deleteEntity(name).then(res => {
+    deleteEntity(idToDelete || name).then(res => {
       displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(entityLabel)} was successfully deleted.`);
 
-        navigate(defaultStackRoute);
+        setModalOpen(false);
+
+        if (onConfirm) {
+          onConfirm();
+        } else {
+          navigate(defaultStackRoute);
+        }
       });
     });
   };

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Delete.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Delete.tsx
@@ -1,9 +1,10 @@
-import {useContext, useState} from 'react';
+import {useContext} from 'react';
+
+import {Form} from 'antd';
+
+import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 
 import {Entity} from '@models/entity';
-import {UseMutationType} from '@models/rtk';
-
-import {Modal} from '@custom-antd';
 
 import {ConfigurationCard} from '@molecules';
 import DeleteEntityModal from '@molecules/DeleteEntityModal';
@@ -11,52 +12,50 @@ import DeleteEntityModal from '@molecules/DeleteEntityModal';
 import {useDeleteTestSuiteMutation} from '@services/testSuites';
 import {useDeleteTestMutation} from '@services/tests';
 
-import {EntityDetailsContext} from '@contexts';
+import {EntityDetailsContext, ModalContext} from '@contexts';
 
 import {namingMap} from '../utils';
 
-const useDeleteMutations: {[key in Entity]: UseMutationType} = {
+const useDeleteMutations: {[key in Entity]: UseMutation<any>} = {
   'test-suites': useDeleteTestSuiteMutation,
   tests: useDeleteTestMutation,
 };
 
 const Delete: React.FC = () => {
   const {entity, entityDetails, defaultStackRoute} = useContext(EntityDetailsContext);
-
-  const [isModalVisible, setIsModalVisible] = useState(false);
+  const {setModalConfig, setModalOpen} = useContext(ModalContext);
 
   if (!entity || !entityDetails) {
     return null;
   }
 
   const onConfirm = () => {
-    setIsModalVisible(true);
+    setModalConfig({
+      title: `Delete this ${namingMap[entity]}`,
+      width: 600,
+      content: (
+        <DeleteEntityModal
+          defaultStackRoute={defaultStackRoute}
+          useDeleteMutation={useDeleteMutations[entity]}
+          name={entityDetails.name}
+          entityLabel={namingMap[entity]}
+        />
+      ),
+    });
+    setModalOpen(true);
   };
+
   return (
-    <>
+    <Form name="delete-entity-form">
       <ConfigurationCard
         title={`Delete this ${namingMap[entity]}`}
-        description="The test suite will be permanently deleted, including its deployments analytical history. This action is irreversible and can not be undone."
+        description={`The ${namingMap[entity]} will be permanently deleted, including its deployments analytical history. This action is irreversible and can not be undone.`}
         onConfirm={onConfirm}
         isWarning
         confirmButtonText="Delete"
+        forceEnableButtons
       />
-      {isModalVisible ? (
-        <Modal
-          title={`Delete this ${namingMap[entity]}`}
-          setIsModalVisible={setIsModalVisible}
-          isModalVisible={isModalVisible}
-          content={
-            <DeleteEntityModal
-              defaultStackRoute={defaultStackRoute}
-              useDeleteMutation={useDeleteMutations[entity]}
-              name={entityDetails.name}
-              entityLabel={namingMap[entity]}
-            />
-          }
-        />
-      ) : null}
-    </>
+    </Form>
   );
 };
 

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,0 +1,57 @@
+import React, {createContext, FC, PropsWithChildren, ReactElement, useContext, useMemo, useState} from 'react';
+import {Modal} from '@custom-antd';
+
+interface ModalConfig {
+  width: number;
+  title: string;
+  content: ReactElement;
+}
+
+export interface ModalContextInterface {
+  modalOpen: boolean;
+  modalConfig: ModalConfig;
+  setModalOpen: (open: boolean) => void;
+  setModalConfig: (config: ModalConfig) => void;
+}
+
+const ModalContext = createContext<ModalContextInterface>(undefined!);
+
+export const ModalHandler: FC<PropsWithChildren<{}>> = ({children}) => {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalConfig, setModalConfig] = useState({
+    width: 500,
+    title: '',
+    content: <></>,
+  });
+
+  const value = useMemo(() => ({
+    modalOpen,
+    modalConfig,
+    setModalOpen,
+    setModalConfig,
+  }), [modalOpen, modalConfig]);
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+    </ModalContext.Provider>
+  );
+};
+
+export const ModalOutlet: FC = () => {
+  const {modalOpen, modalConfig, setModalOpen} = useContext(ModalContext);
+  if (!modalOpen) {
+    return null;
+  }
+  return (
+    <Modal
+      width={modalConfig.width}
+      title={modalConfig.title}
+      content={modalConfig.content}
+      isModalVisible={modalOpen}
+      setIsModalVisible={setModalOpen}
+    />
+  );
+};
+
+export default ModalContext;

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -4,3 +4,4 @@ export {default as EntityDetailsContext} from './EntityDetailsContext';
 export {default as AnalyticsContext} from './AnalyticsContext';
 export {default as ConfigContext} from './ConfigContext';
 export {default as DashboardContext} from './DashboardContext';
+export {default as ModalContext} from './ModalContext';

--- a/src/models/rtk.ts
+++ b/src/models/rtk.ts
@@ -1,6 +1,0 @@
-import {BaseQueryFn, FetchArgs, FetchBaseQueryError, MutationDefinition} from '@reduxjs/toolkit/dist/query';
-import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
-
-export type UseMutationType = UseMutation<
-  MutationDefinition<any, BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError, {}, {}>, never, void, any>
->;

--- a/src/utils/composeProviders.tsx
+++ b/src/utils/composeProviders.tsx
@@ -1,0 +1,22 @@
+import {createElement, FC, ReactElement} from 'react';
+
+class ProviderCompositor {
+  public providers: {provider: FC<any>, props: any}[] = [];
+
+  public append<T>(provider: FC<T>, props: Omit<T, 'children'>): this {
+    this.providers.push({provider, props});
+    return this;
+  }
+
+  public render(children: ReactElement): ReactElement {
+    let current = children;
+    for (let i = this.providers.length - 1; i >= 0; i -= 1) {
+      current = createElement(this.providers[i].provider, this.providers[i].props, current);
+    }
+    return current;
+  }
+}
+
+export function composeProviders(): ProviderCompositor {
+  return new ProviderCompositor();
+}


### PR DESCRIPTION
## Changes

- simplify composing providers, so the Git diffs will be much smaller
- extract global modal mechanism to `ModalContext`
- use it for same feature as in Cloud version (in future it could be used in all such situations)

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
