### PR TITLE
fix: don't break settings page after saving YAML definition

### DIFF
--- a/src/components/molecules/Definition/Definition.tsx
+++ b/src/components/molecules/Definition/Definition.tsx
@@ -23,7 +23,7 @@ import DefinitionSkeleton from './DefinitionSkeleton';
 type DefinitionProps = {
   useGetDefinitionQuery: UseQuery<QueryDefinition<any, any, any, any, any>>;
   useUpdateDefinitionMutation: UseMutation<MutationDefinition<any, any, any, any, any>>;
-  setEntity?: (data: any) => void;
+  onUpdate?: (response: any) => void;
   name: string;
   label: string;
   crdUrl?: string;
@@ -31,7 +31,7 @@ type DefinitionProps = {
 };
 
 const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
-  const {name, setEntity, useGetDefinitionQuery, useUpdateDefinitionMutation, crdUrl, label, overrideSchema} = props;
+  const {name, onUpdate, useGetDefinitionQuery, useUpdateDefinitionMutation, crdUrl, label, overrideSchema} = props;
 
   const {isClusterAvailable} = useContext(MainContext);
 
@@ -60,7 +60,8 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
     const markerErrors = monaco.editor.getModelMarkers({owner: 'yaml'});
 
     if (markerErrors.length > 0) {
-      const errorMessages = {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      return Promise.reject({
         errors: markerErrors.map(x => {
           return {
             title: (
@@ -73,8 +74,7 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
             ),
           };
         }),
-      };
-      throw errorMessages;
+      });
     }
 
     return update({name, value})
@@ -82,7 +82,8 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
       .then(res => {
         if (res && 'data' in res) {
           notificationCall('passed', `${capitalize(label)} was successfully updated.`);
-          setEntity?.(res.data);
+          onUpdate?.(res.data);
+          refetch();
         }
       });
   };

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorDetails.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorDetails.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
+import {useCallback, useContext, useEffect, useState} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {Tabs} from 'antd';
@@ -28,12 +28,13 @@ const ExecutorDetails: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = useState('Settings');
 
   const {data: executor, refetch} = useGetExecutorDetailsQuery(name, {skip: !isClusterAvailable});
+  const reload = useCallback(() => safeRefetch(refetch), [refetch]);
 
   const isPageDisabled = !name;
 
   useEffect(() => {
     dispatch(setCurrentExecutor(name));
-    safeRefetch(refetch);
+    reload();
   }, [name]);
 
   useEffect(() => {
@@ -56,7 +57,7 @@ const ExecutorDetails: React.FC = () => {
             key: 'Settings',
             label: 'Settings',
             disabled: isPageDisabled,
-            children: currentExecutorDetails ? <ExecutorSettings /> : null,
+            children: currentExecutorDetails ? <ExecutorSettings reload={reload} /> : null,
           },
         ]}
       />

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorDefinition/ExecutorDefinition.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorDefinition/ExecutorDefinition.tsx
@@ -1,24 +1,27 @@
+import {FC} from 'react';
+
 import {Definition} from '@molecules';
 
-import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {selectCurrentExecutor, setCurrentExecutor} from '@redux/reducers/executorsSlice';
+import {useAppSelector} from '@redux/hooks';
+import {selectCurrentExecutor} from '@redux/reducers/executorsSlice';
 
 import {useGetExecutorDefinitionQuery, useUpdateExecutorDefinitionMutation} from '@services/executors';
 
 import {createSchemaOverride} from '@utils/createSchemaOverride';
 import {testkubeCRDBases} from '@utils/externalLinks';
 
-const ExecutorDefinition = () => {
+interface ExecutorDefinitionProps {
+  reload: () => void;
+}
+
+const ExecutorDefinition: FC<ExecutorDefinitionProps> = ({reload}) => {
   const executor = useAppSelector(selectCurrentExecutor)!;
-
-  const dispatch = useAppDispatch();
-
   return (
     <Definition
       useGetDefinitionQuery={useGetExecutorDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateExecutorDefinitionMutation}
       label="executor"
-      onUpdate={value => dispatch(setCurrentExecutor(value))}
+      onUpdate={reload}
       name={executor.name}
       crdUrl={testkubeCRDBases.executors}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorDefinition/ExecutorDefinition.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorDefinition/ExecutorDefinition.tsx
@@ -18,7 +18,7 @@ const ExecutorDefinition = () => {
       useGetDefinitionQuery={useGetExecutorDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateExecutorDefinitionMutation}
       label="executor"
-      setEntity={value => dispatch(setCurrentExecutor(value))}
+      onUpdate={value => dispatch(setCurrentExecutor(value))}
       name={executor.name}
       crdUrl={testkubeCRDBases.executors}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorSettings.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorSettings.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {FC, memo} from 'react';
 
 import {SettingsLayout} from '@molecules';
 
@@ -7,13 +7,17 @@ import ContainerImage from './ContainerImage';
 import ExecutorDefinition from './ExecutorDefinition';
 import General from './General';
 
-const ExecutorSettings = () => (
+interface ExecutorSettingsProps {
+  reload: () => void;
+}
+
+const ExecutorSettings: FC<ExecutorSettingsProps> = ({reload}) => (
   <SettingsLayout
     tabs={[
       {id: 'general', label: 'General', children: <General />},
       {id: 'image', label: 'Container image', children: <ContainerImage />},
       {id: 'command', label: 'Command & Arguments', children: <CommandAndArguments />},
-      {id: 'definition', label: 'Definition', children: <ExecutorDefinition />},
+      {id: 'definition', label: 'Definition', children: <ExecutorDefinition reload={reload} />},
     ]}
   />
 );

--- a/src/components/pages/Sources/SourceDetails/SourceDetails.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceDetails.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
+import {useCallback, useContext, useEffect, useState} from 'react';
 
 import {Tabs} from 'antd';
 
@@ -30,6 +30,7 @@ const SourceDetails = () => {
   const [activeTabKey, setActiveTabKey] = useState('Settings');
 
   const {data: sourceDetails, refetch} = useGetSourceDetailsQuery(name, {skip: !isClusterAvailable});
+  const reload = useCallback(() => safeRefetch(refetch), [refetch]);
 
   const isPageDisabled = !name;
 
@@ -40,7 +41,7 @@ const SourceDetails = () => {
   }, [sourceDetails]);
 
   useEffect(() => {
-    safeRefetch(refetch);
+    reload();
   }, [location]);
 
   return (
@@ -50,7 +51,7 @@ const SourceDetails = () => {
       <PageHeader onBack={() => navigate('/sources')} title={name} />
       <Tabs activeKey={activeTabKey} onChange={setActiveTabKey} destroyInactiveTabPane>
         <Tabs.TabPane tab="Settings" key="Settings" disabled={isPageDisabled}>
-          {currentSourceDetails ? <SourceSettings /> : null}
+          {currentSourceDetails ? <SourceSettings reload={reload} /> : null}
         </Tabs.TabPane>
       </Tabs>
     </PageWrapper>

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/Definition/SourceSettingsDefinition.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/Definition/SourceSettingsDefinition.tsx
@@ -18,7 +18,7 @@ const SourceSettingsDefinition = () => {
       useGetDefinitionQuery={useGetSourceDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateSourceDefinitionMutation}
       label="source"
-      setEntity={value => dispatch(setCurrentSource(value))}
+      onUpdate={value => dispatch(setCurrentSource(value))}
       name={source.name}
       crdUrl={testkubeCRDBases.sources}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/Definition/SourceSettingsDefinition.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/Definition/SourceSettingsDefinition.tsx
@@ -1,24 +1,27 @@
+import {FC} from 'react';
+
 import {Definition} from '@molecules';
 
-import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {selectCurrentSource, setCurrentSource} from '@redux/reducers/sourcesSlice';
+import {useAppSelector} from '@redux/hooks';
+import {selectCurrentSource} from '@redux/reducers/sourcesSlice';
 
 import {useGetSourceDefinitionQuery, useUpdateSourceDefinitionMutation} from '@services/sources';
 
 import {createSchemaOverride} from '@utils/createSchemaOverride';
 import {testkubeCRDBases} from '@utils/externalLinks';
 
-const SourceSettingsDefinition = () => {
+interface SourceSettingsDefinitionProps {
+  reload: () => void;
+}
+
+const SourceSettingsDefinition: FC<SourceSettingsDefinitionProps> = ({reload}) => {
   const source = useAppSelector(selectCurrentSource)!;
-
-  const dispatch = useAppDispatch();
-
   return (
     <Definition
       useGetDefinitionQuery={useGetSourceDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateSourceDefinitionMutation}
       label="source"
-      onUpdate={value => dispatch(setCurrentSource(value))}
+      onUpdate={reload}
       name={source.name}
       crdUrl={testkubeCRDBases.sources}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/SourceSettings.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/SourceSettings.tsx
@@ -1,15 +1,19 @@
-import {memo} from 'react';
+import {FC, memo} from 'react';
 
 import {SettingsLayout} from '@molecules';
 
 import SourceSettingsDefinition from './Definition';
 import General from './General';
 
-const SourceSettings = () => (
+interface SourceSettingsProps {
+  reload: () => void;
+}
+
+const SourceSettings: FC<SourceSettingsProps> = ({reload}) => (
   <SettingsLayout
     tabs={[
       {id: 'general', label: 'General', children: <General />},
-      {id: 'definition', label: 'Definition', children: <SourceSettingsDefinition />},
+      {id: 'definition', label: 'Definition', children: <SourceSettingsDefinition reload={reload} />},
     ]}
   />
 );

--- a/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react';
+import {useCallback, useContext, useEffect, useState} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {Tabs} from 'antd';
@@ -32,6 +32,7 @@ const TriggerDetails = () => {
 
   const {data: triggerDetails, refetch} = useGetTriggerByIdQuery(name, {skip: !isClusterAvailable});
   const {data: triggersKeyMap, refetch: refetchKeyMap} = useGetTriggersKeyMapQuery(null, {skip: !isClusterAvailable});
+  const reload = useCallback(() => safeRefetch(refetch), [refetch]);
 
   const isPageDisabled = !name;
 
@@ -48,7 +49,7 @@ const TriggerDetails = () => {
   }, [triggersKeyMap]);
 
   useEffect(() => {
-    safeRefetch(refetch);
+    reload();
   }, [name]);
 
   return (
@@ -58,7 +59,7 @@ const TriggerDetails = () => {
       <PageHeader onBack={() => navigate('/triggers')} title={name} />
       <Tabs activeKey={activeTabKey} onChange={setActiveTabKey} destroyInactiveTabPane>
         <Tabs.TabPane tab="Settings" key="Settings" disabled={isPageDisabled}>
-          {triggerDetails ? <TriggerSettings /> : null}
+          {triggerDetails ? <TriggerSettings reload={reload} /> : null}
         </Tabs.TabPane>
       </Tabs>
     </PageWrapper>

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/Definition/Definition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/Definition/Definition.tsx
@@ -1,3 +1,5 @@
+import {FC} from 'react';
+
 import {Definition} from '@molecules';
 
 import {useGetTriggerDefinitionQuery, useUpdateTriggerDefinitionMutation} from '@services/triggers';
@@ -7,8 +9,12 @@ import {useStore} from '@store';
 import {createSchemaOverride} from '@utils/createSchemaOverride';
 import {testkubeCRDBases} from '@utils/externalLinks';
 
-const TriggerDefinition = () => {
-  const {currentTrigger, setCurrentTrigger} = useStore(state => ({
+interface TriggerDefinitionProps {
+  reload: () => void;
+}
+
+const TriggerDefinition: FC<TriggerDefinitionProps> = ({reload}) => {
+  const {currentTrigger} = useStore(state => ({
     currentTrigger: state.currentTrigger!,
     setCurrentTrigger: state.setCurrentTrigger,
   }));
@@ -18,7 +24,7 @@ const TriggerDefinition = () => {
       useGetDefinitionQuery={useGetTriggerDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateTriggerDefinitionMutation}
       label="trigger"
-      onUpdate={setCurrentTrigger}
+      onUpdate={reload}
       name={currentTrigger.name}
       crdUrl={testkubeCRDBases.triggers}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/Definition/Definition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/Definition/Definition.tsx
@@ -18,7 +18,7 @@ const TriggerDefinition = () => {
       useGetDefinitionQuery={useGetTriggerDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateTriggerDefinitionMutation}
       label="trigger"
-      setEntity={setCurrentTrigger}
+      onUpdate={setCurrentTrigger}
       name={currentTrigger.name}
       crdUrl={testkubeCRDBases.triggers}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {FC, memo} from 'react';
 
 import {SettingsLayout} from '@molecules';
 
@@ -7,13 +7,17 @@ import General from './General';
 import TriggerAction from './TriggerAction';
 import TriggerCondition from './TriggerCondition';
 
-const TriggerSettings = () => (
+interface TriggerSettingsProps {
+  reload: () => void;
+}
+
+const TriggerSettings: FC<TriggerSettingsProps> = ({reload}) => (
   <SettingsLayout
     tabs={[
       {id: 'general', label: 'General', children: <General />},
       {id: 'condition', label: 'Trigger Condition', children: <TriggerCondition />},
       {id: 'action', label: 'Trigger Action', children: <TriggerAction />},
-      {id: 'definition', label: 'Definition', children: <Definition />},
+      {id: 'definition', label: 'Definition', children: <Definition reload={reload} />},
     ]}
   />
 );


### PR DESCRIPTION
## Changes

- Refetch the definition after saving
  - To ensure that it will look exactly the same as from the server
- Refetch the whole resource
  - Earlier, the response from `PATCH` was used, but it doesn't match the contract from `GET`, so we need to refetch it instead
  - It's not that important for tests/test suites, as these are frequently updated anyway

## Fixes

-

## How to test it

- Update YAML definition
- See that page is not broken
- See that the changes are propagated to other settings (i.e. `Command & Arguments`)

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
