### PR TITLE
feat: use configurable API endpoint mechanism, prioritize API URL from environment variable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import {ReactComponent as LoadingIcon} from '@assets/loading.svg';
 import {useGetClusterConfigQuery} from '@services/config';
 import {useGetExecutorsQuery} from '@services/executors';
 import {useGetSourcesQuery} from '@services/sources';
-import {getApiDetails, getApiEndpoint, useApiEndpoint} from '@services/apiEndpoint';
+import {getApiDetails, getApiEndpoint, isApiEndpointLocked, useApiEndpoint} from '@services/apiEndpoint';
 
 import {useAxiosInterceptors} from '@hooks/useAxiosInterceptors';
 
@@ -157,7 +157,11 @@ const App: React.FC = () => {
 
       // Display popup
       notificationCall('failed', 'Could not receive data from the specified API endpoint');
-      setEndpointModalState(true);
+
+      // Allow changing API endpoint if there is none in environment variables
+      if (isApiEndpointLocked()) {
+        setEndpointModalState(true);
+      }
     });
   }, [apiEndpoint]);
 
@@ -219,7 +223,10 @@ const App: React.FC = () => {
                           <Route path="sources/*" element={<Sources />} />
                           <Route path="triggers" element={<Triggers />} />
                           <Route path="settings" element={<GlobalSettings />} />
-                          <Route path="/apiEndpoint" element={<EndpointProcessing />} />
+                          <Route
+                            path="/apiEndpoint"
+                            element={isApiEndpointLocked() ? <EndpointProcessing /> : <Navigate to="/" replace />}
+                          />
                           <Route path="/" element={<Navigate to="/tests" replace />} />
                           <Route path="*" element={<NotFound />} />
                         </Routes>

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -8,7 +8,7 @@ import {FormItem, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
+import {isApiEndpointLocked, useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
 
 import {MainContext} from '@contexts';
 
@@ -20,6 +20,7 @@ const ApiEndpoint = () => {
   const {dispatch} = useContext(MainContext);
   const apiEndpoint = useApiEndpoint();
   const updateApiEndpoint = useUpdateApiEndpoint();
+  const disabled = isApiEndpointLocked();
 
   const checkApiEndpoint = async (endpoint: string) => {
     try {
@@ -42,9 +43,15 @@ const ApiEndpoint = () => {
   };
 
   return (
-    <Form form={form} onFinish={onSave} name="global-settings-api-endpoint" initialValues={{endpoint: apiEndpoint}}>
+    <Form
+      form={form}
+      onFinish={onSave}
+      name="global-settings-api-endpoint"
+      initialValues={{endpoint: apiEndpoint}}
+      disabled={disabled}
+    >
       <ConfigurationCard
-        title="testkube API endpoint"
+        title="Testkube API endpoint"
         description="Please provide the TestKube API endpoint for your installation. The endpoint needs to be accessible from your browser"
         footerText={
           <Text className="regular middle">
@@ -61,6 +68,7 @@ const ApiEndpoint = () => {
           form.resetFields();
         }}
         confirmButtonText={isLoading ? 'Loading...' : 'Save'}
+        enabled={!disabled}
       >
         <Space size={32} direction="vertical" style={{width: '100%'}}>
           <FormItem name="endpoint">

--- a/src/services/apiEndpoint.spec.ts
+++ b/src/services/apiEndpoint.spec.ts
@@ -11,7 +11,7 @@ import env from '../env';
 
 import {
   getApiDetails,
-  getApiEndpoint,
+  getApiEndpoint, isApiEndpointLocked,
   sanitizeApiEndpoint,
   saveApiEndpoint,
   useApiEndpoint,
@@ -91,9 +91,9 @@ describe('services', () => {
           expect(getApiEndpoint()).toBe('http://test-api-url/v1');
         });
 
-        it('should prioritize local storage over environment variable', () => {
+        it('should prioritize environment variable over local storage', () => {
           saveApiEndpoint('http://abc/v1');
-          expect(getApiEndpoint()).toBe('http://abc/v1');
+          expect(getApiEndpoint()).toBe('http://test-api-url/v1');
         });
       });
 
@@ -103,6 +103,24 @@ describe('services', () => {
         it('should be null', () => {
           saveApiEndpoint('');
           expect(getApiEndpoint()).toBe(null);
+        });
+      });
+    });
+
+    describe('isApiEndpointLocked', () => {
+      describe('Environment variable available', () => {
+        replaceEnvEach('apiUrl', 'some-url');
+
+        it('should detect API Endpoint as locked', () => {
+          expect(isApiEndpointLocked()).toBe(true);
+        });
+      });
+
+      describe('Environment variable not available', () => {
+        replaceEnvEach('apiUrl', null);
+
+        it('should detect API Endpoint as not locked', () => {
+          expect(isApiEndpointLocked()).toBe(false);
         });
       });
     });

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -55,6 +55,10 @@ function notifySubscriptions(): void {
   listeners.forEach((listener) => listener(endpoint));
 }
 
+export function isApiEndpointLocked(): boolean {
+  return Boolean(env?.apiUrl);
+}
+
 export function sanitizeApiEndpoint(apiEndpoint: string): string;
 export function sanitizeApiEndpoint(apiEndpoint: null | undefined): null;
 export function sanitizeApiEndpoint(apiEndpoint: string | null | undefined): string | null;
@@ -75,7 +79,7 @@ export function sanitizeApiEndpoint<T>(apiEndpoint: string | null | undefined): 
 }
 
 export function getApiEndpoint(): string | null {
-  return cachedApiEndpoint || sanitizeApiEndpoint(env?.apiUrl) || null;
+  return sanitizeApiEndpoint(env?.apiUrl) || cachedApiEndpoint || null;
 }
 
 export function saveApiEndpoint(apiEndpoint: string): boolean {


### PR DESCRIPTION
## Changes

- add option to configure API endpoint mechanism, so the code may be shared between OSS and Cloud
- prioritize API Endpoint from the environment variable
   - When switching between OSS and Cloud for development, `localStorage` needs to be cleared each time, while it doesn't make sense - if the env variable is set, that instance should rather be statically for this purpose
- related to https://github.com/kubeshop/testkube-cloud-ui/pull/241

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3695

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
