### PR TITLE
chore: persist `navigate` function across all routes

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -15,6 +15,7 @@ import {ConfigContext, DashboardContext, MainContext} from '@contexts';
 import {ModalHandler, ModalOutletProvider} from '@contexts/ModalContext';
 
 import {useAxiosInterceptors} from '@hooks/useAxiosInterceptors';
+import {useLastCallback} from '@hooks/useLastCallback';
 
 import {AiInsightsTab} from '@molecules';
 
@@ -47,7 +48,7 @@ const AppRoot: React.FC = () => {
 
   const dispatch = useAppDispatch();
   const location = useLocation();
-  const navigate = useNavigate();
+  const navigate = useLastCallback(useNavigate());
   const telemetry = useTelemetry();
   const apiEndpoint = useApiEndpoint();
 

--- a/src/hooks/useLastCallback.ts
+++ b/src/hooks/useLastCallback.ts
@@ -1,0 +1,13 @@
+import {useCallback} from 'react';
+import {useLatest} from 'react-use';
+
+type Fn = (...args: any) => any;
+
+/**
+ * Keep the same identity of a callback function,
+ * but calling the latest one anyway.
+ */
+export const useLastCallback = <T extends Fn>(fn: T): T => {
+  const ref = useLatest(fn);
+  return useCallback(((...args) => ref.current(...args)) as T, []);
+};


### PR DESCRIPTION
## Changes

- `react-router` changes the identity of `navigate` function when the location path name changes - now we will keep the always the same identity
   - thanks to that, we will have less memos and effects called on route change

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
