### PR TITLE
feat: stop sending the hostname to the Segment.io

### DIFF
--- a/src/AnalyticsProvider.tsx
+++ b/src/AnalyticsProvider.tsx
@@ -16,6 +16,13 @@ type AnalyticsProviderProps = {
 const maskSensitiveData = (ctx: Context): Context => {
   if (ctx.event.context?.page) {
     ctx.event.context.page.referrer = '';
+    ctx.event.context.page.url = `${window.location.protocol}//dummy.testkube${ctx.event.context.page.path}`;
+  }
+  if (ctx.event.traits?.hostname) {
+    ctx.event.traits.hostname = 'dummy.testkube';
+  }
+  if (ctx.event.properties?.hostname) {
+    ctx.event.properties.hostname = 'dummy.testkube';
   }
   return ctx;
 };


### PR DESCRIPTION
## Changes

- Stop sending the hostname to the Segment.io
   - All environments that should be filtered out in our metrics, are now either deleted or have telemetry disabled, so it should be a safe change

## Fixes

- https://github.com/kubeshop/testkube/issues/3612

## How to test it

- Modify `segmentIOKey` in `AppRoot.tsx` to the valid one, hardcoded `disabled: false` in `AnalyticsProvider`, comment out condition in `analytics` memo in `AnalyticsProvider`, use the production version of `useTrackTimeAnalytics`
- Go to the "Tests" page and navigate to "Test Suites"
- See "Network" for data sent to Segment.io

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
