### PR TITLE
fix: put FullscreenLogOutput container in context of TestkubeApp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,6 +175,7 @@ const App: React.FC<AppProps> = ({plugins}) => {
           <Route path="/" element={<Navigate to="/tests" replace />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
+        <div id="log-output-container" />
       </Suspense>
     );
 };

--- a/src/components/molecules/LogOutput/LogOutput.tsx
+++ b/src/components/molecules/LogOutput/LogOutput.tsx
@@ -134,7 +134,7 @@ const LogOutput: React.FC<LogOutputProps> = props => {
           onExpand={onExpand}
         />
       </LogOutputWrapper>
-      {createPortal(fullscreenLog, document.body)}
+      {createPortal(fullscreenLog, document.querySelector('#log-output-container')!)}
     </>
   );
 };


### PR DESCRIPTION
## Changes

- fix that fullscreen log output is covering the status bar in Cloud version

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
