### PR TITLE
feat: allow void ScrollTrigger without `onScroll` event

### DIFF
--- a/src/components/atoms/ScrollTrigger/ScrollTrigger.spec.tsx
+++ b/src/components/atoms/ScrollTrigger/ScrollTrigger.spec.tsx
@@ -35,7 +35,7 @@ describe('atoms', () => {
         expect(onScroll).toHaveBeenCalledTimes(0);
       });
 
-      it('should emit event when the disabled ScrollTrigger is in viewport, and it is changed to enabled', () => {
+      it('should not emit event immediately after the ScrollTrigger is enabled', () => {
         const onScroll = jest.fn();
         const result = render(<ScrollTrigger disabled onScroll={onScroll} />);
 
@@ -44,7 +44,7 @@ describe('atoms', () => {
           result.rerender(<ScrollTrigger onScroll={onScroll} />);
         });
 
-        expect(onScroll).toHaveBeenCalledTimes(1);
+        expect(onScroll).toHaveBeenCalledTimes(0);
       });
     });
 

--- a/src/components/atoms/ScrollTrigger/ScrollTrigger.tsx
+++ b/src/components/atoms/ScrollTrigger/ScrollTrigger.tsx
@@ -25,7 +25,7 @@ const InternalScrollTrigger: React.FC<ScrollTriggerProps> = memo(props => {
   return <StyledScrollTrigger ref={ref} style={style} />;
 });
 
-const ScrollTrigger: React.FC<ScrollTriggerProps> = ({onScroll, ...rest}) =>
-  onScroll ? <InternalScrollTrigger onScroll={onScroll} {...rest} /> : null;
+const ScrollTrigger: React.FC<ScrollTriggerProps> = ({onScroll, disabled, ...rest}) =>
+  onScroll && !disabled ? <InternalScrollTrigger onScroll={onScroll} {...rest} /> : null;
 
 export default ScrollTrigger;

--- a/src/components/atoms/ScrollTrigger/ScrollTrigger.tsx
+++ b/src/components/atoms/ScrollTrigger/ScrollTrigger.tsx
@@ -7,10 +7,10 @@ import {StyledScrollTrigger} from './ScrollTrigger.styled';
 type ScrollTriggerProps = {
   offset?: number;
   disabled?: boolean;
-  onScroll: () => void;
+  onScroll?: () => void;
 };
 
-const ScrollTrigger: React.FC<ScrollTriggerProps> = props => {
+const InternalScrollTrigger: React.FC<ScrollTriggerProps> = memo(props => {
   const {offset = 0, disabled = false, onScroll} = props;
   const style = useMemo(() => ({top: `${-offset}px`}), [offset]);
   const ref = useRef(null);
@@ -18,11 +18,14 @@ const ScrollTrigger: React.FC<ScrollTriggerProps> = props => {
 
   useEffect(() => {
     if (isInViewport && !disabled) {
-      onScroll();
+      onScroll?.();
     }
   }, [isInViewport, disabled]);
 
   return <StyledScrollTrigger ref={ref} style={style} />;
-};
+});
 
-export default memo(ScrollTrigger);
+const ScrollTrigger: React.FC<ScrollTriggerProps> = ({onScroll, ...rest}) =>
+  onScroll ? <InternalScrollTrigger onScroll={onScroll} {...rest} /> : null;
+
+export default ScrollTrigger;


### PR DESCRIPTION
## Changes

- Simplify abstract usage of `ScrollTrigger`
- `onScroll` is not required, it will not render anything though

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3958

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
