### PR TITLE
feat: add REACT_APP_DISABLE_TELEMETRY to force disabling telemetry

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -2,5 +2,6 @@
 # line endings must be \n, not \r\n !
 echo "window._env_ = {" >./env-config.js
 echo "REACT_APP_API_SERVER_ENDPOINT: '${REACT_APP_API_SERVER_ENDPOINT}'," >>./env-config.js
-echo "REACT_APP_ROOT_ROUTE: '${REACT_APP_ROOT_ROUTE}'" >>./env-config.js
+echo "REACT_APP_ROOT_ROUTE: '${REACT_APP_ROOT_ROUTE}'," >>./env-config.js
+echo "REACT_APP_DISABLE_TELEMETRY: '${REACT_APP_DISABLE_TELEMETRY}'," >>./env-config.js
 echo "};" >>./env-config.js

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -50,8 +50,9 @@ const AppRoot: React.FC = () => {
 
   const [isCookiesVisible, setCookiesVisibility] = useState(!localStorage.getItem('isGADisabled'));
   const [featureFlags, setFeatureFlags] = useState<string[]>([]);
+  const isTelemetryAvailable = clusterConfig?.enableTelemetry && !env.disableTelemetry;
   const isTelemetryEnabled = useMemo(
-    () => !isCookiesVisible && clusterConfig?.enableTelemetry && localStorage.getItem('isGADisabled') === '0',
+    () => !isCookiesVisible && isTelemetryAvailable && localStorage.getItem('isGADisabled') === '0',
     [isCookiesVisible, clusterConfig]
   );
 
@@ -174,7 +175,7 @@ const AppRoot: React.FC = () => {
             </Content>
           </StyledLayoutContentWrapper>
         </Layout>
-        {isCookiesVisible && clusterConfig?.enableTelemetry ? (
+        {isCookiesVisible && isTelemetryAvailable ? (
           <CookiesBanner onAcceptCookies={onAcceptCookies} onDeclineCookies={onDeclineCookies} />
         ) : null}
       </>

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,6 +11,7 @@ const build: BuildTimeEnvironment = {
 const env: DynamicEnvironment = {
   apiUrl: values?.REACT_APP_API_SERVER_ENDPOINT,
   basename: values?.REACT_APP_ROOT_ROUTE,
+  disableTelemetry: values?.REACT_APP_DISABLE_TELEMETRY === 'true',
 };
 
 type BuildTimeEnvironment = {
@@ -22,6 +23,7 @@ type BuildTimeEnvironment = {
 type DynamicEnvironment = {
   apiUrl: string;
   basename: string;
+  disableTelemetry: boolean;
 };
 
 export default {


### PR DESCRIPTION
## Changes

- add `REACT_APP_DISABLE_TELEMETRY` to force disabling telemetry
  - it may be used on Vercel and optionally and test environments

## Fixes

- kubeshop/testkube#3884

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
