### PR TITLE
fix: backwards compatibility for test suites V2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-transition-group": "4.4.2",
         "react-use": "17.4.0",
         "react-use-websocket": "^4.2.0",
+        "semver": "^7.5.4",
         "strip-ansi": "^7.0.1",
         "styled-components": "5.3.5",
         "zustand": "^4.3.7"
@@ -65,6 +66,7 @@
         "@types/react-router-dom": "5.3.3",
         "@types/react-syntax-highlighter": "^15.5.5",
         "@types/react-transition-group": "4.4.4",
+        "@types/semver": "^7.5.0",
         "@types/styled-components": "5.1.18",
         "@typescript-eslint/eslint-plugin": "5.55.0",
         "@typescript-eslint/parser": "5.55.0",
@@ -2675,6 +2677,21 @@
         "node": ">=v12"
       }
     },
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@commitlint/lint": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-15.0.0.tgz",
@@ -2846,20 +2863,6 @@
       },
       "peerDependencies": {
         "react-scripts": "^5.0.0"
-      }
-    },
-    "node_modules/@craco/craco/node_modules/semver": {
-      "version": "7.5.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -8233,21 +8236,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.62.0.tgz",
@@ -8389,21 +8377,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.55.0",
@@ -8585,21 +8558,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.55.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.55.0.tgz",
@@ -8624,21 +8582,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -10754,21 +10697,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/css-loader/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "3.4.1",
       "dev": true,
@@ -12439,20 +12367,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/semver": {
-      "version": "7.5.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/eslint-plugin-unused-imports": {
       "version": "2.0.0",
@@ -16416,7 +16330,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -20976,9 +20889,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "dev": true,
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -22314,21 +22227,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -22996,21 +22894,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ts-jest/node_modules/yargs-parser": {
@@ -24451,7 +24334,6 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/react-router-dom": "5.3.3",
     "@types/react-syntax-highlighter": "^15.5.5",
     "@types/react-transition-group": "4.4.4",
+    "@types/semver": "^7.5.0",
     "@types/styled-components": "5.1.18",
     "@typescript-eslint/eslint-plugin": "5.55.0",
     "@typescript-eslint/parser": "5.55.0",
@@ -100,6 +101,7 @@
     "react-transition-group": "4.4.2",
     "react-use": "17.4.0",
     "react-use-websocket": "^4.2.0",
+    "semver": "^7.5.4",
     "strip-ansi": "^7.0.1",
     "styled-components": "5.3.5",
     "zustand": "^4.3.7"

--- a/src/components/atoms/MonacoEditor/MonacoEditor.tsx
+++ b/src/components/atoms/MonacoEditor/MonacoEditor.tsx
@@ -1,4 +1,4 @@
-import React, {lazy, useEffect, useState} from 'react';
+import React, {lazy, useEffect, useMemo, useState} from 'react';
 import type {EditorDidMount, monaco} from 'react-monaco-editor';
 import {useWindowSize} from 'react-use';
 
@@ -11,6 +11,7 @@ type TkMonacoEditorProps = {
   height?: string;
   minHeight?: number;
   value: string;
+  disabled?: boolean;
   onChange: (value: string) => void;
 };
 
@@ -40,8 +41,9 @@ const options = {
 const defaultEditorHeight = 300;
 
 const TkMonacoEditor: React.FC<TkMonacoEditorProps> = props => {
-  const {value, onChange, language, height, minHeight = defaultEditorHeight} = props;
+  const {value, onChange, language, disabled = false, height, minHeight = defaultEditorHeight} = props;
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const editorOptions = useMemo(() => ({...options, readOnly: disabled}), [disabled]);
 
   const handleEditorDidMount: EditorDidMount = (mountedEditor, monaco) => {
     monaco.editor.defineTheme('testkube-theme', {
@@ -92,7 +94,7 @@ const TkMonacoEditor: React.FC<TkMonacoEditorProps> = props => {
       value={value}
       onChange={onChange}
       theme="testkube-theme"
-      options={options}
+      options={editorOptions}
       editorDidMount={handleEditorDidMount}
       height={height}
     />

--- a/src/components/molecules/ExecutionDetails/TestSuiteExecutionDetails/TestSuiteExecutionDetailsTabs.tsx
+++ b/src/components/molecules/ExecutionDetails/TestSuiteExecutionDetails/TestSuiteExecutionDetailsTabs.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {useContext, useMemo} from 'react';
 
 import {Tabs} from 'antd';
 
@@ -8,10 +8,15 @@ import {TestSuiteExecution} from '@models/testSuiteExecution';
 
 import {ExecutionStepsList} from '@molecules';
 
-const TestSuiteExecutionDetailsTabs: React.FC = () => {
-  const {data} = useContext(ExecutionDetailsContext);
+import {convertTestSuiteV2ExecutionToV3, isTestSuiteV2Execution} from '@utils/testSuites';
 
-  const testSuiteData = data as TestSuiteExecution;
+const TestSuiteExecutionDetailsTabs: React.FC = () => {
+  const {data} = useContext(ExecutionDetailsContext) as {data: TestSuiteExecution};
+
+  const testSuiteData = useMemo(
+    () => (isTestSuiteV2Execution(data) ? convertTestSuiteV2ExecutionToV3(data) : data),
+    [data]
+  );
   const {executeStepResults} = testSuiteData;
 
   return (

--- a/src/components/molecules/InlineNotification/InlineNotification.styled.tsx
+++ b/src/components/molecules/InlineNotification/InlineNotification.styled.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+import Colors from '@styles/Colors';
+
+export const InlineNotificationWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  border-radius: 4px;
+  padding: 20px;
+
+  a {
+    font-weight: 500;
+    text-decoration: underline;
+    color: inherit;
+
+    &:hover {
+      text-decoration: none;
+      color: inherit;
+    }
+  }
+
+  &.error {
+    background-color: ${Colors.pink700};
+
+    .testkube-text.title {
+      color: ${Colors.whitePure};
+    }
+
+    .testkube-text.description {
+      color: ${Colors.whitePure};
+    }
+  }
+
+  &.warning {
+    background-color: ${Colors.amber90099};
+    border: 1px solid ${Colors.amber400};
+
+    .testkube-text.title {
+      color: ${Colors.amber100};
+    }
+
+    .testkube-text.description {
+      color: ${Colors.amber200};
+    }
+  }
+`;

--- a/src/components/molecules/InlineNotification/InlineNotification.tsx
+++ b/src/components/molecules/InlineNotification/InlineNotification.tsx
@@ -1,0 +1,21 @@
+import {Text} from '@custom-antd';
+
+import {InlineNotificationWrapper} from './InlineNotification.styled';
+
+interface InlineNotificationProps {
+  title?: string;
+  description: JSX.Element;
+  type: 'warning' | 'error';
+}
+const InlineNotification: React.FC<InlineNotificationProps> = props => {
+  const {type = 'error', title, description} = props;
+
+  return (
+    <InlineNotificationWrapper className={type}>
+      {title ? <Text className="bold middle title">{title}</Text> : null}
+      <Text className="regular middle description">{description}</Text>
+    </InlineNotificationWrapper>
+  );
+};
+
+export default InlineNotification;

--- a/src/components/molecules/InlineNotification/index.ts
+++ b/src/components/molecules/InlineNotification/index.ts
@@ -1,0 +1,1 @@
+export {default} from './InlineNotification';

--- a/src/components/molecules/KubernetesResourceEditor/KubernetesResourceEditor.tsx
+++ b/src/components/molecules/KubernetesResourceEditor/KubernetesResourceEditor.tsx
@@ -7,6 +7,7 @@ import {MonacoEditor} from '@atoms';
 import useCRD from '@hooks/useCRD';
 
 interface KubernetesResourceEditorProps {
+  disabled?: boolean;
   crdUrl?: string;
   value: string;
   onChange: (value: string) => void;
@@ -14,7 +15,7 @@ interface KubernetesResourceEditorProps {
 }
 
 const KubernetesResourceEditor: FC<KubernetesResourceEditorProps> = props => {
-  const {crdUrl, onChange, value, overrideSchema = x => x} = props;
+  const {disabled, crdUrl, onChange, value, overrideSchema = x => x} = props;
 
   const {crd} = useCRD(crdUrl);
 
@@ -38,7 +39,7 @@ const KubernetesResourceEditor: FC<KubernetesResourceEditorProps> = props => {
     });
   }, [crd]);
 
-  return <MonacoEditor language="yaml" onChange={onChange} value={value} />;
+  return <MonacoEditor language="yaml" onChange={onChange} value={value} disabled={disabled} />;
 };
 
 export default KubernetesResourceEditor;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -39,3 +39,4 @@ export {Revision} from './GitFormItems';
 export {default as RunningContext} from './RunningContext';
 export {RunningContextType} from './RunningContext';
 export {default as MessagePanel} from './MessagePanel';
+export {default as InlineNotification} from './InlineNotification';

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTests/SettingsTests.tsx
@@ -11,6 +11,7 @@ import {EntityDetailsContext, MainContext} from '@contexts';
 
 import {Text, Title} from '@custom-antd';
 
+import {Entity} from '@models/entity';
 import {TestSuiteStepTest} from '@models/test';
 import {TestSuite, TestSuiteStep} from '@models/testSuite';
 
@@ -27,6 +28,9 @@ import {useGetAllTestsQuery} from '@services/tests';
 
 import {externalLinks} from '@utils/externalLinks';
 import {displayDefaultNotificationFlow} from '@utils/notification';
+import {convertTestSuiteV2ToV3, isTestSuiteV2} from '@utils/testSuites';
+
+import {settingsDefinitionData} from '../SettingsDefinition/utils';
 
 import DelayModal from './DelayModal';
 import {EmptyTestsContainer, StyledOptionWrapper, StyledStepsList} from './SettingsTests.styled';
@@ -41,7 +45,25 @@ interface LocalStep extends TestSuiteStep {
 
 const SettingsTests: React.FC<{openDefinition(): void}> = ({openDefinition}) => {
   const {isClusterAvailable} = useContext(MainContext);
-  const {entityDetails} = useContext(EntityDetailsContext) as {entityDetails: TestSuite};
+  const {
+    entityDetails: rawEntityDetails,
+    entity,
+    id,
+  } = useContext(EntityDetailsContext) as {entityDetails: TestSuite; entity: Entity; id: string};
+
+  // Detect the API version of the resource
+  const useGetDefinitionQuery = settingsDefinitionData[entity]!.query;
+  const {data: definition, isLoading, refetch} = useGetDefinitionQuery(id, {skip: !isClusterAvailable});
+  const version = useMemo(() => (definition || '').match(/(?:^|\n)apiVersion:.+\/(v\d+)/)?.[1], [definition]);
+
+  const isV2 = useMemo(
+    () => rawEntityDetails && (version === 'v2' || isTestSuiteV2(rawEntityDetails)),
+    [rawEntityDetails]
+  );
+  const entityDetails = useMemo(
+    () => (isV2 ? convertTestSuiteV2ToV3(rawEntityDetails) : rawEntityDetails),
+    [rawEntityDetails]
+  );
 
   const mayEdit = usePermission(Permissions.editEntity);
 
@@ -122,7 +144,11 @@ const SettingsTests: React.FC<{openDefinition(): void}> = ({openDefinition}) => 
         steps: currentSteps.map(step => {
           return {
             stopTestOnFailure: step.stopTestOnFailure,
-            execute: [{...(step.test ? {test: step.test} : {delay: step.delay})}],
+            execute: isV2
+              ? step.test
+                ? {name: step.test}
+                : {delay: step.delay}
+              : [step.test ? {test: step.test} : {delay: step.delay}],
           };
         }),
       },
@@ -221,7 +247,7 @@ const SettingsTests: React.FC<{openDefinition(): void}> = ({openDefinition}) => 
     <Form name="define-tests-form">
       <ConfigurationCard
         title="Tests"
-        description="Define the tests and their order of execution for this test suite"
+        description={`Define the tests and their order of execution for this test suite`}
         footerText={
           <>
             Learn more about <ExternalLink href={externalLinks.testSuitesCreating}>Tests in a test suite</ExternalLink>

--- a/src/contexts/MainContext.ts
+++ b/src/contexts/MainContext.ts
@@ -7,6 +7,7 @@ import {useAppDispatch} from '@redux/hooks';
 export type MainContextProps = {
   dispatch: ReturnType<typeof useAppDispatch>;
   clusterConfig?: ClusterConfig;
+  clusterVersion?: string;
   isClusterAvailable: boolean;
 };
 

--- a/src/hooks/useClusterVersionMatch.ts
+++ b/src/hooks/useClusterVersionMatch.ts
@@ -1,0 +1,12 @@
+import {useContext} from 'react';
+
+import {satisfies as matchesVersion} from 'semver';
+
+import {MainContext} from '@contexts';
+
+const useClusterVersionMatch = <T>(match: string, defaults?: T): boolean | T => {
+  const {clusterVersion} = useContext(MainContext);
+  return clusterVersion == null ? (defaults as T) : matchesVersion(clusterVersion, match);
+};
+
+export default useClusterVersionMatch;

--- a/src/utils/testSuites.ts
+++ b/src/utils/testSuites.ts
@@ -1,7 +1,17 @@
 import {TestSuite, TestSuiteStep} from '@models/testSuite';
+import {TestSuiteExecution} from '@models/testSuiteExecution';
+
+type TestSuiteExecutionMaybeV2 = TestSuiteExecution & {stepResults?: any};
 
 export function isTestSuiteV2(suite: TestSuite): boolean {
   return !Array.isArray(suite.steps?.[0]?.execute || []);
+}
+
+function mapExecute(execute: any): TestSuiteStep[] {
+  if (!execute) {
+    return [];
+  }
+  return ([] as TestSuiteStep[]).concat(execute!).map(item => ('name' in item ? {test: item.name as string} : item));
 }
 
 export function convertTestSuiteV2ToV3(suite: TestSuite): TestSuite {
@@ -9,9 +19,22 @@ export function convertTestSuiteV2ToV3(suite: TestSuite): TestSuite {
     ...suite,
     steps: suite.steps?.map(step => ({
       ...step,
-      execute: ([] as TestSuiteStep[])
-        .concat(step.execute!)
-        .map(item => ('name' in item ? {test: item.name as string} : item)),
+      execute: mapExecute(step.execute!),
+    })),
+  };
+}
+
+export function isTestSuiteV2Execution(execution: TestSuiteExecutionMaybeV2): boolean {
+  return Boolean(execution.stepResults);
+}
+
+export function convertTestSuiteV2ExecutionToV3(execution: TestSuiteExecutionMaybeV2): TestSuiteExecution {
+  const {stepResults, ...rest} = execution;
+  return {
+    ...rest,
+    executeStepResults: stepResults.map((result: any) => ({
+      execute: [{execution: result.execution, step: mapExecute(result.step.execute)?.[0]}],
+      step: {...result.step, execute: mapExecute(result.step.execute)},
     })),
   };
 }

--- a/src/utils/testSuites.ts
+++ b/src/utils/testSuites.ts
@@ -1,0 +1,17 @@
+import {TestSuite, TestSuiteStep} from '@models/testSuite';
+
+export function isTestSuiteV2(suite: TestSuite): boolean {
+  return !Array.isArray(suite.steps?.[0]?.execute || []);
+}
+
+export function convertTestSuiteV2ToV3(suite: TestSuite): TestSuite {
+  return {
+    ...suite,
+    steps: suite.steps?.map(step => ({
+      ...step,
+      execute: ([] as TestSuiteStep[])
+        .concat(step.execute!)
+        .map(item => ('name' in item ? {test: item.name as string} : item)),
+    })),
+  };
+}


### PR DESCRIPTION
## Changes

- Allow passing `clusterVersion` to `MainContext`, and match it with `useClusterVersionMatch` hook
- Display Test Suite V2 Executions properly
- Display and allow editing Test Suite V2 steps
- Display alert and make the YAML definition editor read-only, when the cluster is <1.13.0

## Fixes

-

## How to test it

-

## screenshots

|![screencapture-localhost-3000-organization-tkcorg-539cb664a4446f37-environment-tkcenv-84019fff03aac934-dashboard-executors-container-executor-curl-2023-07-14-17_31_55](https://github.com/kubeshop/testkube-dashboard/assets/3843526/01e9388e-92a5-4f1b-b3de-8cbb3b890a7d)|
|-|

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
