### PR TITLE
fix: Zustand interface deprecation, use package-lock for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG REACT_APP_VERSION
 ENV REACT_APP_VERSION=$REACT_APP_VERSION
 
 ENV PATH /app/node_modules/.bin:$PATH
-COPY ./package.json /app/
+COPY ./package*.json /app/
 # install  dependencies
 RUN npm install --legacy-peer-deps
 # copy everything to /app directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "semver": "^7.5.4",
         "strip-ansi": "^7.0.1",
         "styled-components": "5.3.5",
-        "zustand": "^4.3.7"
+        "zustand": "^4.4.1"
       },
       "devDependencies": {
         "@commitlint/cli": "15.0.0",
@@ -21750,8 +21750,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.3.8",
-      "license": "MIT",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.1.tgz",
+      "integrity": "sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
@@ -21759,10 +21760,14 @@
         "node": ">=12.7.0"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
         "immer": ">=9.0",
         "react": ">=16.8"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
         "immer": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "reactflow": "^11.7.4",
     "strip-ansi": "^7.0.1",
     "styled-components": "5.3.5",
-    "zustand": "^4.3.7"
+    "zustand": "^4.4.1"
   },
   "scripts": {
     "start": "sh scripts/env.sh && cp env-config.js ./public/ && npm run less && NODE_OPTIONS=--openssl-legacy-provider craco start",

--- a/src/store/utils.tsx
+++ b/src/store/utils.tsx
@@ -2,9 +2,10 @@ import {Context, FC, PropsWithChildren, createContext, useCallback, useContext, 
 import {useLatest} from 'react-use';
 
 import {capitalize, pick} from 'lodash';
-import {StateCreator, StoreApi, createStore as create, useStore as useSelector} from 'zustand';
+import {StateCreator, StoreApi, createStore as create} from 'zustand';
 import {devtools} from 'zustand/middleware';
 import {shallow} from 'zustand/shallow';
+import {useStoreWithEqualityFn as useSelector} from 'zustand/traditional';
 
 type HasAnyKeys<T, K extends string | number | symbol, True, False> = keyof T extends Exclude<keyof T, K>
   ? False


### PR DESCRIPTION
## Changes

- Fix Zustand warning from DEV from latest Zustand version - `[DEPRECATED] Use `createWithEqualityFn` instead of `create` or use `useStoreWithEqualityFn` instead of `useStore`. They can be imported from 'zustand/traditional'.` (https://github.com/pmndrs/zustand/discussions/1937)
- Use `package-lock.json` in the Docker image

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
