### PR TITLE
fix: avoid absolute "/" path for files, to make <base href> working

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "scripts": {
     "start": "sh scripts/env.sh && cp env-config.js ./public/ && npm run less && NODE_OPTIONS=--openssl-legacy-provider craco start",
-    "build": "npm run less && NODE_OPTIONS=--openssl-legacy-provider craco --max_old_space_size=4096 build",
+    "build": "npm run less && NODE_OPTIONS=--openssl-legacy-provider PUBLIC_URL=. craco --max_old_space_size=4096 build",
     "test": "craco test --watchAll=false",
     "test:watch": "craco test --detectOpenHandles",
     "test:coverage": "craco test --coverage --watchAll=false",


### PR DESCRIPTION
## Changes

- avoid absolute "/" path for files, to make <base href> working
   - `<base href>` ignores absolute URLs (incl. starting with `/`), so we need to use `./` kind URLs for resources

## Fixes

- kubeshop/testkube#2952

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
