### PR TITLE
fix: display parallel test suite steps nicely

### DIFF
--- a/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
+++ b/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
@@ -6,7 +6,9 @@ import {ReactComponent as ExternalLinkIcon} from '@assets/external.svg';
 
 import Colors from '@styles/Colors';
 
-export const StyledExecutionStepsList = styled.ul`
+export const ExecutionStepsListContainer = styled.ul`
+  counter-reset: steps;
+
   display: flex;
   flex-direction: column;
 
@@ -16,7 +18,31 @@ export const StyledExecutionStepsList = styled.ul`
   list-style-type: none;
 `;
 
-export const StyledExecutionStepsListItem = styled.li`
+export const ExecutionStepsListItem = styled.ul`
+  position: relative;
+  padding: 0 0 0 6px;
+  margin: 10px 0 10px 30px;
+  border-left: 4px solid ${Colors.slate600};
+
+  &:before {
+    counter-increment: steps;
+    content: counter(steps);
+    position: absolute;
+    right: 100%;
+    margin-right: 10px;
+    margin-top: 4.5px;
+    background: ${Colors.slate600};
+    color: ${Colors.slate800};
+    font-weight: bold;
+    width: 1.5em;
+    height: 1.5em;
+    line-height: 1.5em;
+    border-radius: 3px;
+    text-align: center;
+  }
+`;
+
+export const ExecutionStepsListItemExecution = styled.li`
   display: flex;
   align-items: center;
 
@@ -62,8 +88,4 @@ export const StyledSpace = styled(Space)`
 export const StyledExternalLinkIcon = styled(ExternalLinkIcon)`
   width: 20px;
   height: 30px;
-`;
-
-export const WarningContainer = styled.div`
-  margin-bottom: 20px;
 `;

--- a/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
+++ b/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
@@ -24,7 +24,7 @@ export const ExecutionStepsListItem = styled.ul`
   margin: 10px 0 10px 30px;
   border-left: 4px solid ${Colors.slate600};
 
-  &:before {
+  &::before {
     counter-increment: steps;
     content: counter(steps);
     position: absolute;

--- a/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -1,4 +1,4 @@
-import {memo, useContext, useMemo} from 'react';
+import {FC, memo, useContext, useMemo} from 'react';
 
 import {ClockCircleOutlined} from '@ant-design/icons';
 
@@ -24,15 +24,12 @@ import {
   StyledSpace,
 } from './ExecutionStepsList.styled';
 
-type IconSet = 'default' | 'definition';
-
 type ExecutionStepsListProps = {
   executionSteps: TestSuiteStepExecutionResult[];
-  iconSet?: IconSet;
 };
 
-const ExecutionStepsList: React.FC<ExecutionStepsListProps> = props => {
-  const {executionSteps, iconSet = 'default'} = props;
+const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
+  const {executionSteps} = props;
 
   const {navigate} = useContext(DashboardContext);
 
@@ -46,10 +43,8 @@ const ExecutionStepsList: React.FC<ExecutionStepsListProps> = props => {
         .map(({execution}, index) => {
           const result = step.step.execute[index];
           const status = execution.executionResult?.status;
-          const icon = iconSet === 'definition' ? 'code' : status;
           if (result.delay) {
             return {
-              icon,
               status,
               url: null,
               content: (
@@ -62,11 +57,9 @@ const ExecutionStepsList: React.FC<ExecutionStepsListProps> = props => {
           }
           if (result.test) {
             const stepIcon = getTestExecutorIcon(executors, execution.testType);
-            const clickable = (status !== 'queued' && iconSet === 'default') || iconSet === 'definition';
             return {
-              icon,
               status,
-              url: clickable
+              url: status !== 'queued'
                 ? execution?.id
                   ? `/tests/executions/${result.test}/execution/${execution.id}`
                   : `/tests/executions/${result.test}`
@@ -79,10 +72,10 @@ const ExecutionStepsList: React.FC<ExecutionStepsListProps> = props => {
               ),
             };
           }
-          return {icon, url: null, status, clickable: false, content: null};
+          return {url: null, status, clickable: false, content: null};
         })
         .filter(x => x.content)
-        .map(({icon, url, status, content}, index) => (
+        .map(({url, status, content}, index) => (
           <ExecutionStepsListItemExecution
             // eslint-disable-next-line react/no-array-index-key
             key={`item-${index}`}
@@ -90,7 +83,7 @@ const ExecutionStepsList: React.FC<ExecutionStepsListProps> = props => {
             onClick={url ? () => navigate(url) : undefined}
           >
             <StyledSpace size={15}>
-              {icon ? <StatusIcon status={status} /> : null}
+              {status ? <StatusIcon status={status} /> : null}
               {content}
               {url ? <StyledExternalLinkIcon /> : <div />}
             </StyledSpace>

--- a/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -40,42 +40,31 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
       const groupKey = step.execute.map(item => item.execution?.id || Math.random()).join('-');
 
       const items = step.execute
-        .map(({execution}, index) => {
-          const result = step.step.execute[index];
+        .map(({execution}, index) => ({execution, result: step.step.execute[index]}))
+        .filter(({result}) => result.delay || result.test)
+        .map(({execution, result}) => {
           const status = execution.executionResult?.status;
           if (result.delay) {
             return {
               status,
+              icon: <ClockCircleOutlined style={{fontSize: '26px'}} />,
+              name: `Delay - ${result.delay}`,
               url: null,
-              content: (
-                <>
-                  <ClockCircleOutlined style={{fontSize: '26px'}} />
-                  <ExecutionName name={`Delay - ${result.delay}`} />
-                </>
-              ),
             };
           }
-          if (result.test) {
-            const stepIcon = getTestExecutorIcon(executors, execution.testType);
-            return {
-              status,
-              url: status !== 'queued'
+          return {
+            status,
+            icon: <ExecutorIcon type={getTestExecutorIcon(executors, execution.testType)} />,
+            name: result.test!,
+            url:
+              status !== 'queued'
                 ? execution?.id
                   ? `/tests/executions/${result.test}/execution/${execution.id}`
                   : `/tests/executions/${result.test}`
                 : null,
-              content: (
-                <>
-                  <ExecutorIcon type={stepIcon} />
-                  <ExecutionName name={result.test!} />
-                </>
-              ),
-            };
-          }
-          return {url: null, status, clickable: false, content: null};
+          };
         })
-        .filter(x => x.content)
-        .map(({url, status, content}, index) => (
+        .map(({status, icon, name, url}, index) => (
           <ExecutionStepsListItemExecution
             // eslint-disable-next-line react/no-array-index-key
             key={`item-${index}`}
@@ -84,7 +73,8 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
           >
             <StyledSpace size={15}>
               {status ? <StatusIcon status={status} /> : null}
-              {content}
+              {icon}
+              <ExecutionName name={name} />
               {url ? <StyledExternalLinkIcon /> : <div />}
             </StyledSpace>
           </ExecutionStepsListItemExecution>

--- a/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -57,7 +57,7 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
             icon: <ExecutorIcon type={getTestExecutorIcon(executors, execution.testType)} />,
             name: result.test!,
             url:
-              status !== 'queued'
+              status !== 'queued' && status !== 'aborted'
                 ? execution?.id
                   ? `/tests/executions/${result.test}/execution/${execution.id}`
                   : `/tests/executions/${result.test}`

--- a/src/components/molecules/SettingsLayout/SettingsLayout.tsx
+++ b/src/components/molecules/SettingsLayout/SettingsLayout.tsx
@@ -1,4 +1,4 @@
-import {FC, ReactElement, memo, useCallback, useLayoutEffect, useMemo, useState} from 'react';
+import {FC, ReactElement, createElement, memo, useCallback, useLayoutEffect, useMemo, useState} from 'react';
 
 import {SettingsLeftNavigation, StyledTabContentContainer} from '@molecules';
 
@@ -7,7 +7,7 @@ import {StyledSettingsContainer} from './SettingsLayout.styled';
 export interface SettingsLayoutTab {
   id: string;
   label: string;
-  children: ReactElement<any, any> | null;
+  children: FC<{setId(id: string): void}> | ReactElement<any, any> | null;
 }
 
 interface SettingsLayoutProps {
@@ -44,10 +44,14 @@ const SettingsLayout: FC<SettingsLayoutProps> = ({tabs, active, onChange}) => {
     [tabs, active, onChange]
   );
 
+  const render = tabs[selectedOption]?.children;
+
   return (
     <StyledSettingsContainer>
       <SettingsLeftNavigation options={labels} selectedOption={selectedOption} setSelectedOption={setSelectedOption} />
-      <StyledTabContentContainer key={id}>{tabs[selectedOption]?.children}</StyledTabContentContainer>
+      <StyledTabContentContainer key={id}>
+        {typeof render === 'function' ? createElement(render, {setId}) : render}
+      </StyledTabContentContainer>
     </StyledSettingsContainer>
   );
 };

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -27,7 +27,7 @@ import PageMetadata from '@pages/PageMetadata';
 import {Permissions, usePermission} from '@permissions/base';
 
 import {useAppSelector} from '@redux/hooks';
-import {selectRedirectTarget} from '@redux/reducers/configSlice';
+import {selectSettingsTabConfig} from '@redux/reducers/configSlice';
 
 import {useRunTestSuiteMutation} from '@services/testSuites';
 import {useRunTestMutation} from '@services/tests';
@@ -57,7 +57,7 @@ const EntityDetailsContent: React.FC = () => {
   const mayRun = usePermission(Permissions.runEntity);
   const {isLoading, handleLoading} = useLoadingIndicator(2000);
 
-  const {settingsTabConfig} = useAppSelector(selectRedirectTarget);
+  const settingsTabConfig = useAppSelector(selectSettingsTabConfig);
 
   const [runTest] = useRunTestMutation();
   const [runTestSuite] = useRunTestSuiteMutation();

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/Settings.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useContext} from 'react';
+import React, {FC, ReactElement, useCallback, useContext} from 'react';
 
 import {EntityDetailsContext} from '@contexts';
 
@@ -27,11 +27,15 @@ const testSettings = (
   />
 );
 
+const WrappedSettingsTests: FC<{setId(id: string): void}> = ({setId}) => (
+  <SettingsTests openDefinition={useCallback(() => setId('definition'), [])} />
+);
+
 const testSuiteSettings = (
   <SettingsLayout
     tabs={[
       {id: 'general', label: 'General', children: <General />},
-      {id: 'tests', label: 'Tests', children: <SettingsTests />},
+      {id: 'tests', label: 'Tests', children: WrappedSettingsTests},
       {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
       {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
       {id: 'definition', label: 'Definition', children: <SettingsDefinition />},

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -228,7 +228,7 @@ const SettingsTests: React.FC<{openDefinition(): void}> = ({openDefinition}) => 
           </>
         }
         onConfirm={saveSteps}
-        onCancel={() => setCurrentSteps([])}
+        onCancel={() => setCurrentSteps(initialSteps)}
         isButtonsDisabled={!wasTouched}
         isEditable={mayEdit}
         enabled={mayEdit}

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -1,7 +1,7 @@
 import {memo, useContext, useEffect, useMemo, useRef, useState} from 'react';
 
-import {ClockCircleOutlined} from '@ant-design/icons';
-import {Form, Select} from 'antd';
+import {ClockCircleOutlined, WarningOutlined} from '@ant-design/icons';
+import {Button, Form, Select} from 'antd';
 
 import {nanoid} from '@reduxjs/toolkit';
 
@@ -39,7 +39,7 @@ interface LocalStep extends TestSuiteStep {
   id?: string;
 }
 
-const SettingsTests: React.FC = () => {
+const SettingsTests: React.FC<{openDefinition(): void}> = ({openDefinition}) => {
   const {isClusterAvailable} = useContext(MainContext);
   const {entityDetails} = useContext(EntityDetailsContext) as {entityDetails: TestSuite};
 
@@ -72,6 +72,11 @@ const SettingsTests: React.FC = () => {
       type: getTestExecutorIcon(executors, item.test.type),
     }));
   }, [allTestsList]);
+
+  const hasParallelSteps = useMemo(
+    () => entityDetails?.steps?.some(step => step.execute.length > 0),
+    [entityDetails.steps]
+  );
 
   const initialSteps: LocalStep[] = useMemo(
     () =>
@@ -174,6 +179,43 @@ const SettingsTests: React.FC = () => {
   useEffect(() => {
     scrollToBottom();
   }, [currentSteps?.length]);
+
+  // TODO: Delete when we will support parallel editor
+  if (hasParallelSteps) {
+    return (
+      <Form name="define-tests-form">
+        <ConfigurationCard
+          title="Tests"
+          description="Define the tests and their order of execution for this test suite"
+          footerText={
+            <>
+              Learn more about{' '}
+              <ExternalLink href={externalLinks.testSuitesCreating}>Tests in a test suite</ExternalLink>
+            </>
+          }
+        >
+          <EmptyTestsContainer>
+            <Title level={3} className="text-center">
+              <WarningOutlined /> This test suite is using parallel execution.
+            </Title>
+            <Text className="regular middle text-center" style={{maxWidth: 600}}>
+              Unfortunately, we do not support visual editor for it yet.
+            </Text>
+            <Text className="regular middle text-center" style={{maxWidth: 600}}>
+              We are working hard to deliver it for you soon. Until then, you may use{' '}
+              <strong>
+                <em>Definition</em>
+              </strong>{' '}
+              tab, to modify the test suite definition using YAML.
+            </Text>
+            <Button style={{marginTop: 15}} type="primary" onClick={openDefinition}>
+              Edit YAML definition
+            </Button>
+          </EmptyTestsContainer>
+        </ConfigurationCard>
+      </Form>
+    );
+  }
 
   return (
     <Form name="define-tests-form">

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -74,7 +74,7 @@ const SettingsTests: React.FC<{openDefinition(): void}> = ({openDefinition}) => 
   }, [allTestsList]);
 
   const hasParallelSteps = useMemo(
-    () => entityDetails?.steps?.some(step => step.execute.length > 0),
+    () => entityDetails?.steps?.some(step => step.execute.length > 1),
     [entityDetails.steps]
   );
 

--- a/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationModalContent.tsx
+++ b/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationModalContent.tsx
@@ -2,7 +2,7 @@ import {useContext, useEffect, useState} from 'react';
 
 import {Form} from 'antd';
 
-import {AnalyticsContext, DashboardContext, MainContext, ModalContext} from '@contexts';
+import {AnalyticsContext, DashboardContext, ModalContext} from '@contexts';
 
 import {MetadataResponse, RTKResponse} from '@models/fetch';
 import {Test} from '@models/test';
@@ -11,7 +11,6 @@ import {Hint} from '@molecules';
 import {HintProps} from '@molecules/Hint/Hint';
 
 import {useAppSelector} from '@redux/hooks';
-import {setRedirectTarget} from '@redux/reducers/configSlice';
 import {selectExecutors} from '@redux/reducers/executorsSlice';
 import {selectSources} from '@redux/reducers/sourcesSlice';
 
@@ -31,7 +30,6 @@ const TestCreationModalContent: React.FC = () => {
   const [form] = Form.useForm();
   const testType = Form.useWatch('testType', form);
 
-  const {dispatch} = useContext(MainContext);
   const {navigate} = useContext(DashboardContext);
   const {analyticsTrack} = useContext(AnalyticsContext);
   const {closeModal} = useContext(ModalContext);
@@ -75,8 +73,6 @@ const TestCreationModalContent: React.FC = () => {
           type: res.data.spec?.type,
           uiEvent: 'create-tests',
         });
-
-        dispatch(setRedirectTarget({targetTestId: res.data.metadata.name}));
 
         navigate(`/tests/executions/${res.data.metadata.name}`);
         closeModal();

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -5,9 +5,6 @@ type SettingsTabConfigType = {entity: Entity; tab: number | string};
 interface ConfigState {
   namespace: string;
   redirectTarget: {
-    runTarget: boolean;
-    targetTestId: string | null;
-    targetTestExecutionId: string | null;
     settingsTabConfig: SettingsTabConfigType | null;
   };
   fullScreenLogOutput: {

--- a/src/models/execution.ts
+++ b/src/models/execution.ts
@@ -5,7 +5,7 @@ import {TestContent} from '@models/test';
 import {TestExecutor} from '@models/testExecutors';
 import {Variables} from '@models/variable';
 
-export type ExecutionStatusEnum = 'running' | 'passed' | 'failed' | 'queued' | 'cancelled';
+export type ExecutionStatusEnum = 'running' | 'passed' | 'failed' | 'queued' | 'cancelled' | 'aborted';
 export type ExecutionResultOutputTypeEnum = 'text/plain' | 'application/junit+xml' | 'application/json';
 export type ExecutionStepResultStatusEnum = 'success' | 'error';
 

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -73,9 +73,6 @@ const initialExecutorsState: ExecutorsState = {
 const initialConfigState: ConfigState = {
   namespace: 'testkube',
   redirectTarget: {
-    runTarget: false,
-    targetTestExecutionId: null,
-    targetTestId: null,
     settingsTabConfig: null,
   },
   fullScreenLogOutput: {

--- a/src/redux/reducers/configSlice.ts
+++ b/src/redux/reducers/configSlice.ts
@@ -13,9 +13,6 @@ export const configSlice = createSlice({
     setNamespace: (state: Draft<ConfigState>, action: PayloadAction<string>) => {
       state.namespace = action.payload;
     },
-    setRedirectTarget: (state: Draft<ConfigState>, action: PayloadAction<any>) => {
-      state.redirectTarget = action.payload;
-    },
     setLogOutput: (state: Draft<ConfigState>, action: PayloadAction<string>) => {
       state.fullScreenLogOutput.logOutput += action.payload;
     },
@@ -39,13 +36,12 @@ export const configSlice = createSlice({
 });
 
 export const selectNamespace = (state: RootState) => state.config.namespace;
-export const selectRedirectTarget = (state: RootState) => state.config.redirectTarget;
+export const selectSettingsTabConfig = (state: RootState) => state.config.redirectTarget.settingsTabConfig;
 export const selectFullScreenLogOutput = (state: RootState) => state.config.fullScreenLogOutput;
 
 export const {
   setIsFullScreenLogOutput,
   closeFullScreenLogOutput,
-  setRedirectTarget,
   setLogOutput,
   setSettingsTabConfig,
   closeSettingsTabConfig,


### PR DESCRIPTION
## Changes

- Show properly test suite steps in the Execution Details drawer
- Show a warning message on the form for editing test suite steps, redirecting to YAML edition

## Fixes

- https://github.com/kubeshop/testkube/issues/4139

## How to test it

- Check it [**here**](https://testkube-dashboard-git-dawid-fixdisplay-t-faf028-testkube-cloud.vercel.app/test-suites/executions/executor-artillery-smoke-tests?~api_server_endpoint=https://dev.testkube.io/results/v1&~crd_operator_revision=develop)

## Screenshots

| ![screencapture-testkube-dashboard-git-dawid-fixdisplay-t-faf028-testkube-cloud-vercel-app-test-suites-executions-executor-cypress-smoke-tests-2023-07-05-18_06_55](https://github.com/kubeshop/testkube-dashboard/assets/3843526/8e3c4379-5992-4228-b4b9-bc3043035d51) | ![screencapture-testkube-dashboard-git-dawid-fixdisplay-t-faf028-testkube-cloud-vercel-app-test-suites-executions-parallel-testsuite-2-execution-64a58e32d6b8ed4883b3c46f-2023-07-05-18_08_01](https://github.com/kubeshop/testkube-dashboard/assets/3843526/ef4eeb0d-3fea-4fe3-92c0-37e298582402) |
|-|-|

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
