### PR TITLE
fix: allow non-root user for the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 8080
 WORKDIR /usr/share/nginx/html
 COPY ./scripts/env.sh .
-RUN chmod +x env.sh
+RUN chmod +x env.sh && chmod ugo+w /etc/nginx/nginx.conf
 
 RUN touch ./env-config.js
 RUN chmod a+w ./env-config.js


### PR DESCRIPTION
## Changes

- add write permissions for `nginx.conf` in the Docker image for any user, so `envsubst` may replace it for non-root users

## Fixes

- kubeshop/testkube#3931

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
