### PR TITLE
feat: add ModalOutletProvider to automatically inject the ModalOutlet

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -25,7 +25,7 @@ import {useGetClusterConfigQuery} from '@services/config';
 import {BasePermissionsResolver, PermissionsProvider} from '@permissions/base';
 
 import {ConfigContext, DashboardContext, MainContext} from '@contexts';
-import {ModalHandler, ModalOutlet} from '@contexts/ModalContext';
+import {ModalHandler, ModalOutletProvider} from '@contexts/ModalContext';
 
 import {AnalyticsProvider} from './AnalyticsProvider';
 import App from './App';
@@ -158,6 +158,7 @@ const AppRoot: React.FC = () => {
     })
     .append(MainContext.Provider, {value: mainContextValue})
     .append(ModalHandler, {})
+    .append(ModalOutletProvider, {})
     .render(
       <>
         <Layout>
@@ -173,7 +174,6 @@ const AppRoot: React.FC = () => {
         {isCookiesVisible && clusterConfig?.enableTelemetry ? (
           <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
         ) : null}
-        <ModalOutlet />
       </>
     );
 };

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -54,4 +54,11 @@ export const ModalOutlet: FC = () => {
   );
 };
 
+export const ModalOutletProvider: FC<PropsWithChildren<{}>> = ({children}) => (
+  <>
+    <ModalOutlet />
+    {children}
+  </>
+);
+
 export default ModalContext;


### PR DESCRIPTION
## Changes

- add `ModalOutletProvider` to automatically inject the `ModalOutlet`

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
