### PR TITLE
fix: allow non-root path for the dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 8080
 WORKDIR /usr/share/nginx/html
 COPY ./scripts/env.sh .
-RUN chmod +x env.sh && chmod ugo+w /etc/nginx/nginx.conf
+COPY ./scripts/inject-base-href.sh .
+RUN chmod +x env.sh inject-base-href.sh && chmod ugo+w /etc/nginx/nginx.conf
 
 RUN touch ./env-config.js
 RUN chmod a+w ./env-config.js
@@ -41,6 +42,7 @@ CMD [ \
   "/bin/sh", \
   "-c", \
   "/usr/share/nginx/html/env.sh && \
+   /usr/share/nginx/html/inject-base-href.sh && \
   export DISABLE_IPV6=\"$([[ \"$ENABLE_IPV6\" = \"true\" ]] && echo \"false\" || echo \"true\")\" && \
    envsubst '$DISABLE_IPV6' < /etc/nginx/nginx.conf.tmpl | sed -e '1h;2,$H;$!d;g' -e 's/# cut true.*# end//g' > /etc/nginx/nginx.conf && \
    nginx -g \"daemon off;\"" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ EXPOSE 8080
 WORKDIR /usr/share/nginx/html
 COPY ./scripts/env.sh .
 COPY ./scripts/inject-base-href.sh .
-RUN chmod +x env.sh inject-base-href.sh && chmod ugo+w /etc/nginx/nginx.conf
+RUN chmod +x env.sh inject-base-href.sh && chmod ugo+w /etc/nginx/nginx.conf index.html
 
 RUN touch ./env-config.js
 RUN chmod a+w ./env-config.js

--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- This <base> tag may be replaced in the Docker container, using ./scripts/inject-base-href.sh -->
+    <base href="/">
+
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/scripts/inject-base-href.sh
+++ b/scripts/inject-base-href.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Fail fast
+set -e
+
+# Include the proper <base href> based on the root route
+RENDERED="$(sed -e "s|<base href[^>]*>|<base href=\"${REACT_APP_ROOT_ROUTE:-"/"}\">|" index.html)"
+echo "$RENDERED" > index.html


### PR DESCRIPTION
## Changes

- Add `<base href>` that defaults to `/` (as now), and may be replaced on the Docker container using the existing `REACT_APP_ROOT_ROUTE` environment variable

## Fixes

- https://github.com/kubeshop/testkube/issues/2952

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
