### PR TITLE
fix: adjust useStoreSync, simplify useStoreSetter, allow passing store dependencies

### DIFF
--- a/src/store/utils.tsx
+++ b/src/store/utils.tsx
@@ -150,9 +150,9 @@ const createStoreHooks = <T,>(useStore: StoreFn<T>) => ({
 export const connectStore = <T,>(createStore: StoreFactory<T>) => {
   const StoreContext = createStoreContext<T>();
 
-  const useInitializeStore = (initialState?: Partial<T>) => {
+  const useInitializeStore = (initialState?: Partial<T>, deps: any[] = []) => {
     // Build the store
-    const store = useMemo(() => createStore(initialState), []);
+    const store = useMemo(() => createStore(initialState), deps);
     const Provider: StoreContextProvider = useMemo(
       () =>
         ({children}) => {
@@ -163,10 +163,10 @@ export const connectStore = <T,>(createStore: StoreFactory<T>) => {
           }
           return <StoreContext.Provider value={{store}}>{children}</StoreContext.Provider>;
         },
-      []
+      [store]
     );
 
-    return [Provider, createStoreHooks(() => store)] as const;
+    return [Provider, useMemo(() => createStoreHooks(() => store), [store])] as const;
   };
 
   return {

--- a/src/store/utils.tsx
+++ b/src/store/utils.tsx
@@ -1,7 +1,7 @@
-import {Context, FC, PropsWithChildren, createContext, useCallback, useContext, useMemo} from 'react';
+import {Context, FC, PropsWithChildren, createContext, useCallback, useContext, useEffect, useMemo} from 'react';
 
 import {capitalize, pick} from 'lodash';
-import {StateCreator, StoreApi, UseBoundStore, create} from 'zustand';
+import {StateCreator, StoreApi, createStore as create, useStore as useSelector} from 'zustand';
 import {devtools} from 'zustand/middleware';
 import {shallow} from 'zustand/shallow';
 
@@ -9,7 +9,7 @@ type HasAnyKeys<T, K extends string | number | symbol, True, False> = keyof T ex
   ? False
   : True;
 
-type Store<T> = UseBoundStore<StoreApi<T>>;
+type Store<T> = StoreApi<T>;
 type StoreFn<T> = () => Store<T>;
 
 type StoreFactory<T> = (initialState?: Partial<T>) => Store<T>;
@@ -24,40 +24,23 @@ type StoreField<T, K extends keyof T> = [T[K], StoreSetValue<T, K>];
 type StoreFieldFactory<T> = <K extends keyof T>(key: K) => StoreField<T, K>;
 type StorePick<T> = <K extends keyof T = never>(...keys: K[]) => Pick<T, K>;
 
-/**
- * Magic setter is used for useStoreSetter and useStoreSync hooks.
- * It provides a hidden function, that may replace any value in state.
- */
-const magicSet = Symbol('set data');
-type MagicSetter<T> = <K extends keyof T>(key: K, value: T[K]) => void;
-type MagicSetterState<T> = Record<typeof magicSet, MagicSetter<T>>;
-type MagicSetterSlice<T> = StateCreator<MagicSetterState<T>>;
-const createMagicSlice =
-  <T,>(): MagicSetterSlice<T> =>
-  (setData, _, api) => ({
-    [magicSet]: (key, value) => {
-      const state: any = api.getState();
-      const setter = `set${capitalize(key as string)}`;
-      if (setter in state) {
-        state[setter](value);
-      } else {
-        setData({[key]: value} as any);
-      }
-    },
-  });
-const getMagicSetter = <T,>(state: T): MagicSetter<T> => (state as MagicSetterState<T>)[magicSet];
-const callMagicSetter = <T, K extends keyof T>(state: T, key: K, value: T[K]): void =>
-  getMagicSetter(state)(key, value);
+const internalSet = <T, K extends keyof T>(api: StoreApi<T>, state: T, key: K, value: T[K]) => {
+  const setter = `set${capitalize(key as string)}`;
+  if (setter in (state as any)) {
+    (state as any)[setter](value);
+  } else {
+    api.setState({[key]: value} as any);
+  }
+};
 
 export const createStoreFactory =
   <T,>(name: string, createSlice: StateCreator<T>): StoreFactory<T> =>
   (initialState?) =>
-    create<T & MagicSetterState<T>>()(
+    create<T>()(
       devtools(
         (...a) => ({
           ...createSlice(...a),
           ...initialState,
-          ...createMagicSlice<T>()(...a),
         }),
         {
           name: `${name} - Zustand Store`,
@@ -104,7 +87,7 @@ const createUseStore =
 const createUseStoreGet =
   <T,>(useStore: StoreFn<T>): StoreGet<T> =>
   selector =>
-    useStore()(selector, shallow);
+    useSelector(useStore(), selector, shallow);
 
 const createUseStorePick =
   <T,>(useStore: StoreFn<T>): StorePick<T> =>
@@ -113,27 +96,31 @@ const createUseStorePick =
 
 const createUseStoreSync =
   <T,>(useStore: StoreFn<T>): StoreSync<T> =>
-  data =>
-    useStore()(state => {
+  data => {
+    const store = useStore();
+    useEffect(() => {
+      const state = store.getState();
       (Object.keys(data) as (keyof T)[]).forEach(key => {
         if (data[key] !== state[key]) {
-          callMagicSetter(state, key, data[key]);
+          internalSet(store, state, key, data[key]);
         }
       });
-    });
+    }, [store, data]);
+  };
 
 const createUseStoreSetter =
   <T,>(useStore: StoreFn<T>): StoreSetFactory<T> =>
-  key =>
-    useCallback(
+  key => {
+    const store = useStore();
+    return useCallback(
       value => {
-        useStore()(state => {
-          const nextValue = typeof value === 'function' ? (value as any)(state[key], state) : value;
-          callMagicSetter(state, key, nextValue);
-        });
+        const state = store.getState();
+        const nextValue = typeof value === 'function' ? (value as any)(state[key], state) : value;
+        internalSet(store, state, key, nextValue);
       },
-      [useStore, key]
+      [store, key]
     );
+  };
 
 const createUseStoreField =
   <T,>(useStore: StoreFn<T>): StoreFieldFactory<T> =>

--- a/src/store/utils.tsx
+++ b/src/store/utils.tsx
@@ -1,4 +1,4 @@
-import {Context, FC, PropsWithChildren, createContext, useCallback, useContext, useEffect, useMemo} from 'react';
+import {Context, FC, PropsWithChildren, createContext, useCallback, useContext, useLayoutEffect, useMemo} from 'react';
 
 import {capitalize, pick} from 'lodash';
 import {StateCreator, StoreApi, createStore as create, useStore as useSelector} from 'zustand';
@@ -98,7 +98,7 @@ const createUseStoreSync =
   <T,>(useStore: StoreFn<T>): StoreSync<T> =>
   data => {
     const store = useStore();
-    useEffect(() => {
+    useLayoutEffect(() => {
       const state = store.getState();
       (Object.keys(data) as (keyof T)[]).forEach(key => {
         if (data[key] !== state[key]) {


### PR DESCRIPTION
## Changes

- Fix `useStoreSync` - there was React update scheduled during the React render
- Simplify `useStoreSetter` - use vanilla Zustand store, to avoid calling `setState` from inside
  - It doesn't require now "magic setter" logic, it's done from outside
- Allow passing store dependencies - reinitialize the store from scratch when it has changed
  - Useful, when we want to completely erase the store when a different entity is chosen

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
