### PR TITLE
feat: add routing to different tabs

### DIFF
--- a/src/DashboardRewrite.tsx
+++ b/src/DashboardRewrite.tsx
@@ -1,0 +1,23 @@
+import {FC, useContext, useLayoutEffect} from 'react';
+import {useParams} from 'react-router-dom';
+
+import {DashboardContext} from '@contexts';
+
+interface DashboardRewriteProps {
+  pattern: string;
+  keepQuery?: boolean;
+}
+
+const DashboardRewrite: FC<DashboardRewriteProps> = ({pattern, keepQuery = false}) => {
+  const params = useParams();
+  const pathname = pattern.replace(/:([^/]+)/g, (_, key) => `${params[key]}`);
+  const {navigate, location} = useContext(DashboardContext);
+
+  useLayoutEffect(() => {
+    navigate(keepQuery ? {...location, pathname} : pathname, {replace: true});
+  }, [pattern, keepQuery]);
+
+  return null;
+};
+
+export default DashboardRewrite;

--- a/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -61,8 +61,8 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
               url:
                 status !== 'queued' && status !== 'aborted'
                   ? execution?.id
-                    ? `/tests/executions/${result.test}/execution/${execution.id}`
-                    : `/tests/executions/${result.test}`
+                    ? `/tests/${result.test}/executions/${execution.id}`
+                    : `/tests/${result.test}`
                   : null,
             };
           })

--- a/src/components/molecules/RunningContext/RunningContext.tsx
+++ b/src/components/molecules/RunningContext/RunningContext.tsx
@@ -5,13 +5,11 @@ import {Tooltip} from 'antd';
 
 import {ExternalLink} from '@atoms';
 
-import {MainContext} from '@contexts';
+import {DashboardContext} from '@contexts';
 
 import {Text} from '@custom-antd';
 
 import {Entity} from '@models/entity';
-
-import {setSettingsTabConfig} from '@redux/reducers/configSlice';
 
 import Colors from '@styles/Colors';
 
@@ -27,6 +25,7 @@ export enum RunningContextType {
 }
 
 type RunningContextProps = {
+  id: string;
   type?: RunningContextType;
   context?: string;
   onClose: () => void;
@@ -34,9 +33,9 @@ type RunningContextProps = {
 };
 
 const RunningContext: React.FC<RunningContextProps> = props => {
-  const {type = RunningContextType.default, context = '', onClose, entity} = props;
+  const {id, type = RunningContextType.default, context = '', onClose, entity} = props;
 
-  const {dispatch} = useContext(MainContext);
+  const {navigate} = useContext(DashboardContext);
 
   const runContextMap = {
     'user-ui': 'Manual UI',
@@ -57,7 +56,7 @@ const RunningContext: React.FC<RunningContextProps> = props => {
         <ExternalLink
           onClick={() => {
             onClose();
-            dispatch(setSettingsTabConfig({entity, tab: 'Scheduling'}));
+            navigate(`/${entity}/${id}/settings/scheduling`);
           }}
         >
           {context}
@@ -67,7 +66,8 @@ const RunningContext: React.FC<RunningContextProps> = props => {
       'Scheduler'
     ),
     testsuite: context ? (
-      <Link to={`/test-suites/executions/test-suite/execution/${context}`}>{context}</Link>
+      // TODO: It would be good to point to execution, but we don't have ID
+      <Link to={`/test-suites/${context.replace(/^ts-/, '').replace(/-[0-9]+$/, '')}`}>{context}</Link>
     ) : (
       'Test Suite'
     ),

--- a/src/components/molecules/SettingsLayout/SettingsLayout.tsx
+++ b/src/components/molecules/SettingsLayout/SettingsLayout.tsx
@@ -10,7 +10,7 @@ export interface SettingsLayoutTab {
   children: FC<{setId(id: string): void}> | ReactElement<any, any> | null;
 }
 
-interface SettingsLayoutProps {
+export interface SettingsLayoutProps {
   tabs: SettingsLayoutTab[];
   active?: string;
   onChange?: (id: string) => void;

--- a/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
@@ -30,7 +30,7 @@ import ExecutionDetailsDrawer from '../ExecutionDetailsDrawer';
 
 import {EntityDetailsWrapper} from './EntityDetailsContainer.styled';
 
-interface EntityDetailsContainerProps {
+export interface EntityDetailsContainerProps {
   entity: Entity;
   tab?: string;
 }
@@ -55,7 +55,7 @@ const EntityDetailsContainer: React.FC<EntityDetailsContainerProps> = props => {
     },
     [execId]
   );
-  const [EntityStoreProvider, {sync: useEntityDetailsSync, useField: useEntityDetailsField}] =
+  const [EntityStoreProvider, {sync: useEntityDetailsSync, useField: useEntityDetailsField, pick: useEntityDetailsPick}] =
     initializeEntityDetailsStore({entity, id}, [entity, id, navigate]);
 
   const [metrics, setMetrics] = useEntityDetailsField('metrics');
@@ -231,8 +231,10 @@ const EntityDetailsContainer: React.FC<EntityDetailsContainerProps> = props => {
     error,
   });
 
+  const {details: currentDetails} = useEntityDetailsPick('details');
+
   const errorPage = error && <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
-  const loadingPage = !rawDetails && <Loading />;
+  const loadingPage = (!rawDetails || !currentDetails) && <Loading />;
 
   const setTab = useLastCallback((nextTab: string) => {
     navigate(`/${entity}/${id}/${nextTab}`);

--- a/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
@@ -30,11 +30,16 @@ import ExecutionDetailsDrawer from '../ExecutionDetailsDrawer';
 
 import {EntityDetailsWrapper} from './EntityDetailsContainer.styled';
 
-const EntityDetailsContainer: React.FC<{entity: Entity}> = props => {
-  const {entity} = props;
+interface EntityDetailsContainerProps {
+  entity: Entity;
+  tab?: string;
+}
+
+const EntityDetailsContainer: React.FC<EntityDetailsContainerProps> = props => {
+  const {entity, tab} = props;
   const {useGetEntityDetails, useGetMetrics, useGetExecutions} = useEntityDetailsConfig(entity);
 
-  const {id, execId} = useParams();
+  const {id, execId, settingsTab} = useParams();
 
   const {navigate} = useContext(DashboardContext);
 
@@ -42,10 +47,10 @@ const EntityDetailsContainer: React.FC<{entity: Entity}> = props => {
     {
       id: execId,
       open: useLastCallback((targetId: string) => {
-        navigate(`/${entity}/executions/${id}/execution/${targetId}`);
+        navigate(`/${entity}/${id}/executions/${targetId}`);
       }),
       close: useLastCallback(() => {
-        navigate(`/${entity}/executions/${id}`);
+        navigate(`/${entity}/${id}`);
       }),
     },
     [execId]
@@ -229,12 +234,25 @@ const EntityDetailsContainer: React.FC<{entity: Entity}> = props => {
   const errorPage = error && <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
   const loadingPage = !rawDetails && <Loading />;
 
+  const setTab = useLastCallback((nextTab: string) => {
+    navigate(`/${entity}/${id}/${nextTab}`);
+  });
+
+  const setSettingsTab = useLastCallback((nextTab: string) => {
+    navigate(`/${entity}/${id}/settings/${nextTab}`);
+  });
+
   return (
     <EntityStoreProvider>
       <ExecutionStoreProvider>
         {errorPage || loadingPage || (
           <EntityDetailsWrapper>
-            <EntityDetailsContent />
+            <EntityDetailsContent
+              tab={tab || 'executions'}
+              settingsTab={settingsTab || 'general'}
+              onTabChange={setTab}
+              onSettingsTabChange={setSettingsTab}
+            />
             <ExecutionDetailsDrawer />
           </EntityDetailsWrapper>
         )}

--- a/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer.tsx
@@ -55,8 +55,10 @@ const EntityDetailsContainer: React.FC<EntityDetailsContainerProps> = props => {
     },
     [execId]
   );
-  const [EntityStoreProvider, {sync: useEntityDetailsSync, useField: useEntityDetailsField, pick: useEntityDetailsPick}] =
-    initializeEntityDetailsStore({entity, id}, [entity, id, navigate]);
+  const [
+    EntityStoreProvider,
+    {sync: useEntityDetailsSync, useField: useEntityDetailsField, pick: useEntityDetailsPick},
+  ] = initializeEntityDetailsStore({entity, id}, [entity, id, navigate]);
 
   const [metrics, setMetrics] = useEntityDetailsField('metrics');
   const [, setCurrentPage] = useEntityDetailsField('currentPage');

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/EmptyExecutionsListContent/EmptyExecutionsListContent.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/ExecutionsTable/EmptyExecutionsListContent/EmptyExecutionsListContent.tsx
@@ -1,12 +1,10 @@
 import React, {useContext} from 'react';
 
-import {MainContext} from '@contexts';
+import {DashboardContext} from '@contexts';
 
 import {EmptyListContent, HelpCard} from '@molecules';
 
 import {Permissions, usePermission} from '@permissions/base';
-
-import {setSettingsTabConfig} from '@redux/reducers/configSlice';
 
 import {useEntityDetailsPick} from '@store/entityDetails';
 
@@ -19,8 +17,8 @@ type EmptyExecutionsListContentProps = {
 const EmptyExecutionsListContent: React.FC<EmptyExecutionsListContentProps> = props => {
   const {onRun} = props;
 
-  const {entity, details} = useEntityDetailsPick('entity', 'details');
-  const {dispatch} = useContext(MainContext);
+  const {id, entity, details} = useEntityDetailsPick('id', 'entity', 'details');
+  const {navigate} = useContext(DashboardContext);
   const mayRun = usePermission(Permissions.runEntity);
 
   if (!details) {
@@ -62,7 +60,7 @@ const EmptyExecutionsListContent: React.FC<EmptyExecutionsListContentProps> = pr
         title="Congrats, now add your tests to this suite"
         description="In order to be able to run your test suite you need to define the tests you want to add."
         buttonText="Add your tests to this suite"
-        onButtonClick={() => dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}))}
+        onButtonClick={() => navigate(`/${entity}/${id}/settings/tests`)}
         actionType="create"
       >
         <HelpCard isLink link={externalLinks.createTestSuite}>

--- a/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/Settings.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsContent/Settings/Settings.tsx
@@ -1,8 +1,9 @@
-import React, {ReactElement} from 'react';
+import React, {FC} from 'react';
 
 import {Entity} from '@models/entity';
 
 import {SettingsLayout} from '@molecules';
+import {SettingsLayoutProps} from '@molecules/SettingsLayout/SettingsLayout';
 
 import {useEntityDetailsPick} from '@store/entityDetails';
 
@@ -14,39 +15,31 @@ import SettingsTest from './SettingsTest';
 import SettingsTests from './SettingsTests';
 import SettingsVariables from './SettingsVariables';
 
-const testSettings = (
-  <SettingsLayout
-    tabs={[
-      {id: 'general', label: 'General', children: <General />},
-      {id: 'test', label: 'Test', children: <SettingsTest />},
-      {id: 'execution', label: 'Execution', children: <SettingsExecution />},
-      {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
-      {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
-      {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
-    ]}
-  />
-);
-
-const testSuiteSettings = (
-  <SettingsLayout
-    tabs={[
-      {id: 'general', label: 'General', children: <General />},
-      {id: 'tests', label: 'Tests', children: <SettingsTests />},
-      {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
-      {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
-      {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
-    ]}
-  />
-);
-
-const tabsConfigMap: Record<Entity, ReactElement<any, any>> = {
-  'test-suites': testSuiteSettings,
-  tests: testSettings,
+const tabsConfigMap: Record<Entity, SettingsLayoutProps['tabs']> = {
+  'test-suites': [
+    {id: 'general', label: 'General', children: <General />},
+    {id: 'tests', label: 'Tests', children: <SettingsTests />},
+    {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
+    {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
+    {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
+  ],
+  tests: [
+    {id: 'general', label: 'General', children: <General />},
+    {id: 'test', label: 'Test', children: <SettingsTest />},
+    {id: 'execution', label: 'Execution', children: <SettingsExecution />},
+    {id: 'variables', label: 'Variables & Secrets', children: <SettingsVariables />},
+    {id: 'scheduling', label: 'Scheduling', children: <SettingsScheduling />},
+    {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
+  ],
 };
+interface SettingsProps {
+  tab: string;
+  onTabChange: (tab: string) => void;
+}
 
-const Settings: React.FC = () => {
+const Settings: FC<SettingsProps> = ({tab, onTabChange}) => {
   const {entity} = useEntityDetailsPick('entity');
-  return tabsConfigMap[entity];
+  return <SettingsLayout active={tab} onChange={onTabChange} tabs={tabsConfigMap[entity]} />;
 };
 
 export default Settings;

--- a/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawerHeader.tsx
+++ b/src/components/organisms/EntityDetails/ExecutionDetailsDrawer/ExecutionDetailsDrawerHeader.tsx
@@ -31,7 +31,7 @@ type ExecutionDetailsDrawerHeaderProps = {
 };
 
 const ExecutionDetailsDrawerHeader: React.FC<ExecutionDetailsDrawerHeaderProps> = props => {
-  const {entity} = useEntityDetailsPick('entity');
+  const {id: entityId, entity} = useEntityDetailsPick('id', 'entity');
   const {close, id: execId} = useExecutionDetailsPick('close', 'id');
   const {useAbortExecution} = useEntityDetailsConfig(entity);
   const mayManageExecution = usePermission(Permissions.manageEntityExecution);
@@ -100,6 +100,7 @@ const ExecutionDetailsDrawerHeader: React.FC<ExecutionDetailsDrawerHeaderProps> 
             <Text ellipsis>
               <Text color={Colors.slate400}>Trigger:&nbsp;</Text>
               <RunningContext
+                id={entityId!}
                 type={runningContext?.type}
                 context={runningContext?.context}
                 onClose={close}

--- a/src/components/pages/EntityDetailsBlueprintRenderer/EntityDetailsBlueprintRenderer.tsx
+++ b/src/components/pages/EntityDetailsBlueprintRenderer/EntityDetailsBlueprintRenderer.tsx
@@ -1,9 +1,0 @@
-import {FC} from 'react';
-
-import {Entity} from '@models/entity';
-
-import {EntityDetailsContainer} from '@organisms';
-
-const EntityDetailsBlueprintRenderer: FC<{entity: Entity}> = ({entity}) => <EntityDetailsContainer entity={entity} />;
-
-export default EntityDetailsBlueprintRenderer;

--- a/src/components/pages/EntityDetailsBlueprintRenderer/index.ts
+++ b/src/components/pages/EntityDetailsBlueprintRenderer/index.ts
@@ -1,1 +1,1 @@
-export {default} from './EntityDetailsBlueprintRenderer';
+export {EntityDetailsContainer as default} from '@organisms';

--- a/src/components/pages/EntityDetailsBlueprintRenderer/index.ts
+++ b/src/components/pages/EntityDetailsBlueprintRenderer/index.ts
@@ -1,1 +1,6 @@
-export {EntityDetailsContainer as default} from '@organisms';
+import {createElement} from 'react';
+
+import {EntityDetailsContainer} from '@organisms';
+import {EntityDetailsContainerProps} from '@organisms/EntityDetails/EntityDetailsContainer/EntityDetailsContainer';
+
+export default (props: EntityDetailsContainerProps) => createElement(EntityDetailsContainer, props);

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorSettings.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ExecutorSettings.tsx
@@ -9,10 +9,14 @@ import General from './General';
 
 interface ExecutorSettingsProps {
   reload: () => void;
+  tab: string;
+  onTabChange: (tab: string) => void;
 }
 
-const ExecutorSettings: FC<ExecutorSettingsProps> = ({reload}) => (
+const ExecutorSettings: FC<ExecutorSettingsProps> = ({reload, tab, onTabChange}) => (
   <SettingsLayout
+    active={tab}
+    onChange={onTabChange}
     tabs={[
       {id: 'general', label: 'General', children: <General />},
       {id: 'image', label: 'Container image', children: <ContainerImage />},

--- a/src/components/pages/Executors/Executors.tsx
+++ b/src/components/pages/Executors/Executors.tsx
@@ -10,7 +10,10 @@ const Executors: React.FC = () => {
     <>
       <Routes>
         <Route index element={<ExecutorsList />} />
-        <Route path=":id" element={<ExecutorDetails />} />
+        <Route path=":id" element={<ExecutorDetails />}>
+          <Route index element={null} />
+          <Route path="settings/:settingsTab" element={null} />
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Outlet />

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/SourceSettings.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/SourceSettings.tsx
@@ -7,10 +7,14 @@ import General from './General';
 
 interface SourceSettingsProps {
   reload: () => void;
+  tab: string;
+  onTabChange: (tab: string) => void;
 }
 
-const SourceSettings: FC<SourceSettingsProps> = ({reload}) => (
+const SourceSettings: FC<SourceSettingsProps> = ({reload, tab, onTabChange}) => (
   <SettingsLayout
+    active={tab}
+    onChange={onTabChange}
     tabs={[
       {id: 'general', label: 'General', children: <General />},
       {id: 'definition', label: 'Definition', children: <SourceSettingsDefinition reload={reload} />},

--- a/src/components/pages/Sources/Sources.tsx
+++ b/src/components/pages/Sources/Sources.tsx
@@ -10,7 +10,10 @@ const Sources: React.FC = () => {
     <>
       <Routes>
         <Route index element={<SourcesList />} />
-        <Route path=":id" element={<SourceDetails />} />
+        <Route path=":id" element={<SourceDetails />}>
+          <Route index element={null} />
+          <Route path="settings/:settingsTab" element={null} />
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Outlet />

--- a/src/components/pages/TestSuites/TestSuites.tsx
+++ b/src/components/pages/TestSuites/TestSuites.tsx
@@ -2,18 +2,34 @@ import {Outlet, Route, Routes} from 'react-router-dom';
 
 import {EntityDetailsBlueprintRenderer, NotFound} from '@pages';
 
+import DashboardRewrite from '@src/DashboardRewrite';
+
 import TestSuitesList from './TestSuitesList';
 
 const TestSuites: React.FC = () => {
   return (
     <>
       <Routes>
-        <Route index element={<TestSuitesList />} />
-        <Route path="executions/:id" element={<EntityDetailsBlueprintRenderer entity="test-suites" />} />
+        {/* Backwards compatibility */}
+        <Route path="executions/:id" element={<DashboardRewrite pattern="/tests/:id" />} />
         <Route
           path="executions/:id/execution/:execId"
-          element={<EntityDetailsBlueprintRenderer entity="test-suites" />}
+          element={<DashboardRewrite pattern="/tests/:id/executions/:execId" />}
         />
+
+        <Route index element={<TestSuitesList />} />
+        <Route path=":id">
+          <Route index element={<EntityDetailsBlueprintRenderer entity="test-suites" />} />
+          <Route path="commands" element={<EntityDetailsBlueprintRenderer entity="test-suites" tab="commands" />} />
+          <Route path="executions" element={<EntityDetailsBlueprintRenderer entity="test-suites" tab="executions" />}>
+            <Route index element={null} />
+            <Route path=":execId" element={null} />
+          </Route>
+          <Route path="settings" element={<EntityDetailsBlueprintRenderer entity="test-suites" tab="settings" />}>
+            <Route index element={null} />
+            <Route path=":settingsTab" element={null} />
+          </Route>
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Outlet />

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
@@ -2,7 +2,7 @@ import React, {useContext, useEffect, useRef, useState} from 'react';
 
 import {Form, Input} from 'antd';
 
-import {DashboardContext, MainContext, ModalContext} from '@contexts';
+import {DashboardContext, ModalContext} from '@contexts';
 
 import {Button, FormItem, Text} from '@custom-antd';
 
@@ -13,8 +13,6 @@ import {ErrorNotificationConfig} from '@models/notifications';
 
 import {LabelsSelect, NotificationContent} from '@molecules';
 import {decomposeLabels} from '@molecules/LabelsSelect/utils';
-
-import {setSettingsTabConfig} from '@redux/reducers/configSlice';
 
 import {useAddTestSuiteMutation} from '@services/testSuites';
 
@@ -36,7 +34,6 @@ type TestSuiteCreationModalFormValues = {
 const TestSuiteCreationModalContent: React.FC = () => {
   const [form] = Form.useForm<TestSuiteCreationModalFormValues>();
 
-  const {dispatch} = useContext(MainContext);
   const {navigate} = useContext(DashboardContext);
   const {closeModal} = useContext(ModalContext);
   const telemetry = useTelemetry();
@@ -57,10 +54,7 @@ const TestSuiteCreationModalContent: React.FC = () => {
       .then(displayDefaultNotificationFlow)
       .then(res => {
         telemetry.event('createTestSuite');
-
-        dispatch(setSettingsTabConfig({entity: 'test-suites', tab: 'Tests'}));
-
-        navigate(`/test-suites/executions/${res.data.metadata.name}`);
+        navigate(`/test-suites/${res.data.metadata.name}/settings/tests`);
         closeModal();
       })
       .catch(err => {

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuitesList.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuitesList.tsx
@@ -53,7 +53,7 @@ const TestSuitesList: FC = () => {
   }, [data]);
 
   const [abortAll] = useAbortAllTestSuiteExecutionsMutation();
-  const onItemClick = useCallback((item: TestSuite) => navigate(`/test-suites/executions/${item.name}`), []);
+  const onItemClick = useCallback((item: TestSuite) => navigate(`/test-suites/${item.name}`), []);
   const onItemAbort = useCallback((item: TestSuite) => {
     abortAll({id: item.name})
       .unwrap()

--- a/src/components/pages/Tests/Tests.tsx
+++ b/src/components/pages/Tests/Tests.tsx
@@ -2,15 +2,34 @@ import {Outlet, Route, Routes} from 'react-router-dom';
 
 import {EntityDetailsBlueprintRenderer, NotFound} from '@pages';
 
+import DashboardRewrite from '@src/DashboardRewrite';
+
 import TestsList from './TestsList';
 
 const Tests: React.FC = () => {
   return (
     <>
       <Routes>
+        {/* Backwards compatibility */}
+        <Route path="executions/:id" element={<DashboardRewrite pattern="/tests/:id" />} />
+        <Route
+          path="executions/:id/execution/:execId"
+          element={<DashboardRewrite pattern="/tests/:id/executions/:execId" />}
+        />
+
         <Route index element={<TestsList />} />
-        <Route path="executions/:id" element={<EntityDetailsBlueprintRenderer entity="tests" />} />
-        <Route path="executions/:id/execution/:execId" element={<EntityDetailsBlueprintRenderer entity="tests" />} />
+        <Route path=":id">
+          <Route index element={<EntityDetailsBlueprintRenderer entity="tests" />} />
+          <Route path="commands" element={<EntityDetailsBlueprintRenderer entity="tests" tab="commands" />} />
+          <Route path="executions" element={<EntityDetailsBlueprintRenderer entity="tests" tab="executions" />}>
+            <Route index element={null} />
+            <Route path=":execId" element={null} />
+          </Route>
+          <Route path="settings" element={<EntityDetailsBlueprintRenderer entity="tests" tab="settings" />}>
+            <Route index element={null} />
+            <Route path=":settingsTab" element={null} />
+          </Route>
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Outlet />

--- a/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationModalContent.tsx
+++ b/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationModalContent.tsx
@@ -74,7 +74,7 @@ const TestCreationModalContent: React.FC = () => {
       .then(({data}) => {
         telemetry.event('createTest', {type: data.spec?.type});
 
-        navigate(`/tests/executions/${data.metadata.name}`);
+        navigate(`/tests/${data.metadata.name}`);
         closeModal();
       });
   };

--- a/src/components/pages/Tests/TestsList/TestsList.tsx
+++ b/src/components/pages/Tests/TestsList/TestsList.tsx
@@ -54,7 +54,7 @@ const TestsList: FC = () => {
   }, [data]);
 
   const [abortAll] = useAbortAllTestExecutionsMutation();
-  const onItemClick = useCallback((item: Test) => navigate(`/tests/executions/${item.name}`), []);
+  const onItemClick = useCallback((item: Test) => navigate(`/tests/${item.name}`), []);
   const onItemAbort = useCallback((item: Test) => {
     abortAll({id: item.name})
       .unwrap()

--- a/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
@@ -47,7 +47,7 @@ const TriggerDetails = () => {
   if (error) {
     return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
   }
-  if (!triggerDetails) {
+  if (!triggerDetails || !currentState.current) {
     return <Loading />;
   }
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
@@ -1,9 +1,11 @@
-import {useCallback, useContext, useEffect, useState} from 'react';
+import {useCallback, useContext, useEffect} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {Tabs} from 'antd';
 
 import {DashboardContext, MainContext} from '@contexts';
+
+import {useLastCallback} from '@hooks/useLastCallback';
 
 import {PageHeader, PageWrapper} from '@organisms';
 
@@ -22,9 +24,7 @@ const TriggerDetails = () => {
   const {isClusterAvailable} = useContext(MainContext);
   const {navigate} = useContext(DashboardContext);
 
-  const name = useParams().id!;
-
-  const [activeTabKey, setActiveTabKey] = useState('Settings');
+  const {id: name, settingsTab = 'general'} = useParams() as {id: string; settingsTab?: string};
 
   const {data: triggerDetails, error, refetch} = useGetTriggerByIdQuery(name, {skip: !isClusterAvailable});
   const {data: triggersKeyMap, refetch: refetchKeyMap} = useGetTriggersKeyMapQuery(null, {skip: !isClusterAvailable});
@@ -40,6 +40,10 @@ const TriggerDetails = () => {
     reload();
   }, [name]);
 
+  const setSettingsTab = useLastCallback((nextTab: string) => {
+    navigate(`/triggers/${name}/settings/${nextTab}`);
+  });
+
   if (error) {
     return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
   }
@@ -53,14 +57,12 @@ const TriggerDetails = () => {
 
       <PageHeader onBack={() => navigate('/triggers')} title={name} />
       <Tabs
-        activeKey={activeTabKey}
-        onChange={setActiveTabKey}
         destroyInactiveTabPane
         items={[
           {
-            key: 'Settings',
+            key: 'settings',
             label: 'Settings',
-            children: <TriggerSettings reload={reload} />,
+            children: <TriggerSettings reload={reload} tab={settingsTab} onTabChange={setSettingsTab} />,
           },
         ]}
       />

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
@@ -9,10 +9,14 @@ import TriggerCondition from './TriggerCondition';
 
 interface TriggerSettingsProps {
   reload: () => void;
+  tab: string;
+  onTabChange: (tab: string) => void;
 }
 
-const TriggerSettings: FC<TriggerSettingsProps> = ({reload}) => (
+const TriggerSettings: FC<TriggerSettingsProps> = ({reload, tab, onTabChange}) => (
   <SettingsLayout
+    active={tab}
+    onChange={onTabChange}
     tabs={[
       {id: 'general', label: 'General', children: <General />},
       {id: 'condition', label: 'Trigger Condition', children: <TriggerCondition />},

--- a/src/components/pages/Triggers/Triggers.tsx
+++ b/src/components/pages/Triggers/Triggers.tsx
@@ -10,7 +10,10 @@ const Triggers: React.FC = () => {
     <>
       <Routes>
         <Route index element={<TriggersList />} />
-        <Route path=":id" element={<TriggerDetails />} />
+        <Route path=":id" element={<TriggerDetails />}>
+          <Route index element={null} />
+          <Route path="settings/:settingsTab" element={null} />
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Outlet />

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,12 +1,5 @@
-import {Entity} from './entity';
-
-type SettingsTabConfigType = {entity: Entity; tab: number | string};
-
 interface ConfigState {
   namespace: string;
-  redirectTarget: {
-    settingsTabConfig: SettingsTabConfigType | null;
-  };
   fullScreenLogOutput: {
     isFullScreenLogOutput: boolean;
     logOutput: string;
@@ -27,4 +20,4 @@ type ClusterConfig = {
   enableTelemetry: boolean;
 };
 
-export type {ConfigState, Coordinates, ClusterConfig, SettingsTabConfigType};
+export type {ConfigState, Coordinates, ClusterConfig};

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -72,9 +72,6 @@ const initialExecutorsState: ExecutorsState = {
 
 const initialConfigState: ConfigState = {
   namespace: 'testkube',
-  redirectTarget: {
-    settingsTabConfig: null,
-  },
   fullScreenLogOutput: {
     isFullScreenLogOutput: false,
     logOutput: '',

--- a/src/redux/reducers/configSlice.ts
+++ b/src/redux/reducers/configSlice.ts
@@ -1,6 +1,6 @@
 import {Draft, PayloadAction, createSlice} from '@reduxjs/toolkit';
 
-import {ConfigState, Coordinates, SettingsTabConfigType} from '@models/config';
+import {ConfigState, Coordinates} from '@models/config';
 
 import initialState from '@redux/initialState';
 
@@ -23,12 +23,6 @@ export const configSlice = createSlice({
       state.fullScreenLogOutput.isFullScreenLogOutput = false;
       state.fullScreenLogOutput.logOutput = '';
     },
-    setSettingsTabConfig: (state: Draft<ConfigState>, action: PayloadAction<SettingsTabConfigType>) => {
-      state.redirectTarget.settingsTabConfig = action.payload;
-    },
-    closeSettingsTabConfig: (state: Draft<ConfigState>) => {
-      state.redirectTarget.settingsTabConfig = null;
-    },
     setLogOutputDOMRect: (state: Draft<ConfigState>, action: PayloadAction<Coordinates>) => {
       state.fullScreenLogOutput.logOutputDOMRect = action?.payload;
     },
@@ -36,17 +30,9 @@ export const configSlice = createSlice({
 });
 
 export const selectNamespace = (state: RootState) => state.config.namespace;
-export const selectSettingsTabConfig = (state: RootState) => state.config.redirectTarget.settingsTabConfig;
 export const selectFullScreenLogOutput = (state: RootState) => state.config.fullScreenLogOutput;
 
-export const {
-  setIsFullScreenLogOutput,
-  closeFullScreenLogOutput,
-  setLogOutput,
-  setSettingsTabConfig,
-  closeSettingsTabConfig,
-  setNamespace,
-  setLogOutputDOMRect,
-} = configSlice.actions;
+export const {setIsFullScreenLogOutput, closeFullScreenLogOutput, setLogOutput, setNamespace, setLogOutputDOMRect} =
+  configSlice.actions;
 
 export default configSlice.reducer;


### PR DESCRIPTION
## Changes

- add routing to specific tabs in the UI
- clean up routes for tests and test suites, while maintaining backwards compatibility

## Fixes

- kubeshop/testkube#3708

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
