### PR TITLE
fix: fixed dropdown styles

### DIFF
--- a/src/components/pages/Triggers/Triggers.tsx
+++ b/src/components/pages/Triggers/Triggers.tsx
@@ -263,6 +263,7 @@ const Triggers: React.FC = () => {
                   ) : null}
                   {isTriggersAvailable ? (
                     <Dropdown
+                      overlayClassName="triggers-dropdown"
                       menu={{
                         items: addTriggerOptions.map(({key, ...restProps}) => ({
                           key,

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -215,13 +215,20 @@ export const GlobalStyle = createGlobalStyle`
 
   /* Dropdown */
 
+  .triggers-dropdown {
+    .ant-dropdown-menu {
+      background: ${Colors.slate900};
+
+      .ant-dropdown-menu-item {
+        background: ${Colors.slate700};
+      }
+    }
+  }
+
   .ant-dropdown-menu {
-    background: ${Colors.slate800};
     padding: 0;
 
     .ant-dropdown-menu-item {
-      background: ${Colors.slate700};
-
       &:hover {
         background: transparent;
       }


### PR DESCRIPTION
Specified `className` to triggers dropdown, now looks as it should

<img width="786" alt="image" src="https://github.com/kubeshop/testkube-dashboard/assets/25991946/e132c577-faf7-483e-bdd4-82c75a4532b3">
<img width="446" alt="image" src="https://github.com/kubeshop/testkube-dashboard/assets/25991946/da491a04-d668-4667-9899-b6c4a32666f0">
