### PR TITLE
fix: fixed the text size on TableRow for execution

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/TableRow/TableRowPure.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/TableRow/TableRowPure.tsx
@@ -54,7 +54,7 @@ const TableRowPure: React.FC<{data: any; onAbortExecution: any; mayManageExecuti
             </Text>
           </ItemColumn>
           <ItemColumn>
-            <StatusText color={Colors.slate200} $isRunning={isRunning}>
+            <StatusText className="regular small" color={Colors.slate200} $isRunning={isRunning}>
               {durationMs ? formatDuration(durationMs / 1000) : isRunning ? 'Running' : 'No data'}
             </StatusText>
             {renderedExecutionActions && renderedExecutionActions.length && mayManageExecution ? (


### PR DESCRIPTION
Before
<img width="165" alt="image" src="https://github.com/kubeshop/testkube-dashboard/assets/25991946/7073eabf-7753-44d1-9fd1-2524a928b7ff">
Now
<img width="185" alt="image" src="https://github.com/kubeshop/testkube-dashboard/assets/25991946/2107223d-9ce1-419e-abd5-47a40c85fbc2">