### PR TITLE
Release v1.13.4

### DIFF
--- a/scripts/inject-base-href.sh
+++ b/scripts/inject-base-href.sh
@@ -4,5 +4,6 @@
 set -e
 
 # Include the proper <base href> based on the root route
-RENDERED="$(sed -e "s|<base href[^>]*>|<base href=\"${REACT_APP_ROOT_ROUTE:-"/"}\">|" index.html)"
+BASE_URL="$(echo "${REACT_APP_ROOT_ROUTE:-""}" | sed 's|\/*$||')"
+RENDERED="$(sed -e "s|<base href[^>]*>|<base href=\"${BASE_URL}/\">|" index.html)"
 echo "$RENDERED" > index.html


### PR DESCRIPTION
| Commit | Description | PR |
|-|-|-|
|[**`e8c8c0d2`**](https://github.com/kubeshop/testkube-dashboard/commit/e8c8c0d2)| fix: always use / on end of <base href>|([#792](https://github.com/kubeshop/testkube-dashboard/pull/792))|
