### PR TITLE
fix: user can't open create source modal if the cluster is off

### DIFF
--- a/src/components/pages/Sources/SourcesList/SourcesList.tsx
+++ b/src/components/pages/Sources/SourcesList/SourcesList.tsx
@@ -68,11 +68,17 @@ const Sources: React.FC = () => {
           <ExternalLink href="https://kubeshop.github.io/testkube/openapi/#tag/test-sources">Sources</ExternalLink>
         </>
       }
-      headerButton={mayCreate ? (
-        <Button $customType="primary" onClick={() => setAddSourceModalVisibility(true)}>
-          Create a new source
-        </Button>
-      ) : null}
+      headerButton={
+        mayCreate ? (
+          <Button
+            $customType="primary"
+            onClick={() => setAddSourceModalVisibility(true)}
+            disabled={!isClusterAvailable}
+          >
+            Create a new source
+          </Button>
+        ) : null
+      }
     >
       {isLoading ? (
         <SourcesListSkeletonWrapper>


### PR DESCRIPTION
Before: 
<img width="735" alt="image" src="https://user-images.githubusercontent.com/25991946/234600901-2d0af4a7-5ced-49fa-8974-ff734fc07856.png">

Now:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/25991946/234601011-685149d3-252c-434a-b1ad-c4b6dc132992.png">

After merging here will be moved to Cloud