### PR TITLE
fix: send anonymized query string to GA/GTM / fix: make GTM- tags working

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -90,9 +90,12 @@ const AppRoot: React.FC = () => {
         posthog.opt_in_capturing();
       }
 
-      if (env.ga4Keys.length > 0) {
-        ReactGA.initialize(env.ga4Keys.map(trackingId => ({trackingId})));
-        ReactGA.event('gtm.js');
+      if (env.ga4Key) {
+        ReactGA.initialize(env.ga4Key, {
+          // To make GTM- keys working properly with react-ga4,
+          // we need to override the script URL.
+          gtagUrl: env.ga4Key.startsWith('GTM-') ? 'https://www.googletagmanager.com/gtm.js' : undefined,
+        });
         ReactGA.gtag('consent', 'update', {
           ad_storage: 'granted',
           analytics_storage: 'granted',

--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -25,6 +25,7 @@ import {useAppDispatch} from '@redux/hooks';
 import {useApiEndpoint} from '@services/apiEndpoint';
 import {useGetClusterConfigQuery} from '@services/config';
 
+import anonymizeQueryString from '@utils/anonymizeQueryString';
 import {composeProviders} from '@utils/composeProviders';
 
 import {AnalyticsProvider} from './AnalyticsProvider';
@@ -115,7 +116,7 @@ const AppRoot: React.FC = () => {
   useEffect(() => {
     posthog.capture('$pageview');
 
-    ReactGA.send({hitType: 'pageview', page: location.pathname});
+    ReactGA.send({hitType: 'pageview', page: `${location.pathname}${anonymizeQueryString(location.search)}`});
   }, [location.pathname]);
 
   useEffect(() => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -11,10 +11,7 @@ const values = (window as any)._env_;
 const build: BuildTimeEnvironment = {
   posthogKey: getValue('REACT_APP_POSTHOG_KEY', process.env.REACT_APP_POSTHOG_KEY),
   segmentKey: getValue('REACT_APP_SEGMENT_KEY', process.env.REACT_APP_SEGMENT_KEY),
-  ga4Keys: (getValue('REACT_APP_GOOGLE_ANALYTICS_ID', process.env.REACT_APP_GOOGLE_ANALYTICS_ID) || '')
-    .split(',')
-    .map(key => key.trim())
-    .filter(Boolean),
+  ga4Key: getValue('REACT_APP_GOOGLE_ANALYTICS_ID', process.env.REACT_APP_GOOGLE_ANALYTICS_ID),
   version: getValue('REACT_APP_VERSION', process.env.REACT_APP_VERSION) || 'dev',
 };
 
@@ -28,7 +25,7 @@ const env: DynamicEnvironment = {
 type BuildTimeEnvironment = {
   posthogKey?: string;
   segmentKey?: string;
-  ga4Keys: string[];
+  ga4Key?: string;
   version: string;
 };
 

--- a/src/utils/anonymizeQueryString.ts
+++ b/src/utils/anonymizeQueryString.ts
@@ -1,0 +1,27 @@
+enum DataType {
+  jwt = 'jwt',
+}
+
+const getDataType = (value: unknown): DataType | null => {
+  if (!value) {
+    return null;
+  }
+  if (/^[a-z0-9-_]{2,}\.[a-z0-9-_]{2,}\.[a-z0-9-_]{2,}$/i.test(`${value}`)) {
+    return DataType.jwt;
+  }
+  return null;
+};
+
+const anonymizeQueryString = (qs: string): string => {
+  const params = new URLSearchParams(qs);
+  Array.from(params.entries()).forEach(([key, value]) => {
+    const type = getDataType(value);
+    if (type) {
+      params.set(key, `anon:${type}`);
+    }
+  });
+  const result = params.toString();
+  return /^\?*$/.test(result) ? '' : result.replace(/^\?*/, '?');
+};
+
+export default anonymizeQueryString;


### PR DESCRIPTION
## Changes

- send anonymized query string along with pathname to GA/GTM
- effect is using `pathname` only as dependency, to avoid unnecessary page views with `search` - query string is dynamically adjusted for test/test suite filters
- revert change to envs: allow providing only one key
- fix using `GTM-` tags - use different script URL

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
