### PR TITLE
Utilize external links

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -30,6 +30,7 @@ import {ModalHandler, ModalOutletProvider} from '@contexts/ModalContext';
 import {AnalyticsProvider} from './AnalyticsProvider';
 import App from './App';
 import {StyledLayoutContentWrapper} from './App.styled';
+import {externalLinks} from './utils/externalLinks';
 
 const pjson = require('../package.json');
 
@@ -130,7 +131,7 @@ const AppRoot: React.FC = () => {
   const config = useMemo(
     () => ({
       pageTitle: 'Testkube',
-      discordUrl: 'https://discord.com/invite/hfq44wtR6Q',
+      discordUrl: externalLinks.discord,
     }),
     []
   );

--- a/src/components/molecules/EndpointModal/EndpointModal.tsx
+++ b/src/components/molecules/EndpointModal/EndpointModal.tsx
@@ -4,6 +4,8 @@ import {ExternalLink} from '@atoms';
 
 import {Button, FullWidthSpace, Input, Modal, Text} from '@custom-antd';
 
+import {externalLinks} from '@utils/externalLinks';
+
 import {useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
 
 import Colors from '@styles/Colors';
@@ -57,9 +59,7 @@ const EndpointModal: React.FC<EndpointModalProps> = props => {
           <Text>
             We could not detect the right Testkube API endpoint for you. Please enter the API endpoint for your
             installation (e.g. from the output of the Testkube installer)&nbsp;
-            <ExternalLink href="https://docs.testkube.io/articles/testkube-dashboard-api-endpoint">
-              Learn more...
-            </ExternalLink>
+            <ExternalLink href={externalLinks.apiEndpoint}>Learn more...</ExternalLink>
           </Text>
           <FullWidthSpace size={12}>
             <Input

--- a/src/components/molecules/Hint/Hint.tsx
+++ b/src/components/molecules/Hint/Hint.tsx
@@ -14,7 +14,7 @@ import {AbsoluteExecutorIconContainer, StyledImageContainer, StyledWizardHintCon
 export type HintProps = {
   title: string;
   description: string;
-  openLink: () => void;
+  openLink: () => Window | null;
   selectedExecutor?: string;
 };
 

--- a/src/components/molecules/Hint/Hint.tsx
+++ b/src/components/molecules/Hint/Hint.tsx
@@ -14,7 +14,7 @@ import {AbsoluteExecutorIconContainer, StyledImageContainer, StyledWizardHintCon
 export type HintProps = {
   title: string;
   description: string;
-  openLink: () => Window | null;
+  openLink: () => void;
   selectedExecutor?: string;
 };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/EmptyExecutionsListContent/EmptyExecutionsListContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/EmptyExecutionsListContent/EmptyExecutionsListContent.tsx
@@ -4,6 +4,8 @@ import {setSettingsTabConfig} from '@redux/reducers/configSlice';
 
 import {EmptyListContent, HelpCard} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
+
 import {Permissions, usePermission} from '@permissions/base';
 
 import {EntityDetailsContext, MainContext} from '@contexts';
@@ -61,7 +63,7 @@ const EmptyExecutionsListContent: React.FC<EmptyExecutionsListContentProps> = pr
         onButtonClick={() => dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}))}
         actionType="create"
       >
-        <HelpCard isLink link="https://docs.testkube.io/articles/creating-test-suites">
+        <HelpCard isLink link={externalLinks.createTestSuite}>
           Learn how to add test suites
         </HelpCard>
       </EmptyListContent>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsDefinition/utils.ts
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsDefinition/utils.ts
@@ -3,6 +3,8 @@ import {QueryDefinition} from '@reduxjs/toolkit/src/query/endpointDefinitions';
 
 import {Entity} from '@models/entity';
 
+import {externalLinks} from '@utils/externalLinks';
+
 import {useGetTestSuiteDefinitionQuery} from '@services/testSuites';
 import {useGetTestDefinitionQuery} from '@services/tests';
 
@@ -16,12 +18,12 @@ export const settingsDefinitionData: Record<
 > = {
   'test-suites': {
     description: 'Validate and export your test suite configuration',
-    helpLinkUrl: 'https://docs.testkube.io/articles/creating-test-suites',
+    helpLinkUrl: externalLinks.createTestSuite,
     query: useGetTestSuiteDefinitionQuery,
   },
   tests: {
     description: 'Validate and export your test configuration',
-    helpLinkUrl: 'https://docs.testkube.io/articles/creating-tests',
+    helpLinkUrl: externalLinks.createTest,
     query: useGetTestDefinitionQuery,
   },
 };

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -2,9 +2,7 @@ import {useContext} from 'react';
 
 import {Form, Input} from 'antd';
 
-import {ExternalLink} from '@atoms';
-
-import {FormItem, FullWidthSpace, Text} from '@custom-antd';
+import {FormItem, FullWidthSpace} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
@@ -67,12 +65,6 @@ const Timeout: React.FC = () => {
         onCancel={() => {
           form.resetFields();
         }}
-        footerText={
-          <Text className="regular middle">
-            Learn more about{' '}
-            <ExternalLink href="https://docs.testkube.io/articles/creating-test-suites">Timeouts</ExternalLink>
-          </Text>
-        }
         enabled={mayEdit}
       >
         <FullWidthSpace size={32} direction="vertical">

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -2,10 +2,13 @@ import {useContext} from 'react';
 
 import {Form, Input} from 'antd';
 
-import {FormItem, FullWidthSpace} from '@custom-antd';
+import {ExternalLink} from '@atoms';
+
+import {FormItem, FullWidthSpace, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
 import {digits} from '@utils/form';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
@@ -66,6 +69,11 @@ const Timeout: React.FC = () => {
           form.resetFields();
         }}
         enabled={mayEdit}
+        footerText={
+          <Text className="regular middle">
+            Learn more about <ExternalLink href={externalLinks.addingTimeout}>Timeouts</ExternalLink>
+          </Text>
+        }
       >
         <FullWidthSpace size={32} direction="vertical">
           <FormItem name="activeDeadlineSeconds" rules={[digits]}>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/Source.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/Source.tsx
@@ -22,7 +22,7 @@ import {
 } from '@organisms/TestConfigurationForm';
 import {Props, SourceFields, SourceType, getAdditionalFieldsComponent} from '@organisms/TestConfigurationForm/utils';
 
-import {testSourceLink} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 import {required} from '@utils/form';
 import {
   GetSourceFormValues,
@@ -114,7 +114,7 @@ const Source: React.FC<SourceProps> = props => {
         }}
         footerText={
           <>
-            Learn more about <ExternalLink href={testSourceLink}>test sources</ExternalLink>
+            Learn more about <ExternalLink href={externalLinks.sourcesDocumentation}>test sources</ExternalLink>
           </>
         }
         forceEnableButtons={Boolean(

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/TestType.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/TestType.tsx
@@ -12,6 +12,7 @@ import {FormItem, FullWidthSpace} from '@custom-antd';
 import {ConfigurationCard} from '@molecules';
 
 import {remapExecutors} from '@utils/executors';
+import {externalLinks} from '@utils/externalLinks';
 import {required} from '@utils/form';
 
 import {Permissions, usePermission} from '@permissions/base';
@@ -51,8 +52,7 @@ const TestType: React.FC<TestTypeProps> = props => {
         }}
         footerText={
           <>
-            Learn more about{' '}
-            <ExternalLink href="https://docs.testkube.io/category/test-types">test types and executors</ExternalLink>
+            Learn more about <ExternalLink href={externalLinks.testTypes}>test types and executors</ExternalLink>
           </>
         }
         enabled={mayEdit}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -19,6 +19,7 @@ import {Text, Title} from '@custom-antd';
 
 import {ConfigurationCard, DragNDropList, TestSuiteStepCard, notificationCall} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useGetTestsListForTestSuiteQuery, useUpdateTestSuiteMutation} from '@services/testSuites';
@@ -176,10 +177,7 @@ const SettingsTests: React.FC = () => {
         description="Define the tests and their order of execution for this test suite"
         footerText={
           <>
-            Learn more about{' '}
-            <ExternalLink href="https://docs.testkube.io/using-testkube/test-suites/testsuites-creating/">
-              Tests in a test suite
-            </ExternalLink>
+            Learn more about <ExternalLink href={externalLinks.testSuitesCreating}>Tests in a test suite</ExternalLink>
           </>
         }
         onConfirm={saveSteps}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -10,6 +10,7 @@ import {Button, FullWidthSpace, Text} from '@custom-antd';
 
 import {ConfigurationCard, CopyCommand, notificationCall} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {useUpdateTestMutation} from '@services/tests';
@@ -141,10 +142,7 @@ const Arguments: React.FC = () => {
         description="Define arguments which will be passed to the test executor."
         footerText={
           <>
-            Learn more about{' '}
-            <ExternalLink href="https://docs.testkube.io/test-types/executor-soapui/#using-parameters-and-arguments-in-your-tests">
-              Arguments
-            </ExternalLink>
+            Learn more about <ExternalLink href={externalLinks.arguments}>Arguments</ExternalLink>
           </>
         }
         isButtonsDisabled={isButtonsDisabled}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -9,6 +9,7 @@ import {ExternalLink} from '@atoms';
 
 import {ConfigurationCard, TestsVariablesList, notificationCall} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 import {decomposeVariables, formatVariables} from '@utils/variables';
 
@@ -107,10 +108,7 @@ const Variables: React.FC = () => {
         description={descriptionMap[entity]}
         footerText={
           <>
-            Learn more about{' '}
-            <ExternalLink href="https://docs.testkube.io/articles/adding-tests-variables/">
-              Environment variables
-            </ExternalLink>
+            Learn more about <ExternalLink href={externalLinks.variables}>Environment variables</ExternalLink>
           </>
         }
         onConfirm={onClickSave}

--- a/src/components/organisms/EntityList/EntityCreationModal/ModalConfig.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/ModalConfig.tsx
@@ -1,6 +1,6 @@
 import {ModalConfigProps} from '@models/modal';
 
-import {openCustomExecutorDocumentation} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 
 import TestCreationModalContent from './TestCreationModalContent';
 import TestSuiteCreationModalContent from './TestSuiteCreationModalContent';
@@ -24,5 +24,5 @@ export const TestModalConfig: ModalConfigProps = {
 export const defaultHintConfig = {
   title: 'Missing a test type?',
   description: 'Add test types through testkube executors.',
-  openLink: openCustomExecutorDocumentation,
+  openLink: () => window.open(externalLinks.containerExecutor),
 };

--- a/src/components/organisms/EntityList/EntityCreationModal/TestCreationModalContent.tsx
+++ b/src/components/organisms/EntityList/EntityCreationModal/TestCreationModalContent.tsx
@@ -13,7 +13,7 @@ import {selectSources} from '@redux/reducers/sourcesSlice';
 import {Hint} from '@molecules';
 import {HintProps} from '@molecules/Hint/Hint';
 
-import {openCustomExecutorDocumentation} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
 import {AnalyticsContext, DashboardContext, MainContext} from '@contexts';
@@ -46,7 +46,7 @@ const TestCreationModalContent: React.FC = () => {
         setHintConfig({
           title: 'Testing with custom executor',
           description: 'Discover all the features and examples around custom executors',
-          openLink: openCustomExecutorDocumentation,
+          openLink: () => window.open(externalLinks.containerExecutor),
         });
       }
 

--- a/src/components/organisms/Sider/Sider.tsx
+++ b/src/components/organisms/Sider/Sider.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useContext} from 'react';
+import {useContext, useMemo} from 'react';
 
 import {Space, Tooltip} from 'antd';
 
@@ -7,7 +7,7 @@ import {selectFullScreenLogOutput} from '@redux/reducers/configSlice';
 
 import {Icon} from '@atoms';
 
-import {openDiscord, openDocumentation, openGithub} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 
 import {ReactComponent as ExecutorsIcon} from '@assets/executor.svg';
 import {ReactComponent as SourcesIcon} from '@assets/sources.svg';
@@ -20,7 +20,6 @@ import {ReactComponent as SettingIcon} from '@icons/setting.svg';
 
 import {DashboardContext} from '@contexts';
 
-import SiderLink from './SiderLink';
 import {
   StyledLogo,
   StyledNavigationMenu,
@@ -30,6 +29,7 @@ import {
   StyledSiderChildContainer,
   StyledSiderLink,
 } from './Sider.styled';
+import SiderLink from './SiderLink';
 
 const DEFAULT_ICON_STYLE = {
   fontSize: 24,
@@ -76,18 +76,20 @@ const getRoutes = (showSocialLinksInSider: boolean) => [
       classNames: 'item',
     },
   },
-    ...(showSocialLinksInSider ? [] : [
-      {
-        path: '/settings',
-        icon: SettingIcon,
-        title: 'Settings',
-        transition: {
-          classNames: 'item',
+  ...(showSocialLinksInSider
+    ? []
+    : [
+        {
+          path: '/settings',
+          icon: SettingIcon,
+          title: 'Settings',
+          transition: {
+            classNames: 'item',
+          },
+          additionalClassName: 'settings-icon',
+          active: /environment-management/,
         },
-        additionalClassName: 'settings-icon',
-        active: /environment-management/,
-      }
-    ]),
+      ]),
 ];
 
 const Sider: React.FC = () => {
@@ -100,9 +102,9 @@ const Sider: React.FC = () => {
       icon: 'cog',
       onClick: () => navigate('/settings'),
     },
-    {icon: 'github', onClick: openGithub},
-    {icon: 'documentation', onClick: openDocumentation},
-    {icon: 'discord', onClick: openDiscord},
+    {icon: 'github', onClick: window.open(externalLinks.github)},
+    {icon: 'documentation', onClick: window.open(externalLinks.documentation)},
+    {icon: 'discord', onClick: window.open(externalLinks.discord)},
   ];
 
   const renderedMenuItems = useMemo(() => {
@@ -118,7 +120,9 @@ const Sider: React.FC = () => {
           active={active}
         >
           <Tooltip title={title} placement="right">
-            <span><MenuIcon style={DEFAULT_ICON_STYLE} /></span>
+            <span>
+              <MenuIcon style={DEFAULT_ICON_STYLE} />
+            </span>
           </Tooltip>
         </StyledSiderLink>
       );
@@ -143,11 +147,13 @@ const Sider: React.FC = () => {
       <StyledSiderChildContainer>
         <StyledNavigationMenu>
           <Space size={30} direction="vertical">
-            {showLogoInSider ? <StyledLogo>
-              <SiderLink href="/tests">
-                <Logo />
-              </SiderLink>
-            </StyledLogo> : null}
+            {showLogoInSider ? (
+              <StyledLogo>
+                <SiderLink href="/tests">
+                  <Logo />
+                </SiderLink>
+              </StyledLogo>
+            ) : null}
             {renderedMenuItems}
           </Space>
         </StyledNavigationMenu>

--- a/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
+++ b/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
@@ -9,7 +9,7 @@ import {Button, Input} from '@custom-antd';
 
 import {Hint} from '@molecules';
 
-import {openCustomExecutorDocumentation} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 import {k8sResourceNameMaxLength, k8sResourceNamePattern, required} from '@utils/form';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
@@ -87,7 +87,7 @@ const AddExecutorsModal: React.FC = () => {
       <Hint
         title="Need help?"
         description="We’ll guide you to easily create your very specific container based executor."
-        openLink={openCustomExecutorDocumentation}
+        openLink={() => window.open(externalLinks.containerExecutor)}
       />
     </AddExecutorsModalContainer>
   );

--- a/src/components/pages/Executors/ExecutorsList/EmptyCustomExecutors.tsx
+++ b/src/components/pages/Executors/ExecutorsList/EmptyCustomExecutors.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import {EmptyListContent, HelpCard} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
+
 interface EmptyCustomExecutorsProps {
   onButtonClick: () => void;
 }
@@ -19,13 +21,13 @@ const EmptyCustomExecutors: React.FC<EmptyCustomExecutorsProps> = props => {
       onButtonClick={onButtonClick}
       actionType="create"
     >
-      <HelpCard isLink link="https://docs.testkube.io/test-types/container-executor">
+      <HelpCard isLink link={externalLinks.containerExecutor}>
         What is an executor?
       </HelpCard>
-      <HelpCard isLink link="https://docs.testkube.io/test-types/container-executor">
+      <HelpCard isLink link={externalLinks.containerExecutor}>
         Learn how to easily create a container based executor
       </HelpCard>
-      <HelpCard isLink link="https://docs.testkube.io/test-types/container-executor#creating-a-custom-executor">
+      <HelpCard isLink link={externalLinks.customExecutor}>
         Want to add more complex executors?
       </HelpCard>
     </EmptyListContent>

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -10,6 +10,7 @@ import {Button, Modal, Skeleton, Text, Title} from '@custom-antd';
 
 import {PageBlueprint} from '@organisms';
 
+import {externalLinks} from '@utils/externalLinks';
 import {safeRefetch} from '@utils/fetchUtils';
 
 import {ReactComponent as ExecutorsIcon} from '@assets/executor.svg';
@@ -96,7 +97,7 @@ const Executors: React.FC = () => {
       description={
         <>
           Executors are the type of tests which can be run by testkube. Learn more about{' '}
-          <ExternalLink href="https://docs.testkube.io/test-types/container-executor">executors</ExternalLink>
+          <ExternalLink href={externalLinks.containerExecutor}>executors</ExternalLink>
         </>
       }
       headerButton={

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -8,6 +8,8 @@ import {FormItem, FullWidthSpace, Text} from '@custom-antd';
 
 import {ConfigurationCard, notificationCall} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
+
 import {isApiEndpointLocked, useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
 
 import Colors from '@styles/Colors';
@@ -59,9 +61,7 @@ const ApiEndpoint: React.FC = () => {
         footerText={
           <Text className="regular middle" color={`${Colors.slate400}`}>
             Learn more about{' '}
-            <ExternalLink href="https://docs.testkube.io/articles/common-issues/#why-is-the-testkube-dashboard-not-working-or-does-not-return-results">
-              testkube API endpoints
-            </ExternalLink>
+            <ExternalLink href={externalLinks.dashboardNotWorking}>testkube API endpoints</ExternalLink>
           </Text>
         }
         onConfirm={() => {

--- a/src/components/pages/GlobalSettings/General/ConnectCloud.tsx
+++ b/src/components/pages/GlobalSettings/General/ConnectCloud.tsx
@@ -8,7 +8,7 @@ import {FullWidthSpace, Text} from '@custom-antd';
 
 import {ConfigurationCard} from '@molecules';
 
-import {openOSSToCloudMigrateLink} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 
 import Colors from '@styles/Colors';
 
@@ -20,9 +20,7 @@ const ConnectCloud: React.FC = () => {
       footerText={
         <Text className="regular middle" color={Colors.slate400}>
           Learn more about{' '}
-          <ExternalLink href="https://docs.testkube.io/testkube-cloud/articles/transition-from-oss">
-            connecting to Testkube Cloud
-          </ExternalLink>
+          <ExternalLink href={externalLinks.transitionFromOSS}>connecting to Testkube Cloud</ExternalLink>
         </Text>
       }
     >
@@ -34,12 +32,10 @@ const ConnectCloud: React.FC = () => {
             <Text className="regular middle" color={Colors.slate400}>
               Multiple environments, Teams, RBAC and unique collaboration features.
             </Text>
-            <ExternalLink href="https://docs.testkube.io/testkube-cloud/articles/intro">
-              Learn more about Testkube Cloud
-            </ExternalLink>
+            <ExternalLink href={externalLinks.cloudIntro}>Learn more about Testkube Cloud</ExternalLink>
           </FullWidthSpace>
         </FullWidthSpace>
-        <Button type="primary" onClick={openOSSToCloudMigrateLink}>
+        <Button type="primary" onClick={() => window.open(externalLinks.OSStoCloudMigration, '_self')}>
           Connect your Testkube Cloud account
         </Button>
       </FullWidthSpace>

--- a/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
+++ b/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
@@ -13,7 +13,7 @@ import {Button, Input} from '@custom-antd';
 
 import {Hint} from '@molecules';
 
-import {openSourcesDocumentation} from '@utils/externalLinks';
+import {externalLinks} from '@utils/externalLinks';
 import {k8sResourceNameMaxLength, k8sResourceNamePattern, required} from '@utils/form';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
@@ -101,7 +101,7 @@ const AddSourceModal: React.FC = () => {
       <Hint
         title="Need help?"
         description="We’ll guide you to easily create your very specific test source."
-        openLink={openSourcesDocumentation}
+        openLink={() => window.open(externalLinks.sourcesApi)}
       />
     </AddSourceModalContainer>
   );

--- a/src/components/pages/Sources/SourcesList/EmptySources.tsx
+++ b/src/components/pages/Sources/SourcesList/EmptySources.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import {EmptyListContent, HelpCard} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
+
 interface EmptySourcesProps {
   onButtonClick: () => void;
 }
@@ -19,10 +21,10 @@ const EmptySources: React.FC<EmptySourcesProps> = props => {
       onButtonClick={onButtonClick}
       actionType="create"
     >
-      <HelpCard isLink link="https://docs.testkube.io/articles/test-sources">
+      <HelpCard isLink link={externalLinks.testSources}>
         What is a test source?
       </HelpCard>
-      <HelpCard isLink link="https://docs.testkube.io/articles/creating-tests/">
+      <HelpCard isLink link={externalLinks.createTest}>
         Learn how tests via Testkube work.
       </HelpCard>
     </EmptyListContent>

--- a/src/components/pages/Sources/SourcesList/SourcesList.tsx
+++ b/src/components/pages/Sources/SourcesList/SourcesList.tsx
@@ -9,6 +9,7 @@ import {Button, Modal, Skeleton, Text} from '@custom-antd';
 
 import {PageBlueprint} from '@organisms';
 
+import {externalLinks} from '@utils/externalLinks';
 import {safeRefetch} from '@utils/fetchUtils';
 
 import {useGetSourcesQuery} from '@services/sources';
@@ -65,7 +66,7 @@ const Sources: React.FC = () => {
       description={
         <>
           Define global sources you can refer to in your tests. Learn more about{' '}
-          <ExternalLink href="https://docs.testkube.io/articles/test-sources">Sources</ExternalLink>
+          <ExternalLink href={externalLinks.testSources}>Sources</ExternalLink>
         </>
       }
       headerButton={

--- a/src/components/pages/Triggers/Triggers.tsx
+++ b/src/components/pages/Triggers/Triggers.tsx
@@ -21,6 +21,7 @@ import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 
 import {PageBlueprint} from '@organisms';
 
+import {externalLinks} from '@utils/externalLinks';
 import {safeRefetch} from '@utils/fetchUtils';
 import {displayDefaultNotificationFlow} from '@utils/notification';
 import {PollingIntervals} from '@utils/numbers';
@@ -205,9 +206,7 @@ const Triggers: React.FC = () => {
       description={
         <>
           Listen for events and run specific testkube actions.{' '}
-          <ExternalLink href="https://docs.testkube.io/articles/test-triggers">
-            Learn more about Triggers
-          </ExternalLink>
+          <ExternalLink href={externalLinks.testTriggers}>Learn more about Triggers</ExternalLink>
         </>
       }
     >

--- a/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestSuitesListContent.tsx
+++ b/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestSuitesListContent.tsx
@@ -1,5 +1,7 @@
 import {EmptyListContent, HelpCard} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
+
 const EmptyTestSuitesListContent: React.FC<{action: () => void}> = props => {
   const {action} = props;
 
@@ -13,7 +15,7 @@ const EmptyTestSuitesListContent: React.FC<{action: () => void}> = props => {
       onButtonClick={action}
       actionType="create"
     >
-      <HelpCard isLink link="https://docs.testkube.io/articles/creating-test-suites">
+      <HelpCard isLink link={externalLinks.createTestSuite}>
         Learn how to add test suites
       </HelpCard>
     </EmptyListContent>

--- a/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestsListContent.tsx
+++ b/src/constants/entitiesConfig/EmptyEntitiesListContent/EmptyTestsListContent.tsx
@@ -1,5 +1,7 @@
 import {EmptyListContent, HelpCard} from '@molecules';
 
+import {externalLinks} from '@utils/externalLinks';
+
 const EmptyTestsListContent: React.FC<{action: () => void}> = props => {
   const {action} = props;
 
@@ -13,10 +15,10 @@ const EmptyTestsListContent: React.FC<{action: () => void}> = props => {
       onButtonClick={action}
       actionType="create"
     >
-      <HelpCard isLink link="https://docs.testkube.io/articles/creating-tests">
+      <HelpCard isLink link={externalLinks.createTest}>
         Learn how to add tests
       </HelpCard>
-      <HelpCard isLink link="https://docs.testkube.io/test-types/container-executor">
+      <HelpCard isLink link={externalLinks.containerExecutor}>
         How to add your very own test types and executors?
       </HelpCard>
     </EmptyListContent>

--- a/src/constants/entitiesConfig/TestsConfig.tsx
+++ b/src/constants/entitiesConfig/TestsConfig.tsx
@@ -13,6 +13,8 @@ import {ExternalLink} from '@atoms';
 
 import {Text} from '@custom-antd';
 
+import {externalLinks} from '@utils/externalLinks';
+
 import {useAbortAllTestExecutionsMutation, useGetTestExecutionMetricsQuery, useGetTestsQuery} from '@services/tests';
 
 import Colors from '@styles/Colors';
@@ -23,7 +25,7 @@ const TestsPageDescription: React.FC = () => {
   return (
     <Text className="regular middle" color={Colors.slate400}>
       Explore your tests at a glance... Learn more about{' '}
-      <ExternalLink href="https://docs.testkube.io/">testing with Testkube</ExternalLink>
+      <ExternalLink href={externalLinks.documentation}>testing with Testkube</ExternalLink>
     </Text>
   );
 };

--- a/src/utils/externalLinks.ts
+++ b/src/utils/externalLinks.ts
@@ -1,33 +1,24 @@
-export const openDocumentation = () => {
-  window.open('https://docs.testkube.io/');
-};
-
-export const openGithub = () => {
-  window.open('https://github.com/kubeshop/testkube');
-};
-
-export const openDiscord = () => {
-  window.open('https://discord.gg/6zupCZFQbe');
-};
-
-export const openCustomExecutorDocumentation = () => {
-  window.open('https://docs.testkube.io/test-types/container-executor');
-};
-
-export const openTestkubeDashboardDocumentation = () => {
-  window.open('https://docs.testkube.io/articles/testkube-dashboard');
-};
-
-export const openTestkubeIntegrationsDocumentation = () => {
-  window.open('https://testkube.io/integrations');
-};
-
-export const openSourcesDocumentation = () => {
-  window.open('https://docs.testkube.io/openapi/#tag/test-sources');
-};
-
-export const testSourceLink = 'https://docs.testkube.io/articles/creating-tests/#test-source';
-
-export const openOSSToCloudMigrateLink = () => {
-  window.open('https://cloud.testkube.io/system-init?cloudMigrate=true', '_self');
-};
+export enum externalLinks {
+  documentation = 'https://docs.testkube.io/',
+  github = 'https://github.com/kubeshop/testkube',
+  discord = 'https://discord.com/invite/hfq44wtR6Q',
+  containerExecutor = 'https://docs.testkube.io/test-types/container-executor',
+  dashboardDocumentation = 'https://docs.testkube.io/articles/testkube-dashboard',
+  integrations = 'https://testkube.io/integrations',
+  sourcesApi = 'https://docs.testkube.io/openapi/#tag/test-sources',
+  sourcesDocumentation = 'https://docs.testkube.io/articles/creating-tests/#test-source',
+  testSources = 'https://docs.testkube.io/articles/test-sources',
+  OSStoCloudMigration = 'https://cloud.testkube.io/system-init?cloudMigrate=true',
+  apiEndpoint = 'https://docs.testkube.io/articles/testkube-dashboard-api-endpoint',
+  createTestSuite = 'https://docs.testkube.io/articles/creating-test-suites',
+  createTest = 'https://docs.testkube.io/articles/creating-tests',
+  testTypes = 'https://docs.testkube.io/category/test-types',
+  testSuitesCreating = 'https://docs.testkube.io/using-testkube/test-suites/testsuites-creating/',
+  arguments = 'https://docs.testkube.io/test-types/executor-soapui/#using-parameters-and-arguments-in-your-tests',
+  variables = 'https://docs.testkube.io/articles/adding-tests-variables/',
+  customExecutor = 'https://docs.testkube.io/test-types/container-executor#creating-a-custom-executor',
+  dashboardNotWorking = 'https://docs.testkube.io/articles/common-issues/#why-is-the-testkube-dashboard-not-working-or-does-not-return-results',
+  transitionFromOSS = 'https://docs.testkube.io/testkube-cloud/articles/transition-from-oss',
+  cloudIntro = 'https://docs.testkube.io/testkube-cloud/articles/intro',
+  testTriggers = 'https://docs.testkube.io/articles/test-triggers',
+}

--- a/src/utils/externalLinks.ts
+++ b/src/utils/externalLinks.ts
@@ -21,4 +21,5 @@ export enum externalLinks {
   transitionFromOSS = 'https://docs.testkube.io/testkube-cloud/articles/transition-from-oss',
   cloudIntro = 'https://docs.testkube.io/testkube-cloud/articles/intro',
   testTriggers = 'https://docs.testkube.io/articles/test-triggers',
+  addingTimeout = 'https://docs.testkube.io/articles/adding-timeout/',
 }


### PR DESCRIPTION
This PR...

## Changes
https://github.com/kubeshop/testkube/issues/3629
- official executor links left unutilized. It makes sense to map BE response with executor links and populate them into that config

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
