### PR TITLE
fix: ENABLE_IPV6 was doing the opposite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,6 @@ CMD [ \
   "/bin/sh", \
   "-c", \
   "/usr/share/nginx/html/env.sh && \
-   envsubst '$ENABLE_IPV6' < /etc/nginx/nginx.conf.tmpl | sed -e '1h;2,$H;$!d;g' -e 's/# cut true.*# end//g' > /etc/nginx/nginx.conf && \
+  export DISABLE_IPV6=\"$([[ \"$ENABLE_IPV6\" = \"true\" ]] && echo \"false\" || echo \"true\")\" && \
+   envsubst '$DISABLE_IPV6' < /etc/nginx/nginx.conf.tmpl | sed -e '1h;2,$H;$!d;g' -e 's/# cut true.*# end//g' > /etc/nginx/nginx.conf && \
    nginx -g \"daemon off;\"" ]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -15,7 +15,7 @@ http {
 
     server {
         listen 8080;
-        # cut $ENABLE_IPV6
+        # cut $DISABLE_IPV6
         listen [::]:8080;
         # end
         charset utf-8;
@@ -44,6 +44,6 @@ http {
         gzip_http_version 1.1;
         gzip_min_length 0;
         gzip_types text/plain application/javascript text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype;
-    
+
     }
 }


### PR DESCRIPTION
## Changes

- `ENABLE_IPV6=true` was disabling IPv6, while `ENABLE_IPV6=false` was enabling it

## Fixes

- kubeshop/testkube#3846

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
