### PR TITLE
chore: hide AI Insights tab temporarily

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -21,7 +21,6 @@ import {ErrorBoundary} from '@pages';
 
 import {BasePermissionsResolver, PermissionsProvider} from '@permissions/base';
 
-import createAiInsightsPlugin from '@plugins/definitions/ai-insights';
 import {Plugin} from '@plugins/types';
 
 import {useAppDispatch} from '@redux/hooks';
@@ -109,7 +108,7 @@ const AppRoot: React.FC = () => {
     [navigate, location]
   );
 
-  const plugins: Plugin[] = useMemo(() => [createAiInsightsPlugin()], []);
+  const plugins: Plugin[] = useMemo(() => [], []);
 
   return composeProviders()
     .append(FeatureFlagsProvider, {})


### PR DESCRIPTION
## Changes

- Hide the "AI Insights" tab, so we can release OSS Dashboard
  - We will recover it after the AI Insights will be available on Production

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
