### PR TITLE
fix: handling query params in overrides mechanism

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -67,7 +67,7 @@ export const applyUrlOverrides = () => {
     setOverrides({...overrides, ...newOverrides});
 
     // Delete the overrides from URL
-    const newSearch = params.toString().replace(/^\?$/, '');
+    const newSearch = `?${params.toString()}`.replace(/^\?$/, '');
     if (newSearch !== window.location.search) {
       window.history.replaceState(null, '', window.location.pathname + newSearch);
     }


### PR DESCRIPTION
## Changes

- `URLSearchParams.toString` doesn't have `?` at the beginning, so it needs to be added for the URL

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
