### PR TITLE
fix: always use trailing slash in <base href>

### DIFF
--- a/scripts/inject-base-href.sh
+++ b/scripts/inject-base-href.sh
@@ -4,5 +4,6 @@
 set -e
 
 # Include the proper <base href> based on the root route
-RENDERED="$(sed -e "s|<base href[^>]*>|<base href=\"${REACT_APP_ROOT_ROUTE:-"/"}\">|" index.html)"
+BASE_URL="$(echo "${REACT_APP_ROOT_ROUTE:-""}" | sed 's|\/*$||')"
+RENDERED="$(sed -e "s|<base href[^>]*>|<base href=\"${BASE_URL}/\">|" index.html)"
 echo "$RENDERED" > index.html


### PR DESCRIPTION
## Changes

- always use trailing slash in `<base href>`

## Fixes

- kubeshop/testkube#2952

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
