### PR TITLE
feat: increase details polling interval from 2s to 10s

### DIFF
--- a/src/components/organisms/EntityDetails/EntityDetailsLayer.tsx
+++ b/src/components/organisms/EntityDetails/EntityDetailsLayer.tsx
@@ -63,7 +63,7 @@ const EntityDetailsLayer: FC<PropsWithChildren<EntityDetailsLayerProps>> = ({
     {skip: !isClusterAvailable}
   );
   const {data: rawDetails, error} = useGetEntityDetails(id, {
-    pollingInterval: PollingIntervals.everyTwoSeconds,
+    pollingInterval: PollingIntervals.long,
     skip: !isClusterAvailable,
   });
   const isV2 = isTestSuiteV2(rawDetails);


### PR DESCRIPTION
## Changes

- Increase polling interval for entity details, as WS updates are quite stable now

## Fixes

- kubeshop/testkube#3701

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
