### PR TITLE
feat: add overrides mechanism for testing variables

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -2,4 +2,6 @@ export const config = {
   apiEndpoint: 'apiEndpoint',
   apiVersion: '/v1/executions',
   isTestkubeCloudLaunchBannerHidden: 'isTestkubeCloudLaunchBannerHidden',
+
+  overrides: '$tkOverrides',
 };

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,18 +1,25 @@
+import {applyUrlOverrides, getValue, renderOverridesIndicator} from './overrides';
+
+// Load overrides
+applyUrlOverrides();
+renderOverridesIndicator();
+
+// Obtain dynamic variables from server
 const values = (window as any)._env_;
 
 // Build-time variables
 const build: BuildTimeEnvironment = {
-  posthogKey: process.env.REACT_APP_POSTHOG_KEY,
-  segmentKey: process.env.REACT_APP_SEGMENT_KEY,
-  ga4Key: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
-  version: process.env.REACT_APP_VERSION || 'dev',
+  posthogKey: getValue('REACT_APP_POSTHOG_KEY', process.env.REACT_APP_POSTHOG_KEY),
+  segmentKey: getValue('REACT_APP_SEGMENT_KEY', process.env.REACT_APP_SEGMENT_KEY),
+  ga4Key: getValue('REACT_APP_GOOGLE_ANALYTICS_ID', process.env.REACT_APP_GOOGLE_ANALYTICS_ID),
+  version: getValue('REACT_APP_VERSION', process.env.REACT_APP_VERSION) || 'dev',
 };
 
 // Dynamic variables
 const env: DynamicEnvironment = {
-  apiUrl: values?.REACT_APP_API_SERVER_ENDPOINT,
-  basename: values?.REACT_APP_ROOT_ROUTE,
-  disableTelemetry: values?.REACT_APP_DISABLE_TELEMETRY === 'true',
+  apiUrl: getValue('REACT_APP_API_SERVER_ENDPOINT', values?.REACT_APP_API_SERVER_ENDPOINT),
+  basename: getValue('REACT_APP_ROOT_ROUTE', values?.REACT_APP_ROOT_ROUTE),
+  disableTelemetry: getValue('REACT_APP_DISABLE_TELEMETRY', values?.REACT_APP_DISABLE_TELEMETRY) === 'true',
 };
 
 type BuildTimeEnvironment = {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,0 +1,79 @@
+import {config} from '@constants/config';
+
+// Allow overriding the configuration temporarily,
+// so E2E tests may be completed easily on any environment.
+let overrides: Record<string, any> = JSON.parse(localStorage.getItem(config.overrides) || '{}');
+
+export const hasOverridesApplied = () => {
+  return Object.keys(overrides).length > 0;
+};
+
+export const setOverrides = (newOverrides: Record<string, any>) => {
+  overrides = newOverrides;
+  localStorage.setItem(config.overrides, JSON.stringify(newOverrides));
+};
+
+export const resetOverrides = () => {
+  setOverrides({});
+};
+
+// Create red line on top of the dashboard, to indicate overrides enabled
+export const renderOverridesIndicator = () => {
+  const element = document.querySelector('#overrides-indicator');
+  if (hasOverridesApplied()) {
+    if (!element) {
+      const newElement = document.createElement('div');
+      newElement.id = 'overrides-indicator';
+      newElement.style.position = 'absolute';
+      newElement.style.top = '0px';
+      newElement.style.left = '0px';
+      newElement.style.width = '100%';
+      newElement.style.height = '5px';
+      newElement.style.zIndex = '4444444';
+      newElement.style.background = 'red';
+      newElement.style.cursor = 'pointer';
+      newElement.addEventListener('click', () => {
+        resetOverrides();
+        window.location.reload();
+      });
+      document.body.appendChild(newElement);
+    }
+  } else {
+    element?.parentNode?.removeChild(element);
+  }
+};
+
+// URL with "?~" will reset overrides,
+// URL with "?~<env>=<value>" pairs will update them
+export const applyUrlOverrides = () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('~')) {
+    resetOverrides();
+  } else {
+    const newOverrides: Record<string, any> = {};
+    params.forEach((value, key) => {
+      if (/^~/.test(key)) {
+        // To simplify testing, setup simpler aliases,
+        // ~REACT_APP_ENTERPRISE=true  ==  ~ENTERPRISE=true  ==  ~enterprise=true
+        newOverrides[
+          key
+            .substring(1)
+            .toUpperCase()
+            .replace(/^(REACT_APP)?_*/, 'REACT_APP_')
+        ] = value;
+        params.delete(key);
+      }
+    });
+    setOverrides({...overrides, ...newOverrides});
+
+    // Delete the overrides from URL
+    const newSearch = params.toString().replace(/^\?$/, '');
+    if (newSearch !== window.location.search) {
+      window.history.replaceState(null, '', window.location.pathname + newSearch);
+    }
+  }
+};
+
+export const getValue = <T>(name: string, value: T): T => {
+  return name in overrides ? overrides[name] : value;
+};

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -4,7 +4,7 @@ import {config} from '@constants/config';
 // so E2E tests may be completed easily on any environment.
 let overrides: Record<string, any> = JSON.parse(localStorage.getItem(config.overrides) || '{}');
 
-export const hasOverridesApplied = () => {
+export const areOverridesApplied = () => {
   return Object.keys(overrides).length > 0;
 };
 
@@ -20,7 +20,7 @@ export const resetOverrides = () => {
 // Create red line on top of the dashboard, to indicate overrides enabled
 export const renderOverridesIndicator = () => {
   const element = document.querySelector('#overrides-indicator');
-  if (hasOverridesApplied()) {
+  if (areOverridesApplied()) {
     if (!element) {
       const newElement = document.createElement('div');
       newElement.id = 'overrides-indicator';


### PR DESCRIPTION
## Changes

- More details in the kubeshop/testkube#3948 ticket

## Fixes

- kubeshop/testkube#3948

## How to test it

- https://testkube-dashboard-git-dawid-featadd-opti-844689-testkube-cloud.vercel.app/?~api_server_endpoint=https://demo.testkube.io/results/v1
- see that `https://demo.testkube.io` is used as a server, like it would be environment variable
- click on red line on top of page, to reset overrides

## screenshots

![image](https://github.com/kubeshop/testkube-dashboard/assets/3843526/0361563b-b198-4770-8543-ea13654e2e58)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
