### PR TITLE
tech: add types and cleanup a little EntityGridItem components

### DIFF
--- a/src/components/molecules/EntityGrid/EntityGridItem.tsx
+++ b/src/components/molecules/EntityGrid/EntityGridItem.tsx
@@ -12,10 +12,10 @@ import EntityGridItemPure from './EntityGridItemPure';
 
 const EntityGridItem: React.FC<any> = props => {
   const {item, onClick} = props;
-  const {dataItem} = item;
+  const {dataItem, latestExecution} = item;
 
   const {isClusterAvailable} = useContext(MainContext);
-  const {useGetMetrics, entity, useAbortAllExecutions} = useContext(EntityListContext);
+  const {useGetMetrics, entity} = useContext(EntityListContext);
 
   const ref = useRef(null);
   const isInViewport = useInViewport(ref);
@@ -25,16 +25,14 @@ const EntityGridItem: React.FC<any> = props => {
     {skip: !isInViewport || !isClusterAvailable, pollingInterval: PollingIntervals.halfMin}
   );
 
-  const [abortAllExecutions] = useAbortAllExecutions();
-
   return (
     <EntityGridItemPure
       ref={ref}
-      item={item}
+      item={dataItem}
+      latestExecution={latestExecution}
       onClick={onClick}
-      entity={entity}
       metrics={metrics}
-      abortAllExecutions={abortAllExecutions}
+      dataTest={`${entity}-list-item`}
     />
   );
 };

--- a/src/components/molecules/EntityGrid/EntityGridItemExecutionTime.tsx
+++ b/src/components/molecules/EntityGrid/EntityGridItemExecutionTime.tsx
@@ -1,0 +1,39 @@
+import React, {FC, memo} from 'react';
+import {useInterval, useUpdate} from 'react-use';
+
+import {Tooltip} from 'antd';
+
+import {Text} from '@custom-antd';
+
+import Colors from '@styles/Colors';
+
+import {displayTimeBetweenDates} from '@utils/displayTimeBetweenDates';
+import {formatExecutionDate} from '@utils/formatDate';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+
+const TimeAgo: FC<{time: Date | string}> = ({time}) => {
+  const now = new Date();
+  const then = new Date(time);
+
+  const update = useUpdate();
+  useInterval(update, now.getTime() - then.getTime() > 10 * MINUTE ? MINUTE : 5 * SECOND);
+
+  return <>{displayTimeBetweenDates(now, then).long}</>;
+};
+
+const EntityGridItemExecutionTime: FC<{time?: Date | string}> = ({time}) => (
+  <Tooltip
+    title={time ? formatExecutionDate(new Date(time)) : null}
+    placement="bottomRight"
+    mouseEnterDelay={0.39}
+    mouseLeaveDelay={0.1}
+  >
+    <Text color={Colors.slate200} className="regular small">
+      {time ? <TimeAgo time={time} /> : null}
+    </Text>
+  </Tooltip>
+);
+
+export default memo(EntityGridItemExecutionTime);

--- a/src/components/molecules/EntityGrid/EntityGridItemPure.tsx
+++ b/src/components/molecules/EntityGrid/EntityGridItemPure.tsx
@@ -6,6 +6,10 @@ import {ExecutorIcon, StatusIcon} from '@atoms';
 
 import {Text} from '@custom-antd';
 
+import {Execution} from '@models/execution';
+import {ExecutionMetrics} from '@models/metrics';
+import {LatestExecution} from '@models/test';
+
 import {LabelsList, MetricsBarChart} from '@molecules';
 
 import Colors from '@styles/Colors';
@@ -15,85 +19,104 @@ import {formatDuration, formatExecutionDate} from '@utils/formatDate';
 
 import {DetailsWrapper, ItemColumn, ItemRow, ItemWrapper, RowsWrapper, StyledMetricItem} from './EntityGrid.styled';
 
-const EntityGridItemPure: React.FC<any> = memo(
-  forwardRef<HTMLDivElement, any>((props, ref) => {
-    const {item, onClick, entity, metrics} = props;
-    const {dataItem, latestExecution} = item;
+interface Item {
+  type: string;
+  testIcon?: string;
+  name: string;
+  labels: Record<string, string>;
+}
 
-    const status = latestExecution ? latestExecution?.executionResult?.status || latestExecution?.status : 'pending';
-    const executions = metrics?.executions;
-    const dataTestValue = `${entity}-list-item`;
+interface Metrics {
+  executions: ExecutionMetrics[];
+  failedExecutions: number;
+  passFailRatio: number;
+  executionDurationP50ms: number;
+}
 
-    const click = useCallback(() => {
-      onClick(item);
-    }, [onClick, item]);
+interface EntityGridItemPureProps {
+  item: Item;
+  latestExecution?: LatestExecution | Execution;
+  metrics?: Metrics;
+  onClick: (item: Item) => void;
+  dataTest: string;
+}
 
-    return (
-      <ItemWrapper onClick={click} ref={ref} data-test={dataTestValue}>
-        <DetailsWrapper>
-          <ItemRow $flex={0}>
-            <ItemColumn $isStretch>
-              <StatusIcon status={status} />
-              {dataItem?.type ? <ExecutorIcon type={dataItem?.testIcon} /> : null}
-              <div style={{overflow: 'hidden', flex: 1, display: 'flex'}}>
-                <Text className="regular big" ellipsis title={dataItem?.name}>
-                  {dataItem?.name}
-                </Text>
-              </div>
-            </ItemColumn>
-            <ItemColumn>
-              <Tooltip
-                title={latestExecution?.startTime ? formatExecutionDate(new Date(latestExecution?.startTime)) : null}
-                placement="bottomRight"
-                mouseEnterDelay={0.39}
-                mouseLeaveDelay={0.1}
-              >
-                <Text color={Colors.slate200} className="regular small">
-                  {latestExecution?.startTime
-                    ? displayTimeBetweenDates(new Date(), new Date(latestExecution?.startTime)).long
-                    : null}
-                </Text>
-              </Tooltip>
-            </ItemColumn>
+const EntityGridItemPure = forwardRef<HTMLDivElement, EntityGridItemPureProps>((props, ref) => {
+  const {item, latestExecution, onClick, dataTest, metrics} = props;
+
+  const status =
+    (latestExecution as Execution)?.executionResult?.status ||
+    (latestExecution as LatestExecution)?.status ||
+    'pending';
+  const executions = metrics?.executions;
+
+  const click = useCallback(() => {
+    onClick(item);
+  }, [onClick, item]);
+
+  return (
+    <ItemWrapper onClick={click} ref={ref} data-test={dataTest}>
+      <DetailsWrapper>
+        <ItemRow $flex={0}>
+          <ItemColumn $isStretch>
+            <StatusIcon status={status} />
+            {item.type ? <ExecutorIcon type={item.testIcon} /> : null}
+            <div style={{overflow: 'hidden', flex: 1, display: 'flex'}}>
+              <Text className="regular big" ellipsis title={item.name}>
+                {item.name}
+              </Text>
+            </div>
+          </ItemColumn>
+          <ItemColumn>
+            <Tooltip
+              title={latestExecution?.startTime ? formatExecutionDate(new Date(latestExecution?.startTime)) : null}
+              placement="bottomRight"
+              mouseEnterDelay={0.39}
+              mouseLeaveDelay={0.1}
+            >
+              <Text color={Colors.slate200} className="regular small">
+                {latestExecution?.startTime
+                  ? displayTimeBetweenDates(new Date(), new Date(latestExecution?.startTime)).long
+                  : null}
+              </Text>
+            </Tooltip>
+          </ItemColumn>
+        </ItemRow>
+        <RowsWrapper>
+          <ItemRow $flex={1}>
+            {item.labels ? <LabelsList labels={item.labels} shouldSkipLabels howManyLabelsToShow={2} /> : null}
           </ItemRow>
-          <RowsWrapper>
-            <ItemRow $flex={1}>
-              {dataItem?.labels ? (
-                <LabelsList labels={dataItem?.labels} shouldSkipLabels howManyLabelsToShow={2} />
-              ) : null}
-            </ItemRow>
-            <ItemRow $flex={1}>
-              <StyledMetricItem>
-                <Text className="small uppercase" color={Colors.slate500}>
-                  pass/fail ratio
-                </Text>
-                <Text className="big regular">
-                  {metrics?.passFailRatio ? `${metrics?.passFailRatio.toFixed(2)}%` : '0%'}
-                </Text>
-              </StyledMetricItem>
-              <StyledMetricItem>
-                <Text className="small uppercase" color={Colors.slate500}>
-                  p50
-                </Text>
-                <Text className="big regular">
-                  {metrics?.executionDurationP50ms ? formatDuration(metrics?.executionDurationP50ms / 1000) : '-'}
-                </Text>
-              </StyledMetricItem>
-              <StyledMetricItem>
-                <Text className="small uppercase" color={Colors.slate500}>
-                  failed executions
-                </Text>
-                <Text className="big regular">{metrics?.failedExecutions || '-'}</Text>
-              </StyledMetricItem>
-              <StyledMetricItem>
-                <MetricsBarChart data={executions} chartHeight={38} barWidth={6} />
-              </StyledMetricItem>
-            </ItemRow>
-          </RowsWrapper>
-        </DetailsWrapper>
-      </ItemWrapper>
-    );
-  })
-);
+          <ItemRow $flex={1}>
+            <StyledMetricItem>
+              <Text className="small uppercase" color={Colors.slate500}>
+                pass/fail ratio
+              </Text>
+              <Text className="big regular">
+                {metrics?.passFailRatio ? `${metrics?.passFailRatio.toFixed(2)}%` : '0%'}
+              </Text>
+            </StyledMetricItem>
+            <StyledMetricItem>
+              <Text className="small uppercase" color={Colors.slate500}>
+                p50
+              </Text>
+              <Text className="big regular">
+                {metrics?.executionDurationP50ms ? formatDuration(metrics?.executionDurationP50ms / 1000) : '-'}
+              </Text>
+            </StyledMetricItem>
+            <StyledMetricItem>
+              <Text className="small uppercase" color={Colors.slate500}>
+                failed executions
+              </Text>
+              <Text className="big regular">{metrics?.failedExecutions || '-'}</Text>
+            </StyledMetricItem>
+            <StyledMetricItem>
+              <MetricsBarChart data={executions} chartHeight={38} barWidth={6} />
+            </StyledMetricItem>
+          </ItemRow>
+        </RowsWrapper>
+      </DetailsWrapper>
+    </ItemWrapper>
+  );
+});
 
-export default EntityGridItemPure;
+export default memo(EntityGridItemPure);

--- a/src/components/molecules/EntityGrid/EntityGridItemPure.tsx
+++ b/src/components/molecules/EntityGrid/EntityGridItemPure.tsx
@@ -1,7 +1,5 @@
 import React, {forwardRef, memo, useCallback} from 'react';
 
-import {Tooltip} from 'antd';
-
 import {ExecutorIcon, StatusIcon} from '@atoms';
 
 import {Text} from '@custom-antd';
@@ -14,10 +12,10 @@ import {LabelsList, MetricsBarChart} from '@molecules';
 
 import Colors from '@styles/Colors';
 
-import {displayTimeBetweenDates} from '@utils/displayTimeBetweenDates';
-import {formatDuration, formatExecutionDate} from '@utils/formatDate';
+import {formatDuration} from '@utils/formatDate';
 
 import {DetailsWrapper, ItemColumn, ItemRow, ItemWrapper, RowsWrapper, StyledMetricItem} from './EntityGrid.styled';
+import EntityGridItemExecutionTime from './EntityGridItemExecutionTime';
 
 interface Item {
   type: string;
@@ -68,18 +66,7 @@ const EntityGridItemPure = forwardRef<HTMLDivElement, EntityGridItemPureProps>((
             </div>
           </ItemColumn>
           <ItemColumn>
-            <Tooltip
-              title={latestExecution?.startTime ? formatExecutionDate(new Date(latestExecution?.startTime)) : null}
-              placement="bottomRight"
-              mouseEnterDelay={0.39}
-              mouseLeaveDelay={0.1}
-            >
-              <Text color={Colors.slate200} className="regular small">
-                {latestExecution?.startTime
-                  ? displayTimeBetweenDates(new Date(), new Date(latestExecution?.startTime)).long
-                  : null}
-              </Text>
-            </Tooltip>
+            <EntityGridItemExecutionTime time={latestExecution?.startTime} />
           </ItemColumn>
         </ItemRow>
         <RowsWrapper>

--- a/src/components/molecules/LabelsList/LabelsList.tsx
+++ b/src/components/molecules/LabelsList/LabelsList.tsx
@@ -1,3 +1,5 @@
+import {memo} from 'react';
+
 import {Popover} from 'antd';
 
 import {LabelListItem} from '@atoms';
@@ -63,4 +65,4 @@ const LabelsList: React.FC<LabelsListProps> = props => {
   );
 };
 
-export default LabelsList;
+export default memo(LabelsList);

--- a/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -15,8 +15,8 @@ import useTrackTimeAnalytics from '@hooks/useTrackTimeAnalytics';
 import {Entity, EntityListBlueprint} from '@models/entity';
 import {ModalConfigProps} from '@models/modal';
 import {OnDataChangeInterface} from '@models/onDataChange';
-import {TestWithExecutionRedux} from '@models/test';
-import {TestSuiteWithExecutionRedux} from '@models/testSuite';
+import {Test} from '@models/test';
+import {TestSuite} from '@models/testSuite';
 
 import {EntityGrid} from '@molecules';
 
@@ -92,8 +92,8 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
   };
 
   const onNavigateToDetails = useCallback(
-    (item: TestWithExecutionRedux | TestSuiteWithExecutionRedux) => {
-      navigate(`/${entity}/executions/${item.dataItem.name}`);
+    (item: Test | TestSuite) => {
+      navigate(`/${entity}/executions/${item.name}`);
     },
     [navigate, entity]
   );


### PR DESCRIPTION
## Changes

- avoid nested `dataItem` / `latestExecution` in the pure component
- delete unused `useAbortAllExecutions`
- use the actual `dataTest` property instead of building it internally from the `entity`
- optimize it a little (avoid re-rendering the tooltip, labels and dates)
- add TypeScript definition

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3958

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
