### PR TITLE
fix: building env variables in the Docker container

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 
 OUT=env-config.js
-VARIABLES=(
+VARIABLES="
   REACT_APP_API_SERVER_ENDPOINT
   REACT_APP_ROOT_ROUTE
   REACT_APP_DISABLE_TELEMETRY
   REACT_APP_CRD_OPERATOR_REVISION
-)
+"
 
-echo "window._env_ = {" > "${OUT}"
-for name in ${VARIABLES[@]}; do
-  value="$(eval "echo \"\$${name}\"")"
-  echo "${name}: '${value}'," >> "${OUT}"
+set -- $VARIABLES
+echo "window._env_ = {" > "$OUT"
+while [ -n "$1" ]; do
+  value="$(eval "echo \"\$$1\"")"
+  echo "$1: '$value'," >> "$OUT"
+  shift
 done
-echo "};" >> "${OUT}"
+echo "};" >> "$OUT"


### PR DESCRIPTION
## Changes

- The recent changes to `env.sh` were not running correctly in `busybox/ash` used in `nginx:alpine` image
- The new `env.sh` will work on all terminals

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
