### PR TITLE
fix: show latest data in execution details / make private registry optional

### DIFF
--- a/src/components/pages/Executors/ExecutorDetails/ExecutorDetails.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorDetails.tsx
@@ -33,10 +33,8 @@ const ExecutorDetails: React.FC = () => {
   const isPageDisabled = !name;
 
   useEffect(() => {
-    if (executorDetails) {
-      dispatch(setCurrentExecutor(executorDetails));
-    }
-  }, [executorDetails]);
+    dispatch(setCurrentExecutor(name));
+  }, [name]);
 
   useEffect(() => {
     safeRefetch(refetch);

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -5,7 +5,7 @@ import {Form, Input} from 'antd';
 import {DeleteOutlined} from '@ant-design/icons';
 
 import {useAppSelector} from '@redux/hooks';
-import {selectCurrentExecutor, updateExecutorArguments} from '@redux/reducers/executorsSlice';
+import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/executorsSlice';
 
 import {Button} from '@custom-antd';
 
@@ -48,7 +48,7 @@ const Arguments: React.FC = () => {
     }).then(res => {
       displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Arguments were successfully updated.');
-        dispatch(updateExecutorArguments(values.arguments));
+        dispatch(updateCurrentExecutorData({args: values.arguments}));
       });
     });
   };

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -5,7 +5,7 @@ import {Form} from 'antd';
 import {Executor} from '@models/executors';
 
 import {useAppSelector} from '@redux/hooks';
-import {selectCurrentExecutor, updateExecutorCommand} from '@redux/reducers/executorsSlice';
+import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/executorsSlice';
 
 import {CommandInput} from '@atoms';
 
@@ -45,7 +45,7 @@ const Command: React.FC = () => {
     }).then(res => {
       displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Command was successfully updated.');
-        dispatch(updateExecutorCommand(values.command));
+        dispatch(updateCurrentExecutorData({command: values.command!.split(' ')}));
       });
     });
   };

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -5,7 +5,7 @@ import {Form, Input} from 'antd';
 import {Executor} from '@models/executors';
 
 import {useAppSelector} from '@redux/hooks';
-import {selectCurrentExecutor, updateExecutorContainerImage} from '@redux/reducers/executorsSlice';
+import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/executorsSlice';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
@@ -44,7 +44,7 @@ const ContainerImagePanel: React.FC = () => {
     }).then(res => {
       displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Container image was successfully updated.');
-        dispatch(updateExecutorContainerImage(values.image));
+        dispatch(updateCurrentExecutorData({image: values.image}));
       });
     });
   };

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -3,7 +3,7 @@ import {useContext, useEffect} from 'react';
 import {Form, Input} from 'antd';
 
 import {useAppSelector} from '@redux/hooks';
-import {selectCurrentExecutor, updateExecutorPrivateRegistry} from '@redux/reducers/executorsSlice';
+import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/executorsSlice';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
@@ -43,7 +43,7 @@ const PrivateRegistry: React.FC = () => {
       },
     }).then(res => {
       displayDefaultNotificationFlow(res, () => {
-        dispatch(updateExecutorPrivateRegistry(values.privateRegistry));
+        dispatch(updateCurrentExecutorData({imagePullSecrets: [{name: values.privateRegistry}]}));
         notificationCall('passed', 'Private registry was successfully updated.');
       });
     });

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -7,7 +7,6 @@ import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {required} from '@utils/form';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
@@ -34,16 +33,17 @@ const PrivateRegistry: React.FC = () => {
   const [form] = Form.useForm<PrivateRegistryFormFields>();
 
   const onSubmit = (values: PrivateRegistryFormFields) => {
+    const newImagePullSecrets = values.privateRegistry ? [{name: values.privateRegistry}] : [];
     updateCustomExecutor({
       executorId: name,
       body: {
         name,
         ...executor,
-        imagePullSecrets: [{name: values.privateRegistry}],
+        imagePullSecrets: newImagePullSecrets,
       },
     }).then(res => {
       displayDefaultNotificationFlow(res, () => {
-        dispatch(updateCurrentExecutorData({imagePullSecrets: [{name: values.privateRegistry}]}));
+        dispatch(updateCurrentExecutorData({imagePullSecrets: newImagePullSecrets}));
         notificationCall('passed', 'Private registry was successfully updated.');
       });
     });
@@ -78,7 +78,6 @@ const PrivateRegistry: React.FC = () => {
         <Form.Item
           label="Secret ref name"
           name="privateRegistry"
-          rules={[required]}
           style={{flex: 1, marginBottom: '0'}}
         >
           <Input placeholder="Secret ref name" />

--- a/src/models/executors.ts
+++ b/src/models/executors.ts
@@ -33,7 +33,7 @@ export type ExecutorMeta = {
 interface ExecutorsState {
   executorsList: Executor[];
   executorsFeaturesMap: EntityMap<ExecutorFeature[]>;
-  currentExecutor?: Executor;
+  currentExecutor?: string;
 }
 
 export type {ExecutorsState, Executor, ExecutorFeature};

--- a/src/redux/reducers/executorsSlice.ts
+++ b/src/redux/reducers/executorsSlice.ts
@@ -1,7 +1,7 @@
 import {Draft, PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 import {EntityMap} from '@models/entityMap';
-import {Executor, ExecutorFeature, ExecutorsState, ImagePullSecret} from '@models/executors';
+import {Executor, ExecutorFeature, ExecutorsState} from '@models/executors';
 
 import initialState from '@redux/initialState';
 
@@ -46,38 +46,16 @@ export const executorsSlice = createSlice({
           };
         }) || {};
     },
-    setCurrentExecutor: (state: Draft<ExecutorsState>, action: PayloadAction<Executor>) => {
+    setCurrentExecutor: (state: Draft<ExecutorsState>, action: PayloadAction<string>) => {
       state.currentExecutor = action.payload;
     },
-    updateExecutorContainerImage: (
-      state: Draft<ExecutorsState>,
-      action: PayloadAction<Executor['executor']['image']>
-    ) => {
+    updateCurrentExecutorData: (state: Draft<ExecutorsState>, action: PayloadAction<Partial<Executor['executor']>>) => {
       if (state.currentExecutor) {
-        if (state.currentExecutor.executor) {
-          state.currentExecutor.executor.image = action.payload;
-        }
-      }
-    },
-    updateExecutorPrivateRegistry: (state: Draft<ExecutorsState>, action: PayloadAction<ImagePullSecret['name']>) => {
-      if (state.currentExecutor) {
-        if (state.currentExecutor.executor) {
-          state.currentExecutor.executor.imagePullSecrets = [{name: action.payload}];
-        }
-      }
-    },
-    updateExecutorCommand: (state: Draft<ExecutorsState>, action: PayloadAction<string>) => {
-      if (state.currentExecutor) {
-        if (state.currentExecutor.executor) {
-          state.currentExecutor.executor.command = action.payload.split(' ');
-        }
-      }
-    },
-    updateExecutorArguments: (state: Draft<ExecutorsState>, action: PayloadAction<Executor['executor']['args']>) => {
-      if (state.currentExecutor) {
-        if (state.currentExecutor.executor) {
-          state.currentExecutor.executor.args = action.payload;
-        }
+        state.executorsList = state.executorsList.map(executor => (
+          executor.name === state.currentExecutor
+            ? {...executor, executor: {...executor.executor, ...action.payload}}
+            : executor
+        ));
       }
     },
   },
@@ -85,15 +63,14 @@ export const executorsSlice = createSlice({
 
 export const selectExecutors = (state: RootState) => state.executors.executorsList;
 export const selectExecutorsFeaturesMap = (state: RootState) => state.executors.executorsFeaturesMap;
-export const selectCurrentExecutor = (state: RootState) => state.executors.currentExecutor as Executor;
+export const selectCurrentExecutor = (state: RootState) => (
+  state.executors.executorsList.find(executor => executor.name === state.executors.currentExecutor) as Executor
+);
 
 export const {
   setExecutors,
   setCurrentExecutor,
-  updateExecutorContainerImage,
-  updateExecutorPrivateRegistry,
-  updateExecutorCommand,
-  updateExecutorArguments,
+  updateCurrentExecutorData,
 } = executorsSlice.actions;
 
 export default executorsSlice.reducer;


### PR DESCRIPTION
## Changes

- show the latest data in Execution Details
  - avoid having separate instance for the `currentExecutor`
- make the private registry optional
  - pushed to the same branch, as a change is small and has conflicts with the other feature

## Fixes

- https://github.com/kubeshop/testkube/issues/3831
- https://github.com/kubeshop/testkube/issues/3830

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
