### PR TITLE
fix: test/test suite URLs for E2E tests after routing changes

### DIFF
--- a/test/dashboard-e2e/tests/create-test.spec.ts
+++ b/test/dashboard-e2e/tests/create-test.spec.ts
@@ -24,7 +24,7 @@ for (const testName of testNames) {
 
     const createTestPage = new CreateTestPage(page);
     await createTestPage.createTest(testData);
-    await page.waitForURL(`**/tests/executions/${realTestName}`);
+    await page.waitForURL(`**/tests/${realTestName}`);
 
     const createdTestData = await api.getTestData(realTestName);
     await validateTest(testData, createdTestData);

--- a/test/dashboard-e2e/tests/testsuite.spec.ts
+++ b/test/dashboard-e2e/tests/testsuite.spec.ts
@@ -30,7 +30,7 @@ test(`Creating Test Suite`, async ({page}) => {
 
   const createTestSuitePage = new CreateTestSuitePage(page);
   await createTestSuitePage.createTestSuite(testSuiteData);
-  await page.waitForURL(`**/test-suites/executions/${realTestSuiteName}`);
+  await page.waitForURL(`**/test-suites/${realTestSuiteName}`);
 
   const createdTestSuiteData = await api.getTestSuiteData(realTestSuiteName);
   await validateTestSuite(testSuiteData, createdTestSuiteData);


### PR DESCRIPTION
## Changes

- Change `/tests/executions/*` to `/tests/*` in E2E tests

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
