### PR TITLE
tech: unify settings pages

### DIFF
--- a/src/components/molecules/SettingsLayout/SettingsLayout.tsx
+++ b/src/components/molecules/SettingsLayout/SettingsLayout.tsx
@@ -1,0 +1,55 @@
+import {FC, ReactElement, memo, useCallback, useLayoutEffect, useMemo, useState} from 'react';
+
+import {SettingsLeftNavigation, StyledTabContentContainer} from '@molecules';
+
+import {StyledSettingsContainer} from './SettingsLayout.styled';
+
+export interface SettingsLayoutTab {
+  id: string;
+  label: string;
+  children: ReactElement<any, any> | null;
+}
+
+interface SettingsLayoutProps {
+  tabs: SettingsLayoutTab[];
+  active?: string;
+  onChange?: (id: string) => void;
+}
+
+const getActiveId = (tabs: SettingsLayoutTab[], id?: string) => {
+  const index = tabs.findIndex(tab => tab.id === id);
+  return index === -1 ? tabs[0]?.id : tabs[index].id;
+};
+
+const SettingsLayout: FC<SettingsLayoutProps> = ({tabs, active, onChange}) => {
+  const [id, setId] = useState(getActiveId(tabs, active));
+  const labels = useMemo(() => tabs.map(tab => tab.label), [tabs]);
+
+  useLayoutEffect(() => {
+    const newId = getActiveId(tabs, active ?? id);
+    if (newId !== id) {
+      setId(newId);
+    }
+  }, [tabs, active]);
+
+  const selectedOption = tabs.findIndex(tab => tab.id === id);
+  const setSelectedOption = useCallback(
+    (index: number) => {
+      const newId = tabs[index].id;
+      if (active == null) {
+        setId(newId);
+      }
+      onChange?.(newId);
+    },
+    [tabs, active, onChange]
+  );
+
+  return (
+    <StyledSettingsContainer>
+      <SettingsLeftNavigation options={labels} selectedOption={selectedOption} setSelectedOption={setSelectedOption} />
+      <StyledTabContentContainer key={id}>{tabs[selectedOption]?.children}</StyledTabContentContainer>
+    </StyledSettingsContainer>
+  );
+};
+
+export default memo(SettingsLayout);

--- a/src/components/molecules/SettingsLayout/index.ts
+++ b/src/components/molecules/SettingsLayout/index.ts
@@ -1,2 +1,3 @@
 export {StyledTabContentContainer} from './SettingsLayout.styled';
 export {StyledSettingsContainer} from './SettingsLayout.styled';
+export {default, type SettingsLayoutTab} from './SettingsLayout';

--- a/src/components/molecules/SettingsLeftNavigation/SettingsLeftNavigation.tsx
+++ b/src/components/molecules/SettingsLeftNavigation/SettingsLeftNavigation.tsx
@@ -1,3 +1,5 @@
+import {memo} from 'react';
+
 import {Text} from '@custom-antd';
 
 import Colors from '@styles/Colors';
@@ -26,4 +28,4 @@ const SettingsLeftNavigation: React.FC<SettingsLeftNavigationProps> = props => {
   );
 };
 
-export default SettingsLeftNavigation;
+export default memo(SettingsLeftNavigation);

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -21,8 +21,12 @@ export {default as MetricsBarChart} from './MetricsBarChart';
 export {default as LabelsSelect} from './LabelsSelect';
 export {default as Hint} from './Hint';
 export {default as SettingsLeftNavigation} from './SettingsLeftNavigation';
-export {StyledTabContentContainer} from './SettingsLayout';
-export {StyledSettingsContainer} from './SettingsLayout';
+export {
+  default as SettingsLayout,
+  type SettingsLayoutTab,
+  StyledSettingsContainer,
+  StyledTabContentContainer,
+} from './SettingsLayout';
 export {default as DeleteEntityModal} from './DeleteEntityModal';
 export {default as Definition} from './Definition';
 export {default as DotsDropdown} from './DotsDropdown';

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/Settings.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/Settings.tsx
@@ -1,13 +1,10 @@
-import React, {useContext, useEffect, useMemo, useState} from 'react';
+import React, {ReactElement, useContext} from 'react';
 
-import {EntityDetailsContext, MainContext} from '@contexts';
+import {EntityDetailsContext} from '@contexts';
 
 import {Entity} from '@models/entity';
 
-import {SettingsLeftNavigation, StyledSettingsContainer, StyledTabContentContainer} from '@molecules';
-
-import {useAppSelector} from '@redux/hooks';
-import {closeSettingsTabConfig, selectRedirectTarget} from '@redux/reducers/configSlice';
+import {SettingsLayout} from '@molecules';
 
 import SettingsDefinition from './SettingsDefinition/SettingsDefinition';
 import SettingsExecution from './SettingsExecution';
@@ -17,61 +14,39 @@ import SettingsTest from './SettingsTest';
 import SettingsTests from './SettingsTests';
 import SettingsVariables from './SettingsVariables';
 
-const tabConfig: Record<Entity, JSX.Element[]> = {
-  'test-suites': [
-    <General />,
-    <SettingsTests />,
-    <SettingsVariables />,
-    <SettingsScheduling />,
-    <SettingsDefinition />,
-  ],
-  tests: [
-    <General />,
-    <SettingsTest />,
-    <SettingsExecution />,
-    <SettingsVariables />,
-    <SettingsScheduling />,
-    <SettingsDefinition />,
-  ],
-};
+const testSettings = (
+  <SettingsLayout
+    tabs={[
+      {id: 'general', label: 'General', children: <General />},
+      {id: 'test', label: 'Test', children: <SettingsTest />},
+      {id: 'execution', label: 'Execution', children: <SettingsExecution />},
+      {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
+      {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
+      {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
+    ]}
+  />
+);
 
-const navigationOptionsConfig: Record<Entity, string[]> = {
-  'test-suites': ['General', 'Tests', 'Variables & Secrets', 'Scheduling', 'Definition'],
-  tests: ['General', 'Test', 'Execution', 'Variables & Secrets', 'Scheduling', 'Definition'],
+const testSuiteSettings = (
+  <SettingsLayout
+    tabs={[
+      {id: 'general', label: 'General', children: <General />},
+      {id: 'tests', label: 'Tests', children: <SettingsTests />},
+      {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
+      {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
+      {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
+    ]}
+  />
+);
+
+const tabsConfigMap: Record<Entity, ReactElement<any, any>> = {
+  'test-suites': testSuiteSettings,
+  tests: testSettings,
 };
 
 const Settings: React.FC = () => {
-  const {dispatch} = useContext(MainContext);
   const {entity} = useContext(EntityDetailsContext);
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState(0);
-
-  const {settingsTabConfig} = useAppSelector(selectRedirectTarget);
-
-  useEffect(() => {
-    if (settingsTabConfig && entity === settingsTabConfig.entity) {
-      setSelectedSettingsTab(
-        typeof settingsTabConfig.tab === 'string'
-          ? navigationOptionsConfig[entity].findIndex(tab => tab === settingsTabConfig.tab)
-          : settingsTabConfig.tab
-      );
-      dispatch(closeSettingsTabConfig());
-    }
-  }, [settingsTabConfig, dispatch]);
-
-  const subTabsMap = useMemo(() => tabConfig[entity], [entity]);
-
-  return (
-    <StyledSettingsContainer>
-      {entity ? (
-        <SettingsLeftNavigation
-          options={navigationOptionsConfig[entity]}
-          selectedOption={selectedSettingsTab}
-          setSelectedOption={setSelectedSettingsTab}
-        />
-      ) : null}
-      <StyledTabContentContainer>{subTabsMap[selectedSettingsTab]}</StyledTabContentContainer>
-    </StyledSettingsContainer>
-  );
+  return tabsConfigMap[entity];
 };
 
 export default Settings;

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorSettings.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorSettings.tsx
@@ -1,29 +1,21 @@
-import {useState} from 'react';
+import {memo} from 'react';
 
-import {SettingsLeftNavigation, StyledSettingsContainer, StyledTabContentContainer} from '@molecules';
+import {SettingsLayout} from '@molecules';
 
 import CommandAndArguments from './CommandAndArguments';
 import ContainerImage from './ContainerImage';
 import ExecutorDefinition from './ExecutorDefinition';
 import General from './General';
 
-const tabsConfig = [<General />, <ContainerImage />, <CommandAndArguments />, <ExecutorDefinition />];
+const ExecutorSettings = () => (
+  <SettingsLayout
+    tabs={[
+      {id: 'general', label: 'General', children: <General />},
+      {id: 'image', label: 'Container image', children: <ContainerImage />},
+      {id: 'command', label: 'Command & Arguments', children: <CommandAndArguments />},
+      {id: 'definition', label: 'Definition', children: <ExecutorDefinition />},
+    ]}
+  />
+);
 
-const navigationOptionsConfig: string[] = ['General', 'Container image', 'Command & Arguments', 'Definition'];
-
-const ExecutorSettings = () => {
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState(0);
-
-  return (
-    <StyledSettingsContainer>
-      <SettingsLeftNavigation
-        options={navigationOptionsConfig}
-        selectedOption={selectedSettingsTab}
-        setSelectedOption={setSelectedSettingsTab}
-      />
-      <StyledTabContentContainer>{tabsConfig[selectedSettingsTab]}</StyledTabContentContainer>
-    </StyledSettingsContainer>
-  );
-};
-
-export default ExecutorSettings;
+export default memo(ExecutorSettings);

--- a/src/components/pages/GlobalSettings/GlobalSettings.tsx
+++ b/src/components/pages/GlobalSettings/GlobalSettings.tsx
@@ -1,30 +1,17 @@
-import {useState} from 'react';
+import {FC} from 'react';
 
-import {SettingsLeftNavigation, StyledSettingsContainer, StyledTabContentContainer} from '@molecules';
+import {SettingsLayout} from '@molecules';
 
 import {PageBlueprint} from '@organisms';
 
 import General from './General';
 
-const tabConfig: Array<JSX.Element | null> = [<General />];
+const tabs = [{id: 'general', label: 'General', children: <General />}];
 
-const navigationOptionsConfig: string[] = ['General'];
-
-const GlobalSettings = () => {
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState(0);
-
-  return (
-    <PageBlueprint title="Settings" description="Control everything related to your testkube installation">
-      <StyledSettingsContainer>
-        <SettingsLeftNavigation
-          options={navigationOptionsConfig}
-          selectedOption={selectedSettingsTab}
-          setSelectedOption={setSelectedSettingsTab}
-        />
-        <StyledTabContentContainer>{tabConfig[selectedSettingsTab]}</StyledTabContentContainer>
-      </StyledSettingsContainer>
-    </PageBlueprint>
-  );
-};
+const GlobalSettings: FC = () => (
+  <PageBlueprint title="Settings" description="Control everything related to your testkube installation">
+    <SettingsLayout tabs={tabs} />
+  </PageBlueprint>
+);
 
 export default GlobalSettings;

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/SourceSettings.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/SourceSettings.tsx
@@ -1,27 +1,17 @@
-import {useState} from 'react';
+import {memo} from 'react';
 
-import {SettingsLeftNavigation, StyledSettingsContainer, StyledTabContentContainer} from '@molecules';
+import {SettingsLayout} from '@molecules';
 
 import SourceSettingsDefinition from './Definition';
 import General from './General';
 
-const tabsConfig: Array<JSX.Element> = [<General />, <SourceSettingsDefinition />];
+const SourceSettings = () => (
+  <SettingsLayout
+    tabs={[
+      {id: 'general', label: 'General', children: <General />},
+      {id: 'definition', label: 'Definition', children: <SourceSettingsDefinition />},
+    ]}
+  />
+);
 
-const navigationOptionsConfig: string[] = ['General', 'Definition'];
-
-const SourceSettings = () => {
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState(0);
-
-  return (
-    <StyledSettingsContainer>
-      <SettingsLeftNavigation
-        options={navigationOptionsConfig}
-        selectedOption={selectedSettingsTab}
-        setSelectedOption={setSelectedSettingsTab}
-      />
-      <StyledTabContentContainer>{tabsConfig[selectedSettingsTab]}</StyledTabContentContainer>
-    </StyledSettingsContainer>
-  );
-};
-
-export default SourceSettings;
+export default memo(SourceSettings);

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
@@ -1,29 +1,21 @@
-import {useState} from 'react';
+import {memo} from 'react';
 
-import {SettingsLeftNavigation, StyledSettingsContainer, StyledTabContentContainer} from '@molecules';
+import {SettingsLayout} from '@molecules';
 
 import Definition from './Definition';
 import General from './General';
 import TriggerAction from './TriggerAction';
 import TriggerCondition from './TriggerCondition';
 
-const tabsConfig: Array<JSX.Element> = [<General />, <TriggerCondition />, <TriggerAction />, <Definition />];
+const TriggerSettings = () => (
+  <SettingsLayout
+    tabs={[
+      {id: 'general', label: 'General', children: <General />},
+      {id: 'condition', label: 'Trigger Condition', children: <TriggerCondition />},
+      {id: 'action', label: 'Trigger Action', children: <TriggerAction />},
+      {id: 'definition', label: 'Definition', children: <Definition />},
+    ]}
+  />
+);
 
-const navigationOptionsConfig: string[] = ['General', 'Trigger Condition', 'Trigger Action', 'Definition'];
-
-const TriggerSettings = () => {
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState(0);
-
-  return (
-    <StyledSettingsContainer>
-      <SettingsLeftNavigation
-        options={navigationOptionsConfig}
-        selectedOption={selectedSettingsTab}
-        setSelectedOption={setSelectedSettingsTab}
-      />
-      <StyledTabContentContainer>{tabsConfig[selectedSettingsTab]}</StyledTabContentContainer>
-    </StyledSettingsContainer>
-  );
-};
-
-export default TriggerSettings;
+export default memo(TriggerSettings);


### PR DESCRIPTION
## Changes

- Unify all the settings with `SettingsLayout`
  - It is used as self-controlled at the moment, but it supports being controlled from outside via `active`/`onChange`, so it will be easy to handle routing

## Fixes

- part of kubeshop/testkube#3958

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
