### PR TITLE
fix: log error display

### DIFF
--- a/src/components/pages/Tests/TestDetails/TestExecution/TestExecutionTabs.tsx
+++ b/src/components/pages/Tests/TestDetails/TestExecution/TestExecutionTabs.tsx
@@ -32,7 +32,7 @@ const TestExecutionTabs: React.FC = () => {
 
   const {
     testType,
-    executionResult: {status, output},
+    executionResult: {status, output, errorMessage},
     variables,
     id,
     testName,
@@ -64,7 +64,9 @@ const TestExecutionTabs: React.FC = () => {
       value: {
         key: 'log-output',
         label: 'Log Output',
-        children: <LogOutput logOutput={output} executionId={id} isRunning={isRunning} banner={logBanner} />,
+        children: (
+          <LogOutput logOutput={output || errorMessage} executionId={id} isRunning={isRunning} banner={logBanner} />
+        ),
       },
       metadata: {
         order: Infinity,


### PR DESCRIPTION
This PR...

Adds a fallback in the there are no logs available, but there's an error message, which can be displayed instead

e.g. [https://cloud.testkube.dev/organization/tkcorg_9deb42dda2197657/environment/tkcenv_03e[…]12.7.0-smoke/executions/64d316e7f1573b1bc249ded1/log-output](https://cloud.testkube.dev/organization/tkcorg_9deb42dda2197657/environment/tkcenv_03e3ff499f13ccba/dashboard/tests/container-executor-cypress-v12.7.0-smoke/executions/64d316e7f1573b1bc249ded1/log-output)

## Changes

-

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
