### PR TITLE
fix: allow dots in k8s resource names

### DIFF
--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -2,7 +2,7 @@ import {FilterType} from '@models/filters';
 
 export const executionDateFormat = 'MMM d, p';
 
-export const k8sResourceNameRegex = /^[a-z0-9]{0,1}[a-z0-9-]+[a-z0-9]{1}$/;
+export const k8sResourceNameRegex = /^[a-z0-9]{0,1}[a-z0-9-.]+[a-z0-9]{1}$/;
 export const secretRegex = /^[^*]+$/;
 
 export const hasProtocol = (url: string) => {


### PR DESCRIPTION
## Changes

- allow dots in the k8s resource names (tested and it's supported by the API)

## Fixes

- https://github.com/kubeshop/testkube/issues/3816

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
