### PR TITLE
feat: expose environment variables interface

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
-# line endings must be \n, not \r\n !
-echo "window._env_ = {" >./env-config.js
-echo "REACT_APP_API_SERVER_ENDPOINT: '${REACT_APP_API_SERVER_ENDPOINT}'," >>./env-config.js
-echo "REACT_APP_ROOT_ROUTE: '${REACT_APP_ROOT_ROUTE}'," >>./env-config.js
-echo "REACT_APP_DISABLE_TELEMETRY: '${REACT_APP_DISABLE_TELEMETRY}'," >>./env-config.js
-echo "};" >>./env-config.js
+
+OUTPUT_FILE=env-config.js
+VARIABLES=(
+  REACT_APP_API_SERVER_ENDPOINT
+  REACT_APP_ROOT_ROUTE
+  REACT_APP_DISABLE_TELEMETRY
+  REACT_APP_CRD_OPERATOR_REVISION
+)
+
+echo "window._env_ = {" > "$OUTPUT_FILE"
+for name in ${VARIABLES[@]}; do
+  value="$(eval "echo \"\$${name}\"")"
+  echo "${name}: '${value}'," >> "$OUTPUT_FILE"
+done
+echo "};" >> "$OUTPUT_FILE"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-OUTPUT_FILE=env-config.js
+OUT=env-config.js
 VARIABLES=(
   REACT_APP_API_SERVER_ENDPOINT
   REACT_APP_ROOT_ROUTE
@@ -8,9 +8,9 @@ VARIABLES=(
   REACT_APP_CRD_OPERATOR_REVISION
 )
 
-echo "window._env_ = {" > "$OUTPUT_FILE"
+echo "window._env_ = {" > "${OUT}"
 for name in ${VARIABLES[@]}; do
   value="$(eval "echo \"\$${name}\"")"
-  echo "${name}: '${value}'," >> "$OUTPUT_FILE"
+  echo "${name}: '${value}'," >> "${OUT}"
 done
-echo "};" >> "$OUTPUT_FILE"
+echo "};" >> "${OUT}"

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,10 +5,10 @@ applyUrlOverrides();
 renderOverridesIndicator();
 
 // Obtain dynamic variables from server
-const values = (window as any)._env_;
+export const provided = (window as any)._env_;
 
 // Build-time variables
-const build: BuildTimeEnvironment = {
+export const build: BuildTimeEnvironment = {
   posthogKey: getValue('REACT_APP_POSTHOG_KEY', process.env.REACT_APP_POSTHOG_KEY),
   segmentKey: getValue('REACT_APP_SEGMENT_KEY', process.env.REACT_APP_SEGMENT_KEY),
   ga4Key: getValue('REACT_APP_GOOGLE_ANALYTICS_ID', process.env.REACT_APP_GOOGLE_ANALYTICS_ID),
@@ -16,28 +16,28 @@ const build: BuildTimeEnvironment = {
 };
 
 // Dynamic variables
-const env: DynamicEnvironment = {
-  apiUrl: getValue('REACT_APP_API_SERVER_ENDPOINT', values?.REACT_APP_API_SERVER_ENDPOINT),
-  basename: getValue('REACT_APP_ROOT_ROUTE', values?.REACT_APP_ROOT_ROUTE),
-  disableTelemetry: getValue('REACT_APP_DISABLE_TELEMETRY', values?.REACT_APP_DISABLE_TELEMETRY) === 'true',
-  crdOperatorRevision: getValue('REACT_APP_CRD_OPERATOR_REVISION', values?.REACT_APP_CRD_OPERATOR_REVISION) || 'main',
+export const dynamic: DynamicEnvironment = {
+  apiUrl: getValue('REACT_APP_API_SERVER_ENDPOINT', provided?.REACT_APP_API_SERVER_ENDPOINT),
+  basename: getValue('REACT_APP_ROOT_ROUTE', provided?.REACT_APP_ROOT_ROUTE),
+  disableTelemetry: getValue('REACT_APP_DISABLE_TELEMETRY', provided?.REACT_APP_DISABLE_TELEMETRY) === 'true',
+  crdOperatorRevision: getValue('REACT_APP_CRD_OPERATOR_REVISION', provided?.REACT_APP_CRD_OPERATOR_REVISION) || 'main',
 };
 
-type BuildTimeEnvironment = {
+export interface BuildTimeEnvironment {
   posthogKey?: string;
   segmentKey?: string;
   ga4Key?: string;
   version: string;
-};
+}
 
-type DynamicEnvironment = {
+export interface DynamicEnvironment {
   apiUrl: string;
   basename: string;
   disableTelemetry: boolean;
   crdOperatorRevision: string;
-};
+}
 
 export default {
-  ...env,
+  ...dynamic,
   ...build,
 };

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -77,3 +77,10 @@ export const applyUrlOverrides = () => {
 export const getValue = <T>(name: string, value: T): T => {
   return name in overrides ? overrides[name] : value;
 };
+
+export const getArrayValue = (name: string, value?: string): any[] => {
+  return (getValue(name, value) || '')
+    .split(',')
+    .map((x: string) => x.trim())
+    .filter(Boolean);
+};


### PR DESCRIPTION
This PR simplifies the environment variables usage, so we will have to duplicate less env code between OSS and Cloud.

## Changes

- simplify `env.sh` script to only pass the variables instead of JS code
- expose environment variables interface to be used for Cloud
- add `getArrayValue` helper, that reads `abc, def, xyz` environment variable as `["abc", "def", "xyz"]`

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
