### PR TITLE
feat: add simple wrapper for page metadata

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -1,5 +1,4 @@
 import {useContext, useEffect, useState} from 'react';
-import {Helmet} from 'react-helmet';
 
 import {Select, Space, Tabs} from 'antd';
 
@@ -8,7 +7,7 @@ import {MutationTrigger} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 
 import {ExecutorIcon} from '@atoms';
 
-import {AnalyticsContext, ConfigContext, DashboardContext, EntityDetailsContext} from '@contexts';
+import {AnalyticsContext, DashboardContext, EntityDetailsContext} from '@contexts';
 
 import {Button, Text} from '@custom-antd';
 
@@ -19,6 +18,8 @@ import {Entity} from '@models/entity';
 import {Option as OptionType} from '@models/form';
 
 import {CLICommands, DotsDropdown, LabelsList, MetricsBarChart, RunningContextType, notificationCall} from '@molecules';
+
+import PageMetadata from '@pages/PageMetadata';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -48,7 +49,6 @@ const filterOptions: OptionType[] = [
 const EntityDetailsContent: React.FC = () => {
   const {entity, entityDetails, defaultStackRoute, metrics, daysFilterValue, setDaysFilterValue, abortAllExecutions} =
     useContext(EntityDetailsContext);
-  const {pageTitle} = useContext(ConfigContext);
   const {analyticsTrack} = useContext(AnalyticsContext);
   const {navigate} = useContext(DashboardContext);
   const mayRun = usePermission(Permissions.runEntity);
@@ -134,10 +134,8 @@ const EntityDetailsContent: React.FC = () => {
 
   return (
     <StyledContainer>
-      <Helmet>
-        <title>{name ? `${name} | ${pageTitle}` : pageTitle}</title>
-        <meta name="description" content={`${description}`} />
-      </Helmet>
+      <PageMetadata title={name} description={description} />
+
       <StyledPageHeader
         onBack={() => navigate(defaultStackRoute)}
         title={name || 'Loading...'}

--- a/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -1,12 +1,11 @@
 import React, {memo, useCallback, useContext, useEffect, useState} from 'react';
-import {Helmet} from 'react-helmet';
 import {usePrevious} from 'react-use';
 
 import {LoadingOutlined} from '@ant-design/icons';
 
 import {ScrollTrigger} from '@atoms';
 
-import {ConfigContext, DashboardContext, MainContext} from '@contexts';
+import {DashboardContext, MainContext} from '@contexts';
 
 import {Button, Modal} from '@custom-antd';
 
@@ -19,6 +18,8 @@ import {TestWithExecutionRedux} from '@models/test';
 import {TestSuiteWithExecutionRedux} from '@models/testSuite';
 
 import {EntityGrid} from '@molecules';
+
+import PageMetadata from '@pages/PageMetadata';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -63,7 +64,6 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
   const [isApplyingFilters, setIsApplyingFilters] = useState(false);
   const [isLoadingNext, setIsLoadingNext] = useState(false);
 
-  const {pageTitle: mainPageTitle} = useContext(ConfigContext);
   const {dispatch, isClusterAvailable} = useContext(MainContext);
   const {navigate} = useContext(DashboardContext);
   const apiEndpoint = useApiEndpoint();
@@ -155,10 +155,8 @@ const EntityListContent: React.FC<EntityListBlueprint> = props => {
 
   return (
     <StyledContainer>
-      <Helmet>
-        <title>{`${pageTitle} | ${mainPageTitle}`}</title>
-        <meta name="description" content={`${PageDescription}`} />
-      </Helmet>
+      <PageMetadata title={pageTitle} />
+
       {dataLayers[entity]}
       <Header>
         <EntityListTitle

--- a/src/components/organisms/PageBlueprint/PageBlueprint.tsx
+++ b/src/components/organisms/PageBlueprint/PageBlueprint.tsx
@@ -1,11 +1,10 @@
-import {PropsWithChildren, useContext} from 'react';
-import {Helmet} from 'react-helmet';
+import {PropsWithChildren} from 'react';
 
 import {Space} from 'antd';
 
-import {ConfigContext} from '@contexts';
-
 import {Text, Title} from '@custom-antd';
+
+import PageMetadata from '@pages/PageMetadata';
 
 import Colors from '@styles/Colors';
 
@@ -19,14 +18,11 @@ type PageBlueprintProps = {
 
 const PageBlueprint: React.FC<PropsWithChildren<PageBlueprintProps>> = props => {
   const {children, title, description, headerButton} = props;
-  const {pageTitle} = useContext(ConfigContext);
 
   return (
     <PageBlueprintWrapper>
-      <Helmet>
-        <title>{`${title} | ${pageTitle}`}</title>
-        <meta name="description" content={`${description}`} />
-      </Helmet>
+      <PageMetadata title={title} description={typeof description === 'string' ? description : undefined} />
+
       <PageBlueprintHeader>
         <Space direction="vertical" size={15}>
           <Title color={Colors.slate50} ellipsis>

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorDetails.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorDetails.tsx
@@ -1,10 +1,11 @@
 import {useContext, useEffect, useState} from 'react';
-import {Helmet} from 'react-helmet';
 import {useParams} from 'react-router-dom';
 
 import {Tabs} from 'antd';
 
-import {ConfigContext, DashboardContext, MainContext} from '@contexts';
+import {DashboardContext, MainContext} from '@contexts';
+
+import PageMetadata from '@pages/PageMetadata';
 
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentExecutor, setCurrentExecutor, setExecutorData} from '@redux/reducers/executorsSlice';
@@ -18,8 +19,7 @@ import ExecutorSettings from './ExecutorSettings';
 
 const ExecutorDetails: React.FC = () => {
   const {dispatch, isClusterAvailable} = useContext(MainContext);
-  const {navigate, location} = useContext(DashboardContext);
-  const {pageTitle} = useContext(ConfigContext);
+  const {navigate} = useContext(DashboardContext);
   const {id: name} = useParams() as {id: string};
 
   const currentExecutorDetails = useAppSelector(selectCurrentExecutor);
@@ -43,9 +43,8 @@ const ExecutorDetails: React.FC = () => {
 
   return (
     <StyledContainer>
-      <Helmet>
-        <title>{`${name} | Executors | ${pageTitle}`}</title>
-      </Helmet>
+      <PageMetadata title={`${name} | Executors`} />
+
       <StyledPageHeader onBack={() => navigate('/executors')} title={name} className="testkube-pageheader" />
       <Tabs
         activeKey={activeTabKey}

--- a/src/components/pages/PageMetadata.tsx
+++ b/src/components/pages/PageMetadata.tsx
@@ -1,0 +1,21 @@
+import React, {FC, useContext} from 'react';
+import {Helmet} from 'react-helmet';
+
+import {ConfigContext} from '@contexts';
+
+interface HeadProps {
+  title?: string;
+  description?: string;
+}
+
+const PageMetadata: FC<HeadProps> = ({title, description}) => {
+  const {pageTitle: mainPageTitle} = useContext(ConfigContext);
+  return (
+    <Helmet>
+      <title>{title ? `${title} | ${mainPageTitle}` : mainPageTitle}</title>
+      {description ? <meta name="description" content={description} /> : null}
+    </Helmet>
+  );
+};
+
+export default PageMetadata;

--- a/src/components/pages/Sources/SourceDetails/SourceDetails.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceDetails.tsx
@@ -1,11 +1,12 @@
 import {useContext, useEffect, useState} from 'react';
-import {Helmet} from 'react-helmet';
 
 import {Tabs} from 'antd';
 
-import {ConfigContext, DashboardContext, MainContext} from '@contexts';
+import {DashboardContext, MainContext} from '@contexts';
 
 import useLocation from '@hooks/useLocation';
+
+import PageMetadata from '@pages/PageMetadata';
 
 import {useAppSelector} from '@redux/hooks';
 import {selectCurrentSource, setCurrentSource} from '@redux/reducers/sourcesSlice';
@@ -20,7 +21,6 @@ import SourceSettings from './SourceSettings';
 const SourceDetails = () => {
   const {dispatch, isClusterAvailable} = useContext(MainContext);
   const {location, navigate} = useContext(DashboardContext);
-  const {pageTitle} = useContext(ConfigContext);
 
   const currentSourceDetails = useAppSelector(selectCurrentSource);
 
@@ -44,9 +44,8 @@ const SourceDetails = () => {
 
   return (
     <StyledContainer>
-      <Helmet>
-        <title>{`${name} | Sources | ${pageTitle}`}</title>
-      </Helmet>
+      <PageMetadata title={`${name} | Sources`} />
+
       <StyledPageHeader onBack={() => navigate('/sources')} title={name} className="testkube-pageheader" />
       <Tabs activeKey={activeTabKey} onChange={setActiveTabKey} destroyInactiveTabPane>
         <Tabs.TabPane tab="Settings" key="Settings" disabled={isPageDisabled}>


### PR DESCRIPTION
## Changes

- add a simple wrapper for page metadata
- delete `meta[name=description]` where it was using React nodes, as it ended up with React nodes serialized as JSONs

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3958

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
