### PR TITLE
chore: simplify calling displayDefaultNotificationFlow

### DIFF
--- a/src/components/molecules/Definition/Definition.tsx
+++ b/src/components/molecules/Definition/Definition.tsx
@@ -85,11 +85,9 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
     return update({name, value})
       .then(displayDefaultNotificationFlow)
       .then(res => {
-        if (res && 'data' in res) {
-          notificationCall('passed', `${capitalize(label)} was successfully updated.`);
-          onUpdate?.(res.data);
-          refetch();
-        }
+        notificationCall('passed', `${capitalize(label)} was successfully updated.`);
+        onUpdate?.(res.data);
+        refetch();
       });
   };
 

--- a/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
+++ b/src/components/molecules/DeleteEntityModal/DeleteEntityModal.tsx
@@ -46,7 +46,7 @@ const DeleteEntityModal: React.FC<{
 
   const onDelete = () => {
     deleteEntity(idToDelete || name)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', `${capitalize(entityLabel)} was successfully deleted.`);
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/EntityDetailsContent.tsx
@@ -105,7 +105,7 @@ const EntityDetailsContent: React.FC = () => {
         },
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         if (entity === 'tests') {
           telemetry.event('runTest', {type});

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/FailureHandling.tsx
@@ -53,7 +53,7 @@ const FailureHandling: React.FC = () => {
         },
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', `Test was successfully updated.`));
   };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Labels.tsx
@@ -43,7 +43,7 @@ const Labels: React.FC = () => {
         labels: decomposeLabels(localLabels),
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', `${capitalize(namingMap[entity])} was successfully updated.`);
         setWasTouched(false);

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/NameNDescription.tsx
@@ -51,7 +51,7 @@ const NameNDescription: React.FC = () => {
         },
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', `${capitalize(namingMap[entity])} was successfully updated.`));
   };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsGeneral/Timeout.tsx
@@ -44,7 +44,7 @@ const Timeout: React.FC = () => {
         },
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', 'Test Timeout was successfully updated.'));
   };
 

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsScheduling/Schedule.tsx
@@ -46,7 +46,7 @@ const Schedule: React.FC = () => {
         schedule: cronString,
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         setWasTouched(false);
         notificationCall('passed', `${capitalize(namingMap[entity])} schedule was successfully updated.`);

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsTest/SettingsTest.tsx
@@ -24,7 +24,7 @@ const SettingsTest: React.FC = () => {
         ...data,
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', `Test settings was successfully updated.`);
       });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Arguments.tsx
@@ -58,7 +58,7 @@ const Arguments: React.FC = () => {
       id: details.name,
       data: successRecord,
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', 'Variables were successfully updated.');
       });

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/SettingsVariables/Variables.tsx
@@ -61,7 +61,7 @@ const Variables: React.FC = () => {
       id: details.name,
       data: successRecord,
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', `Variables were successfully updated.`);
       });

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -47,7 +47,7 @@ const Arguments: React.FC = () => {
         args: values.arguments,
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', 'Arguments were successfully updated.');
         dispatch(updateCurrentExecutorData({args: values.arguments}));

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -45,7 +45,7 @@ const Command: React.FC = () => {
         command: values.command.split(' '),
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', 'Command was successfully updated.');
         dispatch(updateCurrentExecutorData({command: values.command!.split(' ')}));

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -44,7 +44,7 @@ const ContainerImagePanel: React.FC = () => {
         ...values,
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', 'Container image was successfully updated.');
         dispatch(updateCurrentExecutorData({image: values.image}));

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -44,7 +44,7 @@ const PrivateRegistry: React.FC = () => {
         imagePullSecrets: newImagePullSecrets,
       },
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         dispatch(updateCurrentExecutorData({imagePullSecrets: newImagePullSecrets}));
         notificationCall('passed', 'Private registry was successfully updated.');

--- a/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
+++ b/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
@@ -54,12 +54,8 @@ const AddExecutorsModal: React.FC = () => {
     delete body.type;
 
     createExecutor(body)
-      .then(res => displayDefaultNotificationFlow(res))
-      .then(res => {
-        if (res && 'data' in res) {
-          navigate(`/executors/${res.data.metadata.name}`);
-        }
-      })
+      .then(displayDefaultNotificationFlow)
+      .then(res => navigate(`/executors/${res.data.metadata.name}`))
       .catch(err => {
         setError(err);
 

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -70,12 +70,10 @@ const Authentication: React.FC = () => {
     };
 
     return updateSource(body)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(res => {
-        if (res && 'data' in res) {
-          notificationCall('passed', 'Source was successfully updated.');
-          dispatch(setCurrentSource({...body, ...res.data.spec}));
-        }
+        notificationCall('passed', 'Source was successfully updated.');
+        dispatch(setCurrentSource({...body, ...res.data.spec}));
       });
   };
 

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -61,7 +61,7 @@ const NameNUrl: React.FC = () => {
     };
 
     return updateSource(body)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', 'Source was successfully updated.');
         dispatch(setCurrentSource(body));

--- a/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
+++ b/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
@@ -60,12 +60,8 @@ const AddSourceModal: React.FC = () => {
     };
 
     createSource(body)
-      .then(res => displayDefaultNotificationFlow(res))
-      .then(res => {
-        if (res && 'data' in res) {
-          navigate(`/sources/${res.data.metadata.name}`);
-        }
-      })
+      .then(displayDefaultNotificationFlow)
+      .then(res => navigate(`/sources/${res.data.metadata.name}`))
       .catch(err => {
         setError(err);
 

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
@@ -54,16 +54,14 @@ const TestSuiteCreationModalContent: React.FC = () => {
       ...values,
       labels: decomposeLabels(localLabels),
     })
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(res => {
-        if (res && 'data' in res) {
-          telemetry.event('createTestSuite');
+        telemetry.event('createTestSuite');
 
-          dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}));
+        dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}));
 
-          navigate(`/test-suites/executions/${res.data.metadata.name}`);
-          closeModal();
-        }
+        navigate(`/test-suites/executions/${res.data.metadata.name}`);
+        closeModal();
       })
       .catch(err => {
         setError(err);

--- a/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationModalContent.tsx
+++ b/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationModalContent.tsx
@@ -69,14 +69,14 @@ const TestCreationModalContent: React.FC = () => {
   }, [testType]);
 
   const onSuccess = (res: RTKResponse<MetadataResponse<Test>>) => {
-    return displayDefaultNotificationFlow(res).then(() => {
-      if ('data' in res) {
-        telemetry.event('createTest', {type: res.data.spec?.type});
+    return Promise.resolve(res)
+      .then(displayDefaultNotificationFlow)
+      .then(({data}) => {
+        telemetry.event('createTest', {type: data.spec?.type});
 
-        navigate(`/tests/executions/${res.data.metadata.name}`);
+        navigate(`/tests/executions/${data.metadata.name}`);
         closeModal();
-      }
-    });
+      });
   };
 
   return (

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/General/Name.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/General/Name.tsx
@@ -32,7 +32,7 @@ const Name: React.FC = () => {
     };
 
     return updateTrigger(body)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(() => {
         notificationCall('passed', 'Trigger was successfully updated.');
         setCurrentTrigger(body);

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/Action.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/Action.tsx
@@ -47,13 +47,11 @@ const Condition: React.FC = () => {
     };
 
     return updateTrigger(body)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(res => {
-        if (res && 'data' in res) {
-          notificationCall('passed', 'Trigger was successfully updated.');
-          setCurrentTrigger(res.data);
-          form.setFieldsValue(getActionFormValues(res.data));
-        }
+        notificationCall('passed', 'Trigger was successfully updated.');
+        setCurrentTrigger(res.data);
+        form.setFieldsValue(getActionFormValues(res.data));
       });
   };
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
@@ -45,13 +45,11 @@ const Condition: React.FC = () => {
     };
 
     return updateTrigger(body)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(res => {
-        if (res && 'data' in res) {
-          notificationCall('passed', 'Trigger was successfully updated.');
-          setCurrentTrigger(res.data);
-          form.setFieldsValue(getConditionFormValues(res.data));
-        }
+        notificationCall('passed', 'Trigger was successfully updated.');
+        setCurrentTrigger(res.data);
+        form.setFieldsValue(getConditionFormValues(res.data));
       });
   };
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/ResourceCondition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/ResourceCondition.tsx
@@ -39,16 +39,14 @@ const ResourceCondition: React.FC = () => {
     };
 
     return updateTrigger(body)
-      .then(res => displayDefaultNotificationFlow(res))
+      .then(displayDefaultNotificationFlow)
       .then(res => {
-        if (res && 'data' in res) {
-          notificationCall('passed', 'Trigger was successfully updated.');
-          setCurrentTrigger(res.data);
-          form.setFieldsValue({
-            timeout: res.data.conditionSpec?.timeout,
-            conditions: res.data.conditionSpec?.conditions || [],
-          });
-        }
+        notificationCall('passed', 'Trigger was successfully updated.');
+        setCurrentTrigger(res.data);
+        form.setFieldsValue({
+          timeout: res.data.conditionSpec?.timeout,
+          conditions: res.data.conditionSpec?.conditions || [],
+        });
       });
   };
 

--- a/src/components/pages/Triggers/TriggersList/AddTriggerModal/AddTriggerModal.tsx
+++ b/src/components/pages/Triggers/TriggersList/AddTriggerModal/AddTriggerModal.tsx
@@ -80,11 +80,7 @@ const AddTriggerModal: React.FC = () => {
     };
     createTrigger(body)
       .then(displayDefaultNotificationFlow)
-      .then(res => {
-        if (res && 'data' in res) {
-          navigate(`/triggers/${res.data.name}`);
-        }
-      })
+      .then(res => navigate(`/triggers/${res.data.name}`))
       .catch(err => {
         setError(err);
 

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -33,13 +33,14 @@ export const getErrorFromResponse = (res?: RTKResponse<unknown>): unknown => {
   }
 };
 
-export async function displayDefaultNotificationFlow<T = unknown>(res?: RTKResponse<T>) {
+export function displayDefaultNotificationFlow<T extends RTKResponse<any>>(
+  res?: T
+): T extends {error: any} ? never : T {
   const error = getErrorFromResponse(res);
-
   if (error) {
     throw error;
   }
-  return res;
+  return res as any;
 }
 
 export function displayDefaultErrorNotification(err: DefaultRequestError) {


### PR DESCRIPTION
## Changes

- make the `displayDefaultNotificationFlow` sync as it should be
- fix the `displayDefaultNotificationFlow` returned type, to state that it has no error
- simplify wrapping functions (`res => displayDefaultNotificationFlow(res)` => `displayDefaultNotificationFlow`)

## Fixes

- part of https://github.com/kubeshop/testkube/issues/3958

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
