### PR TITLE
fix: show axis for executions even when there is a lot of them

### DIFF
--- a/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
+++ b/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
@@ -4,23 +4,37 @@ import Colors, {SecondaryStatusColors, StatusColors} from '@styles/Colors';
 import {invisibleScroll} from '@styles/globalStyles';
 
 export const MetricsBarChartWrapper = styled.div<{
-  isDetailsView?: boolean;
+  $isDetailsView?: boolean;
+}>`
+  ${props => (props.$isDetailsView ? 'min-height: 160px;' : '')}
+`;
+
+export const BarsWrapper = styled.div<{
+  $isDetailsView?: boolean;
 }>`
   overflow-x: auto;
   overflow-y: hidden;
 
   ${invisibleScroll}
 
-  ${props => (props.isDetailsView ? 'min-height: 160px;' : '')}
+  ${({$isDetailsView}) => (
+    // Ensure that axis is visible for details
+    $isDetailsView ? 'margin-left: 30px;' : ''
+  )}
 `;
 
-export const ChartWrapper = styled.div<{$wrapperWidth: number}>`
+export const ChartWrapper = styled.div<{
+  $wrapperWidth: number;
+  $isDetailsView?: boolean;
+}>`
   position: relative;
   overflow-y: hidden;
 
   ${invisibleScroll}
 
-  width: ${({$wrapperWidth}) => $wrapperWidth}px;
+  ${({$isDetailsView, $wrapperWidth}) => (
+    $isDetailsView ? '' : `width: ${$wrapperWidth}px;`
+  )}
   min-width: 100%;
 `;
 
@@ -40,14 +54,16 @@ export const AxisLabel = styled.div<{$top: number}>`
   position: absolute;
 
   top: ${({$top}) => $top}px;
+
+  pointer-events: none;
 `;
 
-export const SvgWrapper = styled.div<{isDetailsView?: boolean}>`
+export const SvgWrapper = styled.div<{$isDetailsView?: boolean}>`
   display: flex;
   align-items: flex-end;
 
-  ${props => (props.isDetailsView ? 'padding-bottom: 50px;' : '')}
-  ${props => (props.isDetailsView ? 'padding-left: 75px;' : '')}
+  ${props => (props.$isDetailsView ? 'padding-bottom: 50px;' : '')}
+  ${props => (props.$isDetailsView ? 'padding-left: 75px;' : '')}
 `;
 
 export const BarWrapper = styled.div<{$margin: number}>`

--- a/src/components/molecules/MetricsBarChart/MetricsBarChart.tsx
+++ b/src/components/molecules/MetricsBarChart/MetricsBarChart.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 
 import {ExecutionMetrics} from '@models/metrics';
 
-import {ChartWrapper, MetricsBarChartWrapper} from './MetricsBarChart.styled';
+import {BarsWrapper, ChartWrapper, MetricsBarChartWrapper} from './MetricsBarChart.styled';
 import Chart from './components/Chart';
 import PAxisLine from './components/PAxisLine';
 import {getAxisPosition, getMaximumValue, getMinimumValue, metricsLogarithmization, secondInMs} from './utils';
@@ -123,8 +123,8 @@ const MetricsBarChart: React.FC<MetricsBarChartProps> = props => {
   }
 
   return (
-    <MetricsBarChartWrapper isDetailsView={isDetailsView}>
-      <ChartWrapper $wrapperWidth={wrapperWidth}>
+    <MetricsBarChartWrapper $isDetailsView={isDetailsView}>
+      <ChartWrapper $wrapperWidth={wrapperWidth} $isDetailsView={isDetailsView}>
         {isDetailsView ? (
           <>
             <PAxisLine
@@ -158,12 +158,14 @@ const MetricsBarChart: React.FC<MetricsBarChartProps> = props => {
             <PAxisLine axisTop={minAxis} durationMs={minValueMs} isLabelVisible />
           </>
         ) : null}
-        <Chart
-          chartConfig={barChartConfig}
-          maxValue={maxLogValue}
-          isDetailsView={isDetailsView}
-          scrollRef={scrollRef}
-        />
+        <BarsWrapper $isDetailsView={isDetailsView}>
+          <Chart
+            chartConfig={barChartConfig}
+            maxValue={maxLogValue}
+            isDetailsView={isDetailsView}
+            scrollRef={scrollRef}
+          />
+        </BarsWrapper>
       </ChartWrapper>
     </MetricsBarChartWrapper>
   );

--- a/src/components/molecules/MetricsBarChart/components/Chart.tsx
+++ b/src/components/molecules/MetricsBarChart/components/Chart.tsx
@@ -77,7 +77,7 @@ const Chart: React.FC<ChartProps> = props => {
   }, [chartData]);
 
   return (
-    <SvgWrapper isDetailsView={isDetailsView}>
+    <SvgWrapper $isDetailsView={isDetailsView}>
       {renderedBarChart}
       <div ref={scrollRef} />
     </SvgWrapper>


### PR DESCRIPTION
## Changes

- Give 30px of space for axis, and detach it from scrolling

## Fixes

- https://github.com/kubeshop/testkube/issues/3466

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
