### PR TITLE
refactor: wrapper configuration card with Form

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -1,5 +1,7 @@
 import {useContext, useState} from 'react';
 
+import {Form} from 'antd';
+
 import {nanoid} from '@reduxjs/toolkit';
 
 import {Option} from '@models/form';
@@ -39,13 +41,12 @@ const Labels: React.FC = () => {
         ...entityDetails,
         labels: decomposeLabels(localLabels),
       },
-    })
-      .then((res: any) => {
-        displayDefaultNotificationFlow(res, () => {
-          notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
-          setWasTouched(false);
-        });
+    }).then((res: any) => {
+      displayDefaultNotificationFlow(res, () => {
+        notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
+        setWasTouched(false);
       });
+    });
   };
 
   const onCancel = () => {
@@ -60,16 +61,18 @@ const Labels: React.FC = () => {
   };
 
   return (
-    <ConfigurationCard
-      title="Labels"
-      description={`Define the labels you want to add for this ${namingMap[entity]}`}
-      isButtonsDisabled={!wasTouched}
-      onConfirm={onSave}
-      onCancel={onCancel}
-      enabled={mayEdit}
-    >
-      <LabelsSelect key={`labels_${labelsKey}`} onChange={onChange} defaultLabels={entityLabels} />
-    </ConfigurationCard>
+    <Form name="labels-form">
+      <ConfigurationCard
+        title="Labels"
+        description={`Define the labels you want to add for this ${namingMap[entity]}`}
+        isButtonsDisabled={!wasTouched}
+        onConfirm={onSave}
+        onCancel={onCancel}
+        enabled={mayEdit}
+      >
+        <LabelsSelect key={`labels_${labelsKey}`} onChange={onChange} defaultLabels={entityLabels} />
+      </ConfigurationCard>
+    </Form>
   );
 };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -1,6 +1,6 @@
 import {useContext, useMemo, useState} from 'react';
 
-import {Select, Tooltip} from 'antd';
+import {Form, Select, Tooltip} from 'antd';
 
 import {WarningOutlined} from '@ant-design/icons';
 
@@ -90,66 +90,83 @@ const Schedule: React.FC = () => {
   const [minute, hour, day, month, dayOfWeek] = cronString.split(' ');
 
   return (
-    <ConfigurationCard
-      title="Schedule"
-      description={`You can add a cronjob like schedule for your ${namingMap[entity]} which will then be executed automatically.`}
-      onConfirm={onSave}
-      onCancel={onCancel}
-      isButtonsDisabled={!wasTouched}
-      enabled={enabled}
-    >
-      <StyledSpace direction="vertical" size={32}>
-        <StyledColumn>
-          <Text className="middle regular">Schedule template</Text>
-          <Select
-            disabled={!enabled}
-            placeholder="Quick select a schedule template"
-            style={{width: '100%'}}
-            options={quickOptions}
-            onSelect={(value: string) => {
-              setCronString(value);
-              setWasTouched(true);
-            }}
-            value={templateValue}
-          />
-        </StyledColumn>
-        {templateValue ? (
-          <>
-            <StyledColumn>
-              <Text className="middle regular">Cron Format</Text>
-              <StyledCronFormat>
-                <CronInput title="Minute" disabled={!enabled} value={minute} onChange={value => onCronInput(value, 0)} />
-                <CronInput title="Hour" disabled={!enabled} value={hour} onChange={value => onCronInput(value, 1)} />
-                <CronInput title="Day" disabled={!enabled} value={day} onChange={value => onCronInput(value, 2)} />
-                <CronInput title="Month" disabled={!enabled} value={month} onChange={value => onCronInput(value, 3)} />
-                <CronInput title="Day / Week" disabled={!enabled} value={dayOfWeek} onChange={value => onCronInput(value, 4)} />
-              </StyledCronFormat>
-            </StyledColumn>
-            <StyledRow>
+    <Form name="schedule-form">
+      <ConfigurationCard
+        title="Schedule"
+        description={`You can add a cronjob like schedule for your ${namingMap[entity]} which will then be executed automatically.`}
+        onConfirm={onSave}
+        onCancel={onCancel}
+        isButtonsDisabled={!wasTouched}
+        enabled={enabled}
+      >
+        <StyledSpace direction="vertical" size={32}>
+          <StyledColumn>
+            <Text className="middle regular">Schedule template</Text>
+            <Select
+              disabled={!enabled}
+              placeholder="Quick select a schedule template"
+              style={{width: '100%'}}
+              options={quickOptions}
+              onSelect={(value: string) => {
+                setCronString(value);
+                setWasTouched(true);
+              }}
+              value={templateValue}
+            />
+          </StyledColumn>
+          {templateValue ? (
+            <>
               <StyledColumn>
-                <Text className="middle regular" style={{color: isValidFormat ? Colors.slate200 : Colors.amber400}}>
-                  Cron Preview{' '}
-                  {!isValidFormat ? (
-                    <Tooltip title="Cron input is invalid">
-                      <WarningOutlined />
-                    </Tooltip>
-                  ) : null}
-                </Text>
-                <Text style={{fontFamily: Fonts.robotoMono, color: Colors.slate400}} className="middle regular">
-                  {cronString}
-                </Text>
+                <Text className="middle regular">Cron Format</Text>
+                <StyledCronFormat>
+                  <CronInput
+                    title="Minute"
+                    disabled={!enabled}
+                    value={minute}
+                    onChange={value => onCronInput(value, 0)}
+                  />
+                  <CronInput title="Hour" disabled={!enabled} value={hour} onChange={value => onCronInput(value, 1)} />
+                  <CronInput title="Day" disabled={!enabled} value={day} onChange={value => onCronInput(value, 2)} />
+                  <CronInput
+                    title="Month"
+                    disabled={!enabled}
+                    value={month}
+                    onChange={value => onCronInput(value, 3)}
+                  />
+                  <CronInput
+                    title="Day / Week"
+                    disabled={!enabled}
+                    value={dayOfWeek}
+                    onChange={value => onCronInput(value, 4)}
+                  />
+                </StyledCronFormat>
               </StyledColumn>
-              <StyledColumn>
-                <Text className="middle regular">Next Execution</Text>
-                <Text style={{color: Colors.slate400}} className="middle regular">
-                  <NextExecution value={nextExecution} />
-                </Text>
-              </StyledColumn>
-            </StyledRow>
-          </>
-        ) : null}
-      </StyledSpace>
-    </ConfigurationCard>
+              <StyledRow>
+                <StyledColumn>
+                  <Text className="middle regular" style={{color: isValidFormat ? Colors.slate200 : Colors.amber400}}>
+                    Cron Preview{' '}
+                    {!isValidFormat ? (
+                      <Tooltip title="Cron input is invalid">
+                        <WarningOutlined />
+                      </Tooltip>
+                    ) : null}
+                  </Text>
+                  <Text style={{fontFamily: Fonts.robotoMono, color: Colors.slate400}} className="middle regular">
+                    {cronString}
+                  </Text>
+                </StyledColumn>
+                <StyledColumn>
+                  <Text className="middle regular">Next Execution</Text>
+                  <Text style={{color: Colors.slate400}} className="middle regular">
+                    <NextExecution value={nextExecution} />
+                  </Text>
+                </StyledColumn>
+              </StyledRow>
+            </>
+          ) : null}
+        </StyledSpace>
+      </ConfigurationCard>
+    </Form>
   );
 };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -1,6 +1,6 @@
 import {memo, useContext, useEffect, useMemo, useRef, useState} from 'react';
 
-import {Select} from 'antd';
+import {Form, Select} from 'antd';
 
 import {ClockCircleOutlined} from '@ant-design/icons';
 
@@ -16,7 +16,7 @@ import {ExecutorIcon, ExternalLink} from '@atoms';
 
 import {Text, Title} from '@custom-antd';
 
-import {ConfigurationCard, DragNDropList, notificationCall, TestSuiteStepCard} from '@molecules';
+import {ConfigurationCard, DragNDropList, TestSuiteStepCard, notificationCall} from '@molecules';
 
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
@@ -159,76 +159,78 @@ const SettingsTests = () => {
   }, [currentSteps?.length]);
 
   return (
-    <ConfigurationCard
-      title="Tests"
-      description="Define the tests and their order of execution for this test suite"
-      footerText={
+    <Form name="define-tests-form">
+      <ConfigurationCard
+        title="Tests"
+        description="Define the tests and their order of execution for this test suite"
+        footerText={
+          <>
+            Learn more about{' '}
+            <ExternalLink href="https://kubeshop.github.io/testkube/using-testkube/test-suites/testsuites-creating/">
+              Tests in a test suite
+            </ExternalLink>
+          </>
+        }
+        onConfirm={saveSteps}
+        onCancel={() => setCurrentSteps(undefined)}
+        isButtonsDisabled={!wasTouched}
+        isEditable={mayEdit}
+        enabled={mayEdit}
+      >
         <>
-          Learn more about{' '}
-          <ExternalLink href="https://kubeshop.github.io/testkube/using-testkube/test-suites/testsuites-creating/">
-            Tests in a test suite
-          </ExternalLink>
-        </>
-      }
-      onConfirm={saveSteps}
-      onCancel={() => setCurrentSteps(undefined)}
-      isButtonsDisabled={!wasTouched}
-      isEditable={mayEdit}
-      enabled={mayEdit}
-    >
-      <>
-        {currentSteps?.length === 0 ? (
-          <EmptyTestsContainer>
-            <Title level={2} className="text-center">
-              Add your tests to this test suite
-            </Title>
-            <Text className="regular middle text-center">
-              Select tests from the dropdown below to add them to this suite
-            </Text>
-          </EmptyTestsContainer>
-        ) : null}
-        <DragNDropList
-          items={currentSteps}
-          setItems={setCurrentSteps}
-          onDelete={deleteStep}
-          scrollRef={scrollRef}
-          ContainerComponent={StyledStepsList}
-          ItemComponent={TestSuiteStepCard}
-          disabled={!mayEdit}
-        />
-        <DelayModal
-          isDelayModalVisible={isDelayModalVisible}
-          setIsDelayModalVisible={setIsDelayModalVisible}
-          addDelay={addDelay}
-        />
-        {mayEdit ? (
-          <Select
-            placeholder="Add a test or delay"
-            showArrow
-            onChange={onSelectStep}
-            style={{width: '100%', marginTop: 15, marginBottom: 30}}
-            value={null}
-            showSearch
-            size="large"
-          >
-            <Option value="delay">
-              <StyledOptionWrapper>
-                <ClockCircleOutlined />
-                <Text className="regular middle">Delay</Text>
-              </StyledOptionWrapper>
-            </Option>
-            {allTestsData.map((item: any) => (
-              <Option value={JSON.stringify(item)} key={item.name}>
+          {currentSteps?.length === 0 ? (
+            <EmptyTestsContainer>
+              <Title level={2} className="text-center">
+                Add your tests to this test suite
+              </Title>
+              <Text className="regular middle text-center">
+                Select tests from the dropdown below to add them to this suite
+              </Text>
+            </EmptyTestsContainer>
+          ) : null}
+          <DragNDropList
+            items={currentSteps}
+            setItems={setCurrentSteps}
+            onDelete={deleteStep}
+            scrollRef={scrollRef}
+            ContainerComponent={StyledStepsList}
+            ItemComponent={TestSuiteStepCard}
+            disabled={!mayEdit}
+          />
+          <DelayModal
+            isDelayModalVisible={isDelayModalVisible}
+            setIsDelayModalVisible={setIsDelayModalVisible}
+            addDelay={addDelay}
+          />
+          {mayEdit ? (
+            <Select
+              placeholder="Add a test or delay"
+              showArrow
+              onChange={onSelectStep}
+              style={{width: '100%', marginTop: 15, marginBottom: 30}}
+              value={null}
+              showSearch
+              size="large"
+            >
+              <Option value="delay">
                 <StyledOptionWrapper>
-                  <ExecutorIcon type={item.type} />
-                  <Text className="regular middle">{item.name}</Text>
+                  <ClockCircleOutlined />
+                  <Text className="regular middle">Delay</Text>
                 </StyledOptionWrapper>
               </Option>
-            ))}
-          </Select>
-        ) : null}
-      </>
-    </ConfigurationCard>
+              {allTestsData.map((item: any) => (
+                <Option value={JSON.stringify(item)} key={item.name}>
+                  <StyledOptionWrapper>
+                    <ExecutorIcon type={item.type} />
+                    <Text className="regular middle">{item.name}</Text>
+                  </StyledOptionWrapper>
+                </Option>
+              ))}
+            </Select>
+          ) : null}
+        </>
+      </ConfigurationCard>
+    </Form>
   );
 };
 


### PR DESCRIPTION
Now `ConfigurationCard`s wrapped the same on OSS and Cloud.
Cloud PR: https://github.com/kubeshop/testkube-cloud-ui/pull/244