### PR TITLE
Move error reports into the area where they were triggered

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {lazy, Suspense, useContext, useEffect, useRef, useState} from 'react';
+import React, {Suspense, lazy, useContext, useEffect, useRef, useState} from 'react';
 import {Navigate, Route, Routes, useLocation} from 'react-router-dom';
 import {CSSTransition} from 'react-transition-group';
 
@@ -7,21 +7,20 @@ import {selectFullScreenLogOutput, setIsFullScreenLogOutput} from '@redux/reduce
 import {setExecutors} from '@redux/reducers/executorsSlice';
 import {setSources} from '@redux/reducers/sourcesSlice';
 
-import {useGetExecutorsQuery} from '@services/executors';
-import {useGetSourcesQuery} from '@services/sources';
-import {getApiDetails, getApiEndpoint, isApiEndpointLocked, useApiEndpoint} from '@services/apiEndpoint';
-
-import {PollingIntervals} from '@utils/numbers';
-import {safeRefetch} from '@utils/fetchUtils';
-
-import {MainContext} from '@contexts';
+import {EndpointModal, notificationCall} from '@molecules';
+import FullScreenLogOutput from '@molecules/LogOutput/FullscreenLogOutput';
+import LogOutputHeader from '@molecules/LogOutput/LogOutputHeader';
 
 import {EndpointProcessing, Loading, NotFound} from '@pages';
 
-import {EndpointModal} from '@molecules';
-import LogOutputHeader from '@molecules/LogOutput/LogOutputHeader';
-import FullScreenLogOutput from '@molecules/LogOutput/FullscreenLogOutput';
-import notificationCall from '@molecules/Notification';
+import {safeRefetch} from '@utils/fetchUtils';
+import {PollingIntervals} from '@utils/numbers';
+
+import {getApiDetails, getApiEndpoint, isApiEndpointLocked, useApiEndpoint} from '@services/apiEndpoint';
+import {useGetExecutorsQuery} from '@services/executors';
+import {useGetSourcesQuery} from '@services/sources';
+
+import {MainContext} from '@contexts';
 
 const Tests = lazy(() => import('@pages').then(module => ({default: module.Tests})));
 const TestSuites = lazy(() => import('@pages').then(module => ({default: module.TestSuites})));
@@ -79,7 +78,7 @@ const App: React.FC<any> = () => {
       return;
     }
 
-    getApiDetails(apiEndpoint).catch((error) => {
+    getApiDetails(apiEndpoint).catch(error => {
       // Handle race condition
       if (getApiEndpoint() !== apiEndpoint) {
         return;
@@ -91,27 +90,35 @@ const App: React.FC<any> = () => {
     });
   }, [apiEndpoint]);
 
-  return <Suspense fallback={<Loading />}>
-    <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
-    <Routes>
-      <Route path="tests/*" element={<Tests />} />
-      <Route path="test-suites/*" element={<TestSuites />} />
-      <Route path="executors/*" element={<Executors />} />
-      <Route path="sources/*" element={<Sources />} />
-      <Route path="triggers" element={<Triggers />} />
-      <Route path="settings" element={<GlobalSettings />} />
-      <Route
-        path="/apiEndpoint"
-        element={isApiEndpointLocked() ? <Navigate to="/" replace /> : <EndpointProcessing />}
-      />
-      <Route path="/" element={<Navigate to="/tests" replace />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
-    {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
-    <CSSTransition nodeRef={logRef} in={isFullScreenLogOutput} timeout={1000} classNames="full-screen-log-output" unmountOnExit>
-      <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
-    </CSSTransition>
-  </Suspense>;
+  return (
+    <Suspense fallback={<Loading />}>
+      <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
+      <Routes>
+        <Route path="tests/*" element={<Tests />} />
+        <Route path="test-suites/*" element={<TestSuites />} />
+        <Route path="executors/*" element={<Executors />} />
+        <Route path="sources/*" element={<Sources />} />
+        <Route path="triggers" element={<Triggers />} />
+        <Route path="settings" element={<GlobalSettings />} />
+        <Route
+          path="/apiEndpoint"
+          element={isApiEndpointLocked() ? <Navigate to="/" replace /> : <EndpointProcessing />}
+        />
+        <Route path="/" element={<Navigate to="/tests" replace />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+      {isFullScreenLogOutput ? <LogOutputHeader logOutput={logOutput} isFullScreen /> : null}
+      <CSSTransition
+        nodeRef={logRef}
+        in={isFullScreenLogOutput}
+        timeout={1000}
+        classNames="full-screen-log-output"
+        unmountOnExit
+      >
+        <FullScreenLogOutput ref={logRef} logOutput={logOutput} />
+      </CSSTransition>
+    </Suspense>
+  );
 };
 
 export default App;

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
@@ -47,3 +47,7 @@ export const StyledFooterText = styled.div`
   margin: auto;
   margin-right: 20px;
 `;
+
+export const StyledNotificationContainer = styled.div`
+  padding: 20px 20px 0;
+`;

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -108,6 +108,7 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
                     </Button>
                     <Button
                       onClick={() => {
+                        setError(null);
                         Promise.resolve(validateFields?.())
                           .then(() => onConfirm?.())
                           .catch((err: ErrorNotificationConfig) => {

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -82,7 +82,7 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
           )}
           {enabled ? (
             <Form.Item noStyle shouldUpdate>
-              {({isFieldsTouched, getFieldsValue}) => {
+              {({isFieldsTouched, getFieldsValue, validateFields}) => {
                 let disabled = isButtonsDisabled || (getFieldsValue() && !isFieldsTouched());
 
                 if (forceEnableButtons) {
@@ -103,13 +103,15 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
                     </Button>
                     <Button
                       onClick={() => {
-                        const confirmResult = onConfirm?.();
+                        validateFields?.().then(() => {
+                          const confirmResult = onConfirm?.();
 
-                        if (typeof confirmResult === 'object' && typeof confirmResult.then === 'function') {
-                          confirmResult.then((res: any) => {
-                            setError(res);
-                          });
-                        }
+                          if (typeof confirmResult === 'object' && typeof confirmResult.then === 'function') {
+                            confirmResult.then((res: any) => {
+                              setError(res);
+                            });
+                          }
+                        });
                       }}
                       $customType={isWarning ? 'warning' : 'primary'}
                       disabled={disabled}

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -108,12 +108,12 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
                     </Button>
                     <Button
                       onClick={() => {
-                        validateFields?.()
-                          .then(() => {
-                            return onConfirm?.();
-                          })
+                        Promise.resolve(validateFields?.())
+                          .then(() => onConfirm?.())
                           .catch((err: ErrorNotificationConfig) => {
-                            setError(err);
+                            if (err.message || err.title) {
+                              setError(err);
+                            }
 
                             if (!inTopInViewport && topRef && topRef.current) {
                               topRef.current.scrollIntoView();

--- a/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
+++ b/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
@@ -11,7 +11,7 @@ import {notificationCall} from '@molecules';
 
 import usePressEnter from '@hooks/usePressEnter';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import Colors from '@styles/Colors';
@@ -45,17 +45,23 @@ const DeleteEntityModal: React.FC<{
 
   const onDelete = () => {
     deleteEntity(idToDelete || name).then(res => {
-      displayDefaultNotificationFlow(res, () => {
-        notificationCall('passed', `${uppercaseFirstSymbol(entityLabel)} was successfully deleted.`);
+      defaultNotificationFlow(
+        res,
+        () => {
+          notificationCall('passed', `${uppercaseFirstSymbol(entityLabel)} was successfully deleted.`);
 
-        setModalOpen(false);
+          setModalOpen(false);
 
-        if (onConfirm) {
-          onConfirm();
-        } else {
-          navigate(defaultStackRoute);
+          if (onConfirm) {
+            onConfirm();
+          } else {
+            navigate(defaultStackRoute);
+          }
+        },
+        error => {
+          notificationCall('failed', error.title, error.message);
         }
-      });
+      );
     });
   };
 

--- a/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
+++ b/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
@@ -11,7 +11,7 @@ import {notificationCall} from '@molecules';
 
 import usePressEnter from '@hooks/usePressEnter';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import Colors from '@styles/Colors';
@@ -44,10 +44,9 @@ const DeleteEntityModal: React.FC<{
   const [checkName, setName] = useState('');
 
   const onDelete = () => {
-    deleteEntity(idToDelete || name).then(res => {
-      defaultNotificationFlow(
-        res,
-        () => {
+    deleteEntity(idToDelete || name)
+      .then(res => {
+        displayDefaultNotificationFlow(res, () => {
           notificationCall('passed', `${uppercaseFirstSymbol(entityLabel)} was successfully deleted.`);
 
           setModalOpen(false);
@@ -57,12 +56,11 @@ const DeleteEntityModal: React.FC<{
           } else {
             navigate(defaultStackRoute);
           }
-        },
-        error => {
-          notificationCall('failed', error.title, error.message);
-        }
-      );
-    });
+        });
+      })
+      .catch(error => {
+        notificationCall('failed', error.title, error.message);
+      });
   };
 
   return (

--- a/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
+++ b/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
@@ -45,18 +45,17 @@ const DeleteEntityModal: React.FC<{
 
   const onDelete = () => {
     deleteEntity(idToDelete || name)
-      .then(res => {
-        displayDefaultNotificationFlow(res, () => {
-          notificationCall('passed', `${uppercaseFirstSymbol(entityLabel)} was successfully deleted.`);
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
+        notificationCall('passed', `${uppercaseFirstSymbol(entityLabel)} was successfully deleted.`);
 
-          setModalOpen(false);
+        setModalOpen(false);
 
-          if (onConfirm) {
-            onConfirm();
-          } else {
-            navigate(defaultStackRoute);
-          }
-        });
+        if (onConfirm) {
+          onConfirm();
+        } else {
+          navigate(defaultStackRoute);
+        }
       })
       .catch(error => {
         notificationCall('failed', error.title, error.message);

--- a/src/components/molecules/Notification/Notification.styled.tsx
+++ b/src/components/molecules/Notification/Notification.styled.tsx
@@ -14,5 +14,5 @@ export const StyledNotificationHeader = styled.div`
 `;
 
 export const StyledNotificationMessage = styled.div`
-  margin-top: 20px;
+  margin-top: 8px;
 `;

--- a/src/components/molecules/Notification/Notification.tsx
+++ b/src/components/molecules/Notification/Notification.tsx
@@ -1,36 +1,12 @@
 import {notification} from 'antd';
 
-import {Text} from '@custom-antd';
-
-import Colors from '@styles/Colors';
-
-import {StyledNotificationContainer, StyledNotificationHeader, StyledNotificationMessage} from './Notification.styled';
-
-const statusBGColorMap: {[key: string]: string} = {
-  passed: Colors.lime600,
-  success: Colors.lime600,
-  failed: Colors.pink700,
-  error: Colors.pink700,
-  warning: Colors.yellow400,
-  info: Colors.sky600,
-};
+import NotificationContent from './NotificationContent';
 
 function notificationCall(status: string, title: string, message: string = '', duration: number = 4.5) {
   notification.open({
     message: null,
     placement: 'bottomRight',
-    description: (
-      <StyledNotificationContainer $bg={statusBGColorMap[status]}>
-        <StyledNotificationHeader>
-          <Text className="regular middle">{title}</Text>
-        </StyledNotificationHeader>
-        {message ? (
-          <StyledNotificationMessage>
-            <Text className="regular middle">{message}</Text>
-          </StyledNotificationMessage>
-        ) : null}
-      </StyledNotificationContainer>
-    ),
+    description: <NotificationContent status={status} title={title} message={message} />,
     closeIcon: <svg />,
     duration,
   });

--- a/src/components/molecules/Notification/NotificationContent.tsx
+++ b/src/components/molecules/Notification/NotificationContent.tsx
@@ -1,0 +1,38 @@
+import {ErrorNotificationConfig} from '@models/notifications';
+
+import {Text} from '@custom-antd';
+
+import Colors from '@styles/Colors';
+
+import {StyledNotificationContainer, StyledNotificationHeader, StyledNotificationMessage} from './Notification.styled';
+
+type NotificationContentProps = {
+  status: string;
+} & ErrorNotificationConfig;
+
+const statusBGColorMap: {[key: string]: string} = {
+  passed: Colors.lime600,
+  success: Colors.lime600,
+  failed: Colors.pink700,
+  error: Colors.pink700,
+  warning: Colors.yellow400,
+  info: Colors.sky600,
+};
+
+const NotificationContent: React.FC<NotificationContentProps> = props => {
+  const {status, title, message} = props;
+  return (
+    <StyledNotificationContainer $bg={statusBGColorMap[status]}>
+      <StyledNotificationHeader>
+        <Text className="regular middle">{title}</Text>
+      </StyledNotificationHeader>
+      {message ? (
+        <StyledNotificationMessage>
+          <Text className="regular middle">{message}</Text>
+        </StyledNotificationMessage>
+      ) : null}
+    </StyledNotificationContainer>
+  );
+};
+
+export default NotificationContent;

--- a/src/components/molecules/Notification/index.ts
+++ b/src/components/molecules/Notification/index.ts
@@ -1,1 +1,2 @@
-export {default} from './Notification';
+export {default as notificationCall} from './Notification';
+export {default as NotificationContent} from './NotificationContent';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -8,7 +8,7 @@ export {default as CookiesBanner} from './CookiesBanner';
 export {default as LogOutput} from './LogOutput';
 export {TestsVariablesList, ExecutionsVariablesList} from './Variables';
 export {default as EntityGrid} from './EntityGrid';
-export {default as notificationCall} from './Notification';
+export {notificationCall, NotificationContent} from './Notification';
 export {default as EndpointModal} from './EndpointModal';
 export {default as ConfigurationCard} from './ConfigurationCard';
 export {TestExecutionDetailsTabs, TestSuiteExecutionDetailsTabs} from './ExecutionDetails';

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -89,7 +89,7 @@ const EntityDetailsContent: React.FC = () => {
     handleLoading();
     const runEntity = runRequestsMap[entity];
 
-    runEntity({
+    return runEntity({
       id: name,
       data: {
         namespace,
@@ -98,12 +98,11 @@ const EntityDetailsContent: React.FC = () => {
         },
       },
     })
-      .then(res => {
-        displayDefaultNotificationFlow(res, () => {
-          analyticsTrack('trackEvents', {
-            type,
-            uiEvent: `run-${entity}`,
-          });
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
+        analyticsTrack('trackEvents', {
+          type,
+          uiEvent: `run-${entity}`,
         });
       })
       .catch(error => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -21,7 +21,7 @@ import {CLICommands, DotsDropdown, LabelsList, MetricsBarChart, RunningContextTy
 import useLoadingIndicator from '@hooks/useLoadingIndicator';
 import useTrackTimeAnalytics from '@hooks/useTrackTimeAnalytics';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useRunTestSuiteMutation} from '@services/testSuites';
 import {useRunTestMutation} from '@services/tests';
@@ -98,12 +98,16 @@ const EntityDetailsContent: React.FC = () => {
         },
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
-        analyticsTrack('trackEvents', {
-          type,
-          uiEvent: `run-${entity}`,
-        });
-      });
+      defaultNotificationFlow(
+        res,
+        () => {
+          analyticsTrack('trackEvents', {
+            type,
+            uiEvent: `run-${entity}`,
+          });
+        },
+        error => notificationCall('failed', error.title, error.message)
+      );
     });
   };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -21,7 +21,7 @@ import {CLICommands, DotsDropdown, LabelsList, MetricsBarChart, RunningContextTy
 import useLoadingIndicator from '@hooks/useLoadingIndicator';
 import useTrackTimeAnalytics from '@hooks/useTrackTimeAnalytics';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useRunTestSuiteMutation} from '@services/testSuites';
 import {useRunTestMutation} from '@services/tests';
@@ -97,18 +97,18 @@ const EntityDetailsContent: React.FC = () => {
           type: RunningContextType.userUI,
         },
       },
-    }).then(res => {
-      defaultNotificationFlow(
-        res,
-        () => {
+    })
+      .then(res => {
+        displayDefaultNotificationFlow(res, () => {
           analyticsTrack('trackEvents', {
             type,
             uiEvent: `run-${entity}`,
           });
-        },
-        error => notificationCall('failed', error.title, error.message)
-      );
-    });
+        });
+      })
+      .catch(error => {
+        notificationCall('failed', error.title, error.message);
+      });
   };
 
   const onAbortAllExecutionsClick = () => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
@@ -8,7 +8,7 @@ import {FormItem, FullWidthSpace} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -34,8 +34,10 @@ const PreRun: React.FC = () => {
 
   const command = entityDetails?.executionRequest?.preRunScript;
 
-  const onSave = (values: PreRunFormValues) => {
-    updateTest({
+  const onSave = () => {
+    const values = form.getFieldsValue();
+
+    return updateTest({
       id: entityDetails.name,
       data: {
         ...entityDetails,
@@ -45,7 +47,7 @@ const PreRun: React.FC = () => {
         },
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', `Pre-Run command was successfully updated.`);
       });
     });
@@ -54,7 +56,6 @@ const PreRun: React.FC = () => {
   return (
     <Form
       form={form}
-      onFinish={onSave}
       name="execution-settings-pre-run"
       initialValues={{command}}
       disabled={!isPreRunAvailable}
@@ -63,9 +64,7 @@ const PreRun: React.FC = () => {
       <ConfigurationCard
         title="Pre-Run phase"
         description="You can run a command or a script (relative to your source root) which will be executed before the test itself is started."
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSave}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
@@ -46,11 +46,9 @@ const PreRun: React.FC = () => {
           preRunScript: values.command,
         },
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
-        notificationCall('passed', `Pre-Run command was successfully updated.`);
-      });
-    });
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => notificationCall('passed', `Pre-Run command was successfully updated.`));
   };
 
   return (

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsExecution/PreRun.tsx
@@ -8,7 +8,7 @@ import {FormItem, FullWidthSpace} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -47,7 +47,7 @@ const PreRun: React.FC = () => {
         },
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `Pre-Run command was successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
@@ -6,7 +6,7 @@ import {Checkbox, FormItem, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -55,7 +55,7 @@ const FailureHandling: React.FC = () => {
         },
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `Test was successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
@@ -6,7 +6,7 @@ import {Checkbox, FormItem, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -42,8 +42,10 @@ const FailureHandling: React.FC = () => {
 
   const negativeTest = entityDetails?.executionRequest?.negativeTest;
 
-  const onSave = (values: FailureHandlingFormValues) => {
-    updateTest({
+  const onSave = () => {
+    const values = form.getFieldsValue();
+
+    return updateTest({
       id: entityDetails.name,
       data: {
         ...entityDetails,
@@ -53,26 +55,18 @@ const FailureHandling: React.FC = () => {
         },
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', `Test was successfully updated.`);
       });
     });
   };
 
   return (
-    <Form
-      form={form}
-      onFinish={onSave}
-      initialValues={{negativeTest}}
-      name="general-settings-failure-handling"
-      disabled={!mayEdit}
-    >
+    <Form form={form} initialValues={{negativeTest}} name="general-settings-failure-handling" disabled={!mayEdit}>
       <ConfigurationCard
         title="Failure handling"
         description="Define how Testkube should treat occurring errors."
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSave}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
@@ -54,11 +54,9 @@ const FailureHandling: React.FC = () => {
           negativeTest: values.negativeTest,
         },
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
-        notificationCall('passed', `Test was successfully updated.`);
-      });
-    });
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => notificationCall('passed', `Test was successfully updated.`));
   };
 
   return (

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -41,12 +41,12 @@ const Labels: React.FC = () => {
         ...entityDetails,
         labels: decomposeLabels(localLabels),
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
         setWasTouched(false);
       });
-    });
   };
 
   const onCancel = () => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -9,7 +9,7 @@ import {Option} from '@models/form';
 import {ConfigurationCard, LabelsSelect, notificationCall} from '@molecules';
 import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -35,14 +35,14 @@ const Labels: React.FC = () => {
   const entityLabels = entityDetails?.labels || {};
 
   const onSave = () => {
-    updateEntity({
+    return updateEntity({
       id: entityDetails.name,
       data: {
         ...entityDetails,
         labels: decomposeLabels(localLabels),
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
         setWasTouched(false);
       });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -9,7 +9,7 @@ import {Option} from '@models/form';
 import {ConfigurationCard, LabelsSelect, notificationCall} from '@molecules';
 import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -42,7 +42,7 @@ const Labels: React.FC = () => {
         labels: decomposeLabels(localLabels),
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
         setWasTouched(false);
       });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
@@ -51,11 +51,9 @@ const NameNDescription: React.FC = () => {
           description: values.description,
         },
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
-        notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
-      });
-    });
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`));
   };
 
   return (

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
@@ -7,7 +7,7 @@ import {FormItem, FullWidthSpace} from '@custom-antd';
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -38,8 +38,10 @@ const NameNDescription: React.FC = () => {
   const name = entityDetails?.name;
   const description = entityDetails?.description;
 
-  const onSave = (values: NameNDescriptionFormValues) => {
-    updateEntity({
+  const onSave = () => {
+    const values = form.getFieldsValue();
+
+    return updateEntity({
       id: entityDetails.name,
       data: {
         ...entityDetails,
@@ -50,26 +52,18 @@ const NameNDescription: React.FC = () => {
         },
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
       });
     });
   };
 
   return (
-    <Form
-      form={form}
-      onFinish={onSave}
-      name="general-settings-name-description"
-      initialValues={{name, description}}
-      disabled={!mayEdit}
-    >
+    <Form form={form} name="general-settings-name-description" initialValues={{name, description}} disabled={!mayEdit}>
       <ConfigurationCard
         title={`${uppercaseFirstSymbol(namingMap[entity])} name & description`}
         description="Define the name and description of the project which will be displayed across the Dashboard and CLI"
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSave}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
@@ -7,7 +7,7 @@ import {FormItem, FullWidthSpace} from '@custom-antd';
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -52,7 +52,7 @@ const NameNDescription: React.FC = () => {
         },
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} was successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -45,11 +45,9 @@ const Timeout: React.FC = () => {
           activeDeadlineSeconds: activeDeadlineSeconds ? Number(activeDeadlineSeconds) : 0,
         },
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
-        notificationCall('passed', 'Test Timeout was successfully updated.');
-      });
-    });
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => notificationCall('passed', 'Test Timeout was successfully updated.'));
   };
 
   return (

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -10,7 +10,7 @@ import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
 import {digits} from '@utils/form';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -46,7 +46,7 @@ const Timeout: React.FC = () => {
         },
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Test Timeout was successfully updated.');
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -10,7 +10,7 @@ import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
 import {digits} from '@utils/form';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -32,10 +32,11 @@ const Timeout: React.FC = () => {
 
   const [updateTest] = useUpdateTestMutation();
 
-  const onSave = (values: TimeoutForm) => {
+  const onSave = () => {
+    const values = form.getFieldsValue();
     const {activeDeadlineSeconds} = values;
 
-    updateTest({
+    return updateTest({
       id: name,
       data: {
         ...entityDetails,
@@ -45,7 +46,7 @@ const Timeout: React.FC = () => {
         },
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Test Timeout was successfully updated.');
       });
     });
@@ -54,7 +55,6 @@ const Timeout: React.FC = () => {
   return (
     <Form
       form={form}
-      onFinish={onSave}
       name="general-settings-name-description"
       initialValues={{activeDeadlineSeconds: executionRequest?.activeDeadlineSeconds}}
       disabled={!mayEdit}
@@ -62,9 +62,7 @@ const Timeout: React.FC = () => {
       <ConfigurationCard
         title="Timeout"
         description="Define the timeout in seconds after which this test will fail."
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSave}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -10,7 +10,7 @@ import {FullWidthSpace, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import Colors from '@styles/Colors';
@@ -47,7 +47,7 @@ const Schedule: React.FC = () => {
       },
     }).then(res => {
       setWasTouched(false);
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} schedule was successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -10,7 +10,7 @@ import {FullWidthSpace, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 import {uppercaseFirstSymbol} from '@utils/strings';
 
 import Colors from '@styles/Colors';
@@ -39,17 +39,17 @@ const Schedule: React.FC = () => {
   const [wasTouched, setWasTouched] = useState(false);
 
   const onSave = () => {
-    updateEntity({
+    return updateEntity({
       id: name,
       data: {
         ...entityDetails,
         schedule: cronString,
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      setWasTouched(false);
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} schedule was successfully updated.`);
       });
-      setWasTouched(false);
     });
   };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -45,12 +45,12 @@ const Schedule: React.FC = () => {
         ...entityDetails,
         schedule: cronString,
       },
-    }).then(res => {
-      setWasTouched(false);
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
+        setWasTouched(false);
         notificationCall('passed', `${uppercaseFirstSymbol(namingMap[entity])} schedule was successfully updated.`);
       });
-    });
   };
 
   const onCancel = () => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
@@ -25,11 +25,11 @@ const SettingsTest: React.FC = () => {
         ...entityDetails,
         ...data,
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', `Test settings was successfully updated.`);
       });
-    });
   };
 
   return (

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
@@ -4,7 +4,7 @@ import {Space} from 'antd';
 
 import {notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -26,7 +26,7 @@ const SettingsTest: React.FC = () => {
         ...data,
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `Test settings was successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
@@ -4,7 +4,7 @@ import {Space} from 'antd';
 
 import {notificationCall} from '@molecules';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -19,14 +19,14 @@ const SettingsTest: React.FC = () => {
   const [updateTestMutation] = useUpdateTestMutation();
 
   const updateTest = (data: Object) => {
-    updateTestMutation({
+    return updateTestMutation({
       id: entityDetails.name,
       data: {
         ...entityDetails,
         ...data,
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', `Test settings was successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/Source.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/Source.tsx
@@ -82,10 +82,11 @@ const Source: React.FC<SourceProps> = props => {
   const [isClearedToken, setIsClearedToken] = useState(!additionalFormValues.token);
   const [isClearedUsername, setIsClearedUsername] = useState(!additionalFormValues.username);
 
-  const onSave = (values: SourceFormValues) => {
+  const onSave = () => {
+    const values = form.getFieldsValue();
     const {testSource: newTestSource} = values;
 
-    updateTest({
+    return updateTest({
       content: getSourcePayload(values, testSources),
       ...getCustomSourceField(newTestSource),
     });
@@ -98,15 +99,12 @@ const Source: React.FC<SourceProps> = props => {
       initialValues={{testSource: source, ...additionalFormValues}}
       layout="vertical"
       labelAlign="right"
-      onFinish={onSave}
       disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Source"
         description="Define the source for your test"
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSave}
         onCancel={() => {
           form.resetFields();
           setIsClearedUsername(!additionalFormValues.username);

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/TestType.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/TestType.tsx
@@ -35,8 +35,10 @@ const TestType: React.FC<TestTypeProps> = props => {
   const executors = useAppSelector(selectExecutors);
   const remappedExecutors = remapExecutors(executors);
 
-  const onSave = (values: TestTypeFormValues) => {
-    updateTest({type: values.type});
+  const onSave = () => {
+    const values = form.getFieldsValue();
+
+    return updateTest({type: values.type});
   };
 
   return (
@@ -44,9 +46,7 @@ const TestType: React.FC<TestTypeProps> = props => {
       <ConfigurationCard
         title="Test type"
         description="Define the test type for this test."
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSave}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -20,7 +20,7 @@ import {Text, Title} from '@custom-antd';
 import {ConfigurationCard, DragNDropList, TestSuiteStepCard, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useGetTestsListForTestSuiteQuery, useUpdateTestSuiteMutation} from '@services/testSuites';
 import {useGetAllTestsQuery} from '@services/tests';
@@ -105,14 +105,14 @@ const SettingsTests: React.FC = () => {
   }, [initialSteps]);
 
   const saveSteps = () => {
-    updateTestSuite({
+    return updateTestSuite({
       id: entityDetails.name,
       data: {
         ...entityDetails,
         steps: currentSteps,
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Steps were successfully updated.');
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -111,11 +111,11 @@ const SettingsTests: React.FC = () => {
         ...entityDetails,
         steps: currentSteps,
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', 'Steps were successfully updated.');
       });
-    });
   };
 
   const onSelectStep = (value: string) => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -20,7 +20,7 @@ import {Text, Title} from '@custom-antd';
 import {ConfigurationCard, DragNDropList, TestSuiteStepCard, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useGetTestsListForTestSuiteQuery, useUpdateTestSuiteMutation} from '@services/testSuites';
 import {useGetAllTestsQuery} from '@services/tests';
@@ -112,7 +112,7 @@ const SettingsTests: React.FC = () => {
         steps: currentSteps,
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Steps were successfully updated.');
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -11,7 +11,7 @@ import {Button, FullWidthSpace, Text} from '@custom-antd';
 import {ConfigurationCard, CopyCommand, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -60,7 +60,7 @@ const Arguments: React.FC = () => {
       id: entityDetails.name,
       data: successRecord,
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Variables were successfully updated.');
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -11,7 +11,7 @@ import {Button, FullWidthSpace, Text} from '@custom-antd';
 import {ConfigurationCard, CopyCommand, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
 
@@ -44,7 +44,8 @@ const Arguments: React.FC = () => {
   const [isPrettified, setPrettifiedState] = useState(true);
   const [isButtonsDisabled, setIsButtonsDisabled] = useState(true);
 
-  const onSaveForm = (values: ArgumentsFormValues) => {
+  const onSaveForm = () => {
+    const values = form.getFieldsValue();
     const argVal = !values.args.length ? [] : values.args.trim().split('\n');
 
     const successRecord = {
@@ -55,11 +56,11 @@ const Arguments: React.FC = () => {
       },
     };
 
-    updateTest({
+    return updateTest({
       id: entityDetails.name,
       data: successRecord,
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Variables were successfully updated.');
       });
     });
@@ -133,7 +134,6 @@ const Arguments: React.FC = () => {
       form={form}
       name="general-settings-name-description"
       onChange={onChange}
-      onFinish={onSaveForm}
       initialValues={{args: argsValue}}
       disabled={!mayEdit}
     >
@@ -146,9 +146,7 @@ const Arguments: React.FC = () => {
           </>
         }
         isButtonsDisabled={isButtonsDisabled}
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSaveForm}
         onCancel={() => {
           setArgsValue(entityArgs.join(' '));
           form.setFieldValue(['args'], entityArgs.join(' '));

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -59,11 +59,11 @@ const Arguments: React.FC = () => {
     return updateTest({
       id: entityDetails.name,
       data: successRecord,
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', 'Variables were successfully updated.');
       });
-    });
   };
 
   const onChange = () => {

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -10,7 +10,7 @@ import {ExternalLink} from '@atoms';
 import {ConfigurationCard, TestsVariablesList, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {decomposeVariables, formatVariables} from '@utils/variables';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -61,7 +61,7 @@ const Variables: React.FC = () => {
       id: entityDetails.name,
       data: successRecord,
     }).then(res => {
-      defaultNotificationFlow(res, () => {
+      displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', `Variables were successfully updated.`);
       });
     });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -10,7 +10,7 @@ import {ExternalLink} from '@atoms';
 import {ConfigurationCard, TestsVariablesList, notificationCall} from '@molecules';
 
 import {externalLinks} from '@utils/externalLinks';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 import {decomposeVariables, formatVariables} from '@utils/variables';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -47,7 +47,8 @@ const Variables: React.FC = () => {
     form.resetFields();
   }, [variables]);
 
-  const onSaveForm = (value: VariablesFormValues) => {
+  const onSaveForm = () => {
+    const value = form.getFieldsValue();
     const successRecord = {
       ...entityDetails,
       executionRequest: {
@@ -60,20 +61,15 @@ const Variables: React.FC = () => {
       id: entityDetails.name,
       data: successRecord,
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      defaultNotificationFlow(res, () => {
         notificationCall('passed', `Variables were successfully updated.`);
       });
     });
   };
 
-  const onClickSave = () => {
-    form.submit();
-  };
-
   return (
     <Form
       form={form}
-      onFinish={onSaveForm}
       onFieldsChange={(_: any) => {
         if (_[0]) {
           const action = _[0];
@@ -111,7 +107,7 @@ const Variables: React.FC = () => {
             Learn more about <ExternalLink href={externalLinks.variables}>Environment variables</ExternalLink>
           </>
         }
-        onConfirm={onClickSave}
+        onConfirm={onSaveForm}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -57,14 +57,14 @@ const Variables: React.FC = () => {
       },
     };
 
-    updateEntity({
+    return updateEntity({
       id: entityDetails.name,
       data: successRecord,
-    }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', `Variables were successfully updated.`);
       });
-    });
   };
 
   return (

--- a/src/components/organisms/EntityList/EntityCreationModal/TestCreationForm/TestCreationForm.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestCreationForm/TestCreationForm.tsx
@@ -86,7 +86,7 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
 
     addTest(requestBody)
       .then(res => {
-        onSuccess(res);
+        return onSuccess(res);
       })
       .catch(err => {
         setError(err);

--- a/src/components/organisms/EntityList/EntityCreationModal/TestCreationForm/TestCreationForm.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestCreationForm/TestCreationForm.tsx
@@ -10,7 +10,7 @@ import {Test} from '@models/test';
 
 import {Button, FormItem, Text} from '@custom-antd';
 
-import {LabelsSelect} from '@molecules';
+import {LabelsSelect, NotificationContent} from '@molecules';
 import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 
 import {
@@ -33,6 +33,8 @@ import {
 
 import {useAddTestMutation} from '@services/tests';
 
+import {ErrorNotificationConfig} from '@src/models/notifications';
+
 import {LabelsWrapper, StyledFormSpace} from '../CreationModal.styled';
 
 type TestCreationFormValues = {
@@ -47,6 +49,7 @@ type TestCreationFormProps = {
   onSuccess: (res: RTKResponse<MetadataResponse<Test>>) => void;
   testSources: SourceWithRepository[];
   executors: Executor[];
+  error?: ErrorNotificationConfig;
 };
 
 const additionalFields: SourceFields = {
@@ -57,7 +60,7 @@ const additionalFields: SourceFields = {
 };
 
 const TestCreationForm: React.FC<TestCreationFormProps> = props => {
-  const {form, testSources, executors, onSuccess} = props;
+  const {form, testSources, executors, onSuccess, error} = props;
 
   const remappedExecutors = remapExecutors(executors);
   const remappedCustomTestSources = remapTestSources(testSources);
@@ -90,6 +93,7 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
     <Form form={form} layout="vertical" name="test-creation" onFinish={onSave} style={{flex: 1}} labelAlign="right">
       <StyledFormSpace size={24} direction="vertical">
         <Text className="regular big">Test details</Text>
+        {error ? <NotificationContent status="failed" message={error.message} title={error.title} /> : null}
         <FormItem
           name="name"
           label="Name"

--- a/src/components/organisms/EntityList/EntityCreationModal/TestCreationModalContent.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestCreationModalContent.tsx
@@ -3,7 +3,6 @@ import {useContext, useEffect, useState} from 'react';
 import {Form} from 'antd';
 
 import {MetadataResponse, RTKResponse} from '@models/fetch';
-import {ErrorNotificationConfig} from '@models/notifications';
 import {Test} from '@models/test';
 
 import {useAppSelector} from '@redux/hooks';
@@ -15,7 +14,7 @@ import {Hint} from '@molecules';
 import {HintProps} from '@molecules/Hint/Hint';
 
 import {externalLinks} from '@utils/externalLinks';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {AnalyticsContext, DashboardContext, MainContext} from '@contexts';
 
@@ -34,7 +33,6 @@ const TestCreationModalContent: React.FC = () => {
   const testSources = useAppSelector(selectSources);
 
   const [hintConfig, setHintConfig] = useState<HintProps>(defaultHintConfig);
-  const [error, setError] = useState<ErrorNotificationConfig | undefined>(undefined);
 
   useEffect(() => {
     const selectedExecutor = executors.find(executor =>
@@ -66,35 +64,23 @@ const TestCreationModalContent: React.FC = () => {
   }, [form.getFieldValue('testType')]);
 
   const onSuccess = (res: RTKResponse<MetadataResponse<Test>>) => {
-    defaultNotificationFlow(
-      res,
-      () => {
-        if ('data' in res) {
-          analyticsTrack('trackEvents', {
-            type: res.data.spec?.type,
-            uiEvent: 'create-tests',
-          });
+    displayDefaultNotificationFlow(res, () => {
+      if ('data' in res) {
+        analyticsTrack('trackEvents', {
+          type: res.data.spec?.type,
+          uiEvent: 'create-tests',
+        });
 
-          dispatch(setRedirectTarget({targetTestId: res.data.metadata.name}));
+        dispatch(setRedirectTarget({targetTestId: res.data.metadata.name}));
 
-          navigate(`/tests/executions/${res.data.metadata.name}`);
-        }
-      },
-      err => {
-        setError(err);
+        navigate(`/tests/executions/${res.data.metadata.name}`);
       }
-    );
+    });
   };
 
   return (
     <TestCreationModalWrapper>
-      <TestCreationForm
-        form={form}
-        testSources={testSources}
-        executors={executors}
-        onSuccess={onSuccess}
-        error={error}
-      />
+      <TestCreationForm form={form} testSources={testSources} executors={executors} onSuccess={onSuccess} />
       <Hint {...hintConfig} />
     </TestCreationModalWrapper>
   );

--- a/src/components/organisms/EntityList/EntityCreationModal/TestCreationModalContent.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestCreationModalContent.tsx
@@ -64,7 +64,7 @@ const TestCreationModalContent: React.FC = () => {
   }, [form.getFieldValue('testType')]);
 
   const onSuccess = (res: RTKResponse<MetadataResponse<Test>>) => {
-    displayDefaultNotificationFlow(res, () => {
+    return displayDefaultNotificationFlow(res).then(() => {
       if ('data' in res) {
         analyticsTrack('trackEvents', {
           type: res.data.spec?.type,

--- a/src/components/organisms/EntityList/EntityCreationModal/TestSuiteCreationModalContent.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestSuiteCreationModalContent.tsx
@@ -50,18 +50,17 @@ const TestSuiteCreationModalContent: React.FC = () => {
       ...values,
       labels: decomposeLabels(localLabels),
     })
+      .then(res => displayDefaultNotificationFlow(res))
       .then(res => {
-        displayDefaultNotificationFlow(res, () => {
-          if ('data' in res) {
-            analyticsTrack('trackEvents', {
-              uiEvent: 'create-test-suites',
-            });
+        if (res && 'data' in res) {
+          analyticsTrack('trackEvents', {
+            uiEvent: 'create-test-suites',
+          });
 
-            dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}));
+          dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}));
 
-            navigate(`/test-suites/executions/${res.data.metadata.name}`);
-          }
-        });
+          navigate(`/test-suites/executions/${res.data.metadata.name}`);
+        }
       })
       .catch(err => {
         setError(err);

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -47,12 +47,12 @@ const Arguments: React.FC = () => {
         name: executorName,
         args: values.arguments,
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', 'Arguments were successfully updated.');
         dispatch(updateCurrentExecutorData({args: values.arguments}));
       });
-    });
   };
 
   useEffect(() => {

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -12,7 +12,7 @@ import {Button} from '@custom-antd';
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -48,7 +48,7 @@ const Arguments: React.FC = () => {
         args: values.arguments,
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Arguments were successfully updated.');
         dispatch(updateCurrentExecutorData({args: values.arguments}));
       });

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -12,7 +12,7 @@ import {Button} from '@custom-antd';
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -37,8 +37,10 @@ const Arguments: React.FC = () => {
 
   const [form] = Form.useForm<ArgumentsFormFields>();
 
-  const onSubmit = (values: ArgumentsFormFields) => {
-    updateCustomExecutor({
+  const onSubmit = () => {
+    const values = form.getFieldsValue();
+
+    return updateCustomExecutor({
       executorId: executorName,
       body: {
         ...executor,
@@ -46,7 +48,7 @@ const Arguments: React.FC = () => {
         args: values.arguments,
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Arguments were successfully updated.');
         dispatch(updateCurrentExecutorData({args: values.arguments}));
       });
@@ -65,15 +67,12 @@ const Arguments: React.FC = () => {
       name="executor-settings-arguments-list"
       initialValues={{arguments: args}}
       layout="vertical"
-      onFinish={onSubmit}
       disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Arguments for your command"
         description="Define the arguments for your command"
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSubmit}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -11,7 +11,7 @@ import {CommandInput} from '@atoms';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -34,8 +34,10 @@ const Command: React.FC = () => {
 
   const [form] = Form.useForm<CommandFormFields>();
 
-  const onSubmit = (values: CommandFormFields) => {
-    updateCustomExecutor({
+  const onSubmit = () => {
+    const values = form.getFieldsValue();
+
+    return updateCustomExecutor({
       executorId: name,
       body: {
         name,
@@ -43,7 +45,7 @@ const Command: React.FC = () => {
         command: values.command.split(' '),
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Command was successfully updated.');
         dispatch(updateCurrentExecutorData({command: values.command!.split(' ')}));
       });
@@ -62,15 +64,12 @@ const Command: React.FC = () => {
       name="general-settings-name-type"
       initialValues={{command: command?.join(' ')}}
       layout="vertical"
-      onFinish={onSubmit}
       disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Command"
         description="Define the command your image needs to run"
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSubmit}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -44,12 +44,12 @@ const Command: React.FC = () => {
         ...executor,
         command: values.command.split(' '),
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', 'Command was successfully updated.');
         dispatch(updateCurrentExecutorData({command: values.command!.split(' ')}));
       });
-    });
   };
 
   useEffect(() => {

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -11,7 +11,7 @@ import {CommandInput} from '@atoms';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -45,7 +45,7 @@ const Command: React.FC = () => {
         command: values.command.split(' '),
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Command was successfully updated.');
         dispatch(updateCurrentExecutorData({command: values.command!.split(' ')}));
       });

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -10,7 +10,7 @@ import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -33,8 +33,10 @@ const ContainerImagePanel: React.FC = () => {
 
   const [form] = Form.useForm<ContainerImageFormFields>();
 
-  const onSubmit = (values: ContainerImageFormFields) => {
-    updateCustomExecutor({
+  const onSubmit = () => {
+    const values = form.getFieldsValue();
+
+    return updateCustomExecutor({
       executorId: name,
       body: {
         name,
@@ -42,7 +44,7 @@ const ContainerImagePanel: React.FC = () => {
         ...values,
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Container image was successfully updated.');
         dispatch(updateCurrentExecutorData({image: values.image}));
       });
@@ -56,20 +58,11 @@ const ContainerImagePanel: React.FC = () => {
   }, [image]);
 
   return (
-    <Form
-      form={form}
-      name="general-settings-name-type"
-      initialValues={{image}}
-      layout="vertical"
-      onFinish={onSubmit}
-      disabled={!mayEdit}
-    >
+    <Form form={form} name="general-settings-name-type" initialValues={{image}} layout="vertical" disabled={!mayEdit}>
       <ConfigurationCard
         title="Container image"
-        description="Define the image you want to use for this executor. We defer by default to Dockerhub – but you can also insert a URL to your very own image"
-        onConfirm={() => {
-          form.submit();
-        }}
+        description="Define the image you want to use for this executor. We defer by default to Dockerhub - but you can also insert a URL to your very own image"
+        onConfirm={onSubmit}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -10,7 +10,7 @@ import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -44,7 +44,7 @@ const ContainerImagePanel: React.FC = () => {
         ...values,
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Container image was successfully updated.');
         dispatch(updateCurrentExecutorData({image: values.image}));
       });

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -43,12 +43,12 @@ const ContainerImagePanel: React.FC = () => {
         ...executor,
         ...values,
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', 'Container image was successfully updated.');
         dispatch(updateCurrentExecutorData({image: values.image}));
       });
-    });
   };
 
   useEffect(() => {

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -7,7 +7,7 @@ import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -44,7 +44,7 @@ const PrivateRegistry: React.FC = () => {
         imagePullSecrets: newImagePullSecrets,
       },
     }).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         dispatch(updateCurrentExecutorData({imagePullSecrets: newImagePullSecrets}));
         notificationCall('passed', 'Private registry was successfully updated.');
       });

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -43,12 +43,12 @@ const PrivateRegistry: React.FC = () => {
         ...executor,
         imagePullSecrets: newImagePullSecrets,
       },
-    }).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    })
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         dispatch(updateCurrentExecutorData({imagePullSecrets: newImagePullSecrets}));
         notificationCall('passed', 'Private registry was successfully updated.');
       });
-    });
   };
 
   useEffect(() => {

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -7,7 +7,7 @@ import {selectCurrentExecutor, updateCurrentExecutorData} from '@redux/reducers/
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateCustomExecutorMutation} from '@services/executors';
 
@@ -32,9 +32,11 @@ const PrivateRegistry: React.FC = () => {
 
   const [form] = Form.useForm<PrivateRegistryFormFields>();
 
-  const onSubmit = (values: PrivateRegistryFormFields) => {
+  const onSubmit = () => {
+    const values = form.getFieldsValue();
     const newImagePullSecrets = values.privateRegistry ? [{name: values.privateRegistry}] : [];
-    updateCustomExecutor({
+
+    return updateCustomExecutor({
       executorId: name,
       body: {
         name,
@@ -42,7 +44,7 @@ const PrivateRegistry: React.FC = () => {
         imagePullSecrets: newImagePullSecrets,
       },
     }).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+      return defaultNotificationFlow(res, () => {
         dispatch(updateCurrentExecutorData({imagePullSecrets: newImagePullSecrets}));
         notificationCall('passed', 'Private registry was successfully updated.');
       });
@@ -61,25 +63,18 @@ const PrivateRegistry: React.FC = () => {
       name="general-settings-name-type"
       initialValues={{privateRegistry}}
       layout="vertical"
-      onFinish={onSubmit}
       disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Private registry"
         description="In case your image is on a private registry please add the name of your credential secret."
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onSubmit}
         onCancel={() => {
           form.resetFields();
         }}
         enabled={mayEdit}
       >
-        <Form.Item
-          label="Secret ref name"
-          name="privateRegistry"
-          style={{flex: 1, marginBottom: '0'}}
-        >
+        <Form.Item label="Secret ref name" name="privateRegistry" style={{flex: 1, marginBottom: '0'}}>
           <Input placeholder="Secret ref name" />
         </Form.Item>
       </ConfigurationCard>

--- a/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
+++ b/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
@@ -54,12 +54,11 @@ const AddExecutorsModal: React.FC = () => {
     delete body.type;
 
     createExecutor(body)
+      .then(res => displayDefaultNotificationFlow(res))
       .then(res => {
-        displayDefaultNotificationFlow(res, () => {
-          if ('data' in res) {
-            navigate(`/executors/${res.data.metadata.name}`);
-          }
-        });
+        if (res && 'data' in res) {
+          navigate(`/executors/${res.data.metadata.name}`);
+        }
       })
       .catch(err => {
         setError(err);

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -2,6 +2,8 @@ import {useContext, useEffect, useState} from 'react';
 
 import {Form} from 'antd';
 
+import {ErrorNotificationConfig} from '@models/notifications';
+
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentSource, setCurrentSource} from '@redux/reducers/sourcesSlice';
 
@@ -9,7 +11,7 @@ import {FullWidthSpace} from '@custom-antd';
 
 import {ConfigurationCard, SecretFormItem, notificationCall} from '@molecules';
 
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {dummySecret} from '@utils/sources';
 
 import {useUpdateSourceMutation} from '@services/sources';
@@ -17,8 +19,6 @@ import {useUpdateSourceMutation} from '@services/sources';
 import {Permissions, usePermission} from '@permissions/base';
 
 import {MainContext} from '@contexts';
-
-import {ErrorNotificationConfig} from '@src/models/notifications';
 
 type AuthenticationFormValues = {
   token: string;
@@ -70,7 +70,7 @@ const Authentication: React.FC = () => {
     };
 
     return updateSource(body).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         if ('data' in res) {
           notificationCall('passed', 'Source was successfully updated.');
           dispatch(setCurrentSource({...body, ...res.data.spec}));

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -1,21 +1,24 @@
 import {useContext, useEffect, useState} from 'react';
 
 import {Form} from 'antd';
-import {FullWidthSpace} from '@custom-antd';
 
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentSource, setCurrentSource} from '@redux/reducers/sourcesSlice';
 
-import {ConfigurationCard, notificationCall, SecretFormItem} from '@molecules';
+import {FullWidthSpace} from '@custom-antd';
 
+import {ConfigurationCard, SecretFormItem, notificationCall} from '@molecules';
+
+import {defaultNotificationFlow} from '@utils/notification';
 import {dummySecret} from '@utils/sources';
-import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateSourceMutation} from '@services/sources';
 
 import {Permissions, usePermission} from '@permissions/base';
 
 import {MainContext} from '@contexts';
+
+import {ErrorNotificationConfig} from '@src/models/notifications';
 
 type AuthenticationFormValues = {
   token: string;
@@ -49,31 +52,31 @@ const Authentication: React.FC = () => {
     setIsClearedUsername(!usernameSecret);
   }, [repository]);
 
-  const onFinish = (values: AuthenticationFormValues) => {
-    if (!source) {
-      notificationCall('failed', 'Something went wrong.');
-    } else {
-      const token = values.token || '';
-      const username = values.username || '';
-      const body = {
-        ...source,
-        repository: {
-          ...source.repository,
-          ...(!tokenSecret || isClearedToken ? {token, tokenSecret: undefined} : {}),
-          ...(!usernameSecret || isClearedUsername ? {username, usernameSecret: undefined} : {}),
-        },
-      };
+  const onFinish = () => {
+    const values = form.getFieldsValue();
 
-      // @ts-ignore:
-      updateSource(body).then(res => {
-        displayDefaultNotificationFlow(res, () => {
-          if ('data' in res) {
-            notificationCall('passed', 'Source was successfully updated.');
-            dispatch(setCurrentSource({...body, ...res.data.spec}));
-          }
-        });
-      });
+    if (!source) {
+      return new Promise<ErrorNotificationConfig>(() => ({title: 'Something went wrong'}));
     }
+    const token = values.token || '';
+    const username = values.username || '';
+    const body = {
+      ...source,
+      repository: {
+        ...source.repository,
+        ...(!tokenSecret || isClearedToken ? {token, tokenSecret: undefined} : {}),
+        ...(!usernameSecret || isClearedUsername ? {username, usernameSecret: undefined} : {}),
+      },
+    };
+
+    return updateSource(body).then(res => {
+      return defaultNotificationFlow(res, () => {
+        if ('data' in res) {
+          notificationCall('passed', 'Source was successfully updated.');
+          dispatch(setCurrentSource({...body, ...res.data.spec}));
+        }
+      });
+    });
   };
 
   return (
@@ -82,15 +85,12 @@ const Authentication: React.FC = () => {
       initialValues={defaults}
       name="general-settings-authentication"
       layout="vertical"
-      onFinish={onFinish}
       disabled={!mayEdit}
     >
       <ConfigurationCard
         title="Authentication"
         description="Add authentication related information required by your git repository"
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onFinish}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -69,14 +69,14 @@ const Authentication: React.FC = () => {
       },
     };
 
-    return updateSource(body).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
-        if ('data' in res) {
+    return updateSource(body)
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(res => {
+        if (res && 'data' in res) {
           notificationCall('passed', 'Source was successfully updated.');
           dispatch(setCurrentSource({...body, ...res.data.spec}));
         }
       });
-    });
   };
 
   return (

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -10,7 +10,7 @@ import {Input} from '@custom-antd';
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateSourceMutation} from '@services/sources';
 
@@ -25,8 +25,11 @@ type NameNUrlFormValues = {
 
 const NameNUrl: React.FC = () => {
   const source = useAppSelector(selectCurrentSource);
+
   const {dispatch} = useContext(MainContext);
+
   const mayEdit = usePermission(Permissions.editEntity);
+
   const [form] = Form.useForm<NameNUrlFormValues>();
 
   const [updateSource] = useUpdateSourceMutation();
@@ -40,7 +43,9 @@ const NameNUrl: React.FC = () => {
     form.resetFields();
   }, [name, uri]);
 
-  const onFinish = (values: NameNUrlFormValues) => {
+  const onFinish = () => {
+    const values = form.getFieldsValue();
+
     if (!source) {
       notificationCall('failed', 'Something went wrong.');
       return;
@@ -55,8 +60,8 @@ const NameNUrl: React.FC = () => {
       },
     };
 
-    updateSource(body).then(res => {
-      displayDefaultNotificationFlow(res, () => {
+    return updateSource(body).then(res => {
+      return defaultNotificationFlow(res, () => {
         notificationCall('passed', 'Source was successfully updated.');
         dispatch(setCurrentSource(body));
       });
@@ -64,20 +69,11 @@ const NameNUrl: React.FC = () => {
   };
 
   return (
-    <Form
-      form={form}
-      name="general-settings-name-url"
-      initialValues={defaults}
-      layout="vertical"
-      onFinish={onFinish}
-      disabled={!mayEdit}
-    >
+    <Form form={form} name="general-settings-name-url" initialValues={defaults} layout="vertical" disabled={!mayEdit}>
       <ConfigurationCard
         title="Source name & repository URL"
         description="Define the name and repository URL of the source which will be later available in your tests."
-        onConfirm={() => {
-          form.submit();
-        }}
+        onConfirm={onFinish}
         onCancel={() => {
           form.resetFields();
         }}

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -60,12 +60,12 @@ const NameNUrl: React.FC = () => {
       },
     };
 
-    return updateSource(body).then(res => {
-      return displayDefaultNotificationFlow(res, () => {
+    return updateSource(body)
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => {
         notificationCall('passed', 'Source was successfully updated.');
         dispatch(setCurrentSource(body));
       });
-    });
   };
 
   return (

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -10,7 +10,7 @@ import {Input} from '@custom-antd';
 import {ConfigurationCard, notificationCall} from '@molecules';
 
 import {required} from '@utils/form';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateSourceMutation} from '@services/sources';
 
@@ -61,7 +61,7 @@ const NameNUrl: React.FC = () => {
     };
 
     return updateSource(body).then(res => {
-      return defaultNotificationFlow(res, () => {
+      return displayDefaultNotificationFlow(res, () => {
         notificationCall('passed', 'Source was successfully updated.');
         dispatch(setCurrentSource(body));
       });

--- a/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
+++ b/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
@@ -61,12 +61,11 @@ const AddSourceModal: React.FC = () => {
     };
 
     createSource(body)
+      .then(res => displayDefaultNotificationFlow(res))
       .then(res => {
-        displayDefaultNotificationFlow(res, () => {
-          if ('data' in res) {
-            navigate(`/sources/${res.data.metadata.name}`);
-          }
-        });
+        if (res && 'data' in res) {
+          navigate(`/sources/${res.data.metadata.name}`);
+        }
       })
       .catch(err => {
         setError(err);

--- a/src/components/pages/Triggers/Triggers.tsx
+++ b/src/components/pages/Triggers/Triggers.tsx
@@ -23,7 +23,7 @@ import {PageBlueprint} from '@organisms';
 
 import {externalLinks} from '@utils/externalLinks';
 import {safeRefetch} from '@utils/fetchUtils';
-import {defaultNotificationFlow} from '@utils/notification';
+import {displayDefaultNotificationFlow} from '@utils/notification';
 import {PollingIntervals} from '@utils/numbers';
 
 import {useGetAllTestSuitesQuery} from '@services/testSuites';
@@ -196,7 +196,7 @@ const Triggers: React.FC = () => {
     });
 
     return updateTriggers(body).then(res => {
-      return defaultNotificationFlow(res, () => notificationCall('passed', 'Triggers successfully updated'));
+      return displayDefaultNotificationFlow(res, () => notificationCall('passed', 'Triggers successfully updated'));
     });
   };
 

--- a/src/components/pages/Triggers/Triggers.tsx
+++ b/src/components/pages/Triggers/Triggers.tsx
@@ -23,7 +23,7 @@ import {PageBlueprint} from '@organisms';
 
 import {externalLinks} from '@utils/externalLinks';
 import {safeRefetch} from '@utils/fetchUtils';
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {defaultNotificationFlow} from '@utils/notification';
 import {PollingIntervals} from '@utils/numbers';
 
 import {useGetAllTestSuitesQuery} from '@services/testSuites';
@@ -175,7 +175,9 @@ const Triggers: React.FC = () => {
     };
   };
 
-  const onSave = (values: TriggersFormValues) => {
+  const onSave = () => {
+    const values = form.getFieldsValue();
+
     const body = values.triggers.map(trigger => {
       const [action, execution] = trigger.action.split(' ');
 
@@ -193,8 +195,8 @@ const Triggers: React.FC = () => {
       return triggerPayload;
     });
 
-    updateTriggers(body).then(res => {
-      displayDefaultNotificationFlow(res, () => notificationCall('passed', 'Triggers successfully updated'));
+    return updateTriggers(body).then(res => {
+      return defaultNotificationFlow(res, () => notificationCall('passed', 'Triggers successfully updated'));
     });
   };
 
@@ -215,10 +217,12 @@ const Triggers: React.FC = () => {
           title="Cluster events"
           description="Testkube can listen to cluster events and trigger specific actions. Events and actions are related to labelled resources."
           onConfirm={() => {
-            form
+            return form
               .validateFields()
-              .then(() => form.submit())
-              .catch(() => notificationCall('failed', 'Validate you triggers data, please'));
+              .then(onSave)
+              .catch(() => {
+                return {title: 'Invalid triggers data'};
+              });
           }}
           onCancel={() => {
             setDefaultTriggersData(triggersList || []);

--- a/src/components/pages/Triggers/Triggers.tsx
+++ b/src/components/pages/Triggers/Triggers.tsx
@@ -195,9 +195,9 @@ const Triggers: React.FC = () => {
       return triggerPayload;
     });
 
-    return updateTriggers(body).then(res => {
-      return displayDefaultNotificationFlow(res, () => notificationCall('passed', 'Triggers successfully updated'));
-    });
+    return updateTriggers(body)
+      .then(res => displayDefaultNotificationFlow(res))
+      .then(() => notificationCall('passed', 'Triggers successfully updated'));
   };
 
   const isLoading = keyMapLoading || testsLoading || testSuitesLoading || triggersLoading;
@@ -216,14 +216,7 @@ const Triggers: React.FC = () => {
         <ConfigurationCard
           title="Cluster events"
           description="Testkube can listen to cluster events and trigger specific actions. Events and actions are related to labelled resources."
-          onConfirm={() => {
-            return form
-              .validateFields()
-              .then(onSave)
-              .catch(() => {
-                return {title: 'Invalid triggers data'};
-              });
-          }}
+          onConfirm={onSave}
           onCancel={() => {
             setDefaultTriggersData(triggersList || []);
             form.resetFields();

--- a/src/models/notifications.ts
+++ b/src/models/notifications.ts
@@ -1,4 +1,4 @@
 export type ErrorNotificationConfig = {
   title: string;
-  message?: string;
+  message?: string | undefined;
 };

--- a/src/models/notifications.ts
+++ b/src/models/notifications.ts
@@ -1,0 +1,4 @@
+export type ErrorNotificationConfig = {
+  title: string;
+  message?: string;
+};

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -8,7 +8,7 @@ export type DefaultRequestError = {
   status?: number;
 };
 
-const getErrorFromResponse = (res?: RTKResponse<unknown>) => {
+export const getErrorFromResponse = (res?: RTKResponse<unknown>): unknown => {
   if (res && 'error' in res) {
     let errorObject = null;
 
@@ -33,17 +33,13 @@ const getErrorFromResponse = (res?: RTKResponse<unknown>) => {
   }
 };
 
-export function displayDefaultNotificationFlow<T = unknown>(
-  res?: RTKResponse<T>,
-  success?: () => void
-): {title: string; message?: string} | void {
+export async function displayDefaultNotificationFlow<T = unknown>(res?: RTKResponse<T>) {
   const error = getErrorFromResponse(res);
 
   if (error) {
     throw error;
   }
-
-  success?.();
+  return res;
 }
 
 export function displayDefaultErrorNotification(err: DefaultRequestError) {

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,5 +1,4 @@
 import {RTKResponse} from '@models/fetch';
-import {ErrorNotificationConfig} from '@models/notifications';
 
 import {notificationCall} from '@molecules';
 
@@ -9,11 +8,7 @@ export type DefaultRequestError = {
   status?: number;
 };
 
-export function defaultNotificationFlow<T = unknown>(
-  res?: RTKResponse<T>,
-  success?: () => void,
-  fail?: (error: ErrorNotificationConfig) => void
-): {title: string; message?: string} | null {
+const getErrorFromResponse = (res?: RTKResponse<unknown>) => {
   if (res && 'error' in res) {
     let errorObject = null;
 
@@ -34,14 +29,21 @@ export function defaultNotificationFlow<T = unknown>(
       };
     }
 
-    if (errorObject) {
-      fail?.(errorObject);
-    }
     return errorObject;
+  }
+};
+
+export function displayDefaultNotificationFlow<T = unknown>(
+  res?: RTKResponse<T>,
+  success?: () => void
+): {title: string; message?: string} | void {
+  const error = getErrorFromResponse(res);
+
+  if (error) {
+    throw error;
   }
 
   success?.();
-  return null;
 }
 
 export function displayDefaultErrorNotification(err: DefaultRequestError) {


### PR DESCRIPTION
This PR...

## Changes
https://github.com/kubeshop/testkube/issues/2708
- moved error notifications triggered in forms such as creation and settings
- refactored Configuration card, adding ability for future refactor https://github.com/kubeshop/testkube/issues/3787

## Fixes

-

## How to test it
- create test/suite/executor etc
- try to make some error so notification appear
- edit some settings cards across the dashboard

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
