### PR TITLE
fix: make EntityDetailsContainer scrollable on Cloud

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.styled.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.styled.tsx
@@ -1,9 +1,7 @@
 import styled from 'styled-components';
 
 export const EntityDetailsWrapper = styled.div`
-  overflow: hidden;
+  overflow-x: hidden;
 
   display: flex;
-
-  height: 100%;
 `;


### PR DESCRIPTION
## Changes

- The Entity Details are not scrollable on Cloud instance (i.e. https://testkube-cloud-fwatsy5n6-testkube-cloud.vercel.app/organization/tkcorg_9deb42dda2197657/environment/tkcenv_03e3ff499f13ccba/dashboard/tests/executions/soapui-executor-smoke/execution/6489ae1915c7e745d0e7f671)

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
