### PR TITLE
fix: allow scrolling test suite steps list

### DIFF
--- a/src/antd-theme/my-antd-theme.less
+++ b/src/antd-theme/my-antd-theme.less
@@ -72,6 +72,7 @@
 @notification-padding-horizontal: 0;
 // drawer
 @drawer-body-padding: 0;
+@drawer-bg: #1e293b;
 // tooltip
 @tooltip-bg: #334155;
 @popover-bg: #334155;

--- a/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.styled.tsx
+++ b/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.styled.tsx
@@ -1,12 +1,8 @@
 import {motion} from 'framer-motion';
 import styled from 'styled-components';
 
-import Colors from '@styles/Colors';
-
 export const ExecutionDetailsDrawerWrapper = styled(motion.div)<{$isRowSelected: boolean; drawerWidth: string}>`
   position: relative;
-  overflow-y: hidden;
-  overflow-x: hidden;
 
   display: flex;
   flex-direction: column;
@@ -16,8 +12,6 @@ export const ExecutionDetailsDrawerWrapper = styled(motion.div)<{$isRowSelected:
 
   margin: 0;
   padding: ${({$isRowSelected}) => ($isRowSelected ? '45px 30px' : '0')};
-
-  background: ${Colors.slate800};
 `;
 
 export const DrawerHeader = styled.div`

--- a/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.tsx
+++ b/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawer.tsx
@@ -15,8 +15,6 @@ import {TestExecutionDetailsTabs, TestSuiteExecutionDetailsTabs, notificationCal
 import {useGetTestSuiteExecutionByIdQuery} from '@services/testSuiteExecutions';
 import {useGetTestExecutionByIdQuery} from '@services/tests';
 
-import Colors from '@styles/Colors';
-
 import {PollingIntervals} from '@utils/numbers';
 
 import {ExecutionDetailsDrawerWrapper} from './ExecutionDetailsDrawer.styled';
@@ -70,12 +68,11 @@ const components: Record<Entity, JSX.Element> = {
   tests: <TestExecutionDetailsTabs />,
 };
 
-const headerStyle = {borderBottom: 0, padding: '40px 30px 0', backgroundColor: Colors.slate800};
+const headerStyle = {borderBottom: 0, padding: '40px 30px 0'};
 const loaderBodyStyle = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  background: Colors.slate800,
   fontSize: '48px',
 };
 


### PR DESCRIPTION
## Changes

- allow scrolling list of test suite steps (avoid `overflow: hidden`)
- overwrite Drawer styles correctly

## Fixes

- kubeshop/testkube#4076

## How to test it

- Open test suite execution with many steps ([**dev**](https://dev.testkube.io/test-suites/executions/koko/execution/64a483da17e6aa7e6ff7e5dd)
- Try to scroll

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
