### PR TITLE
fix: some forms had never enabled "Save" button

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -69,6 +69,7 @@ const Labels: React.FC = () => {
         onConfirm={onSave}
         onCancel={onCancel}
         enabled={mayEdit}
+        forceEnableButtons={wasTouched}
       >
         <LabelsSelect key={`labels_${labelsKey}`} onChange={onChange} defaultLabels={entityLabels} />
       </ConfigurationCard>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -98,6 +98,7 @@ const Schedule: React.FC = () => {
         onCancel={onCancel}
         isButtonsDisabled={!wasTouched}
         enabled={enabled}
+        forceEnableButtons={wasTouched}
       >
         <StyledSpace direction="vertical" size={32}>
           <StyledColumn>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -178,6 +178,7 @@ const SettingsTests = () => {
         isButtonsDisabled={!wasTouched}
         isEditable={mayEdit}
         enabled={mayEdit}
+        forceEnableButtons={wasTouched}
       >
         <>
           {currentSteps?.length === 0 ? (


### PR DESCRIPTION
## Changes

- set `forceEnableButtons` correctly for all forms

## Fixes

- https://github.com/kubeshop/testkube/issues/3786
- https://github.com/kubeshop/testkube/issues/3751

## How to test it

- make some changes in labels, schedule or test suite steps
- if it works, it's fine

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
