### PR TITLE
feat: add NGINX IPv6 configuration

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -15,6 +15,7 @@ http {
 
     server {
         listen 8080;
+        listen [::]:8080;
         charset utf-8;
         sendfile on;
         server_name _;


### PR DESCRIPTION
This PR configure nginx for IPv6 by adding the directive `listen [::]:8080`

## Changes

## Fixes
https://github.com/kubeshop/testkube/issues/3808
## How to test it

## screenshots

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
