### PR TITLE
tech: simplify configuration forms

### DIFF
--- a/src/components/custom-antd/FullWidthSpace/FullWidthSpace.styled.tsx
+++ b/src/components/custom-antd/FullWidthSpace/FullWidthSpace.styled.tsx
@@ -7,6 +7,7 @@ export interface FullWidthSpaceProps extends SpaceProps {
 }
 
 export const StyledSpace = styled(AntdSpace)<{$justify: FullWidthSpaceProps['justify']}>`
+  display: flex;
   justify-content: ${({$justify}) => $justify};
 
   width: 100%;

--- a/src/components/molecules/CommonSettings/Delete.tsx
+++ b/src/components/molecules/CommonSettings/Delete.tsx
@@ -1,13 +1,13 @@
 import {FC, useContext} from 'react';
 
-import {Form} from 'antd';
-
 import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import {MutationDefinition} from '@reduxjs/toolkit/query';
 
 import {ModalContext} from '@contexts';
 
-import {ConfigurationCard, DeleteEntityModal} from '@molecules';
+import {DeleteEntityModal} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 interface DeleteProps {
   name: string;
@@ -37,16 +37,15 @@ const Delete: FC<DeleteProps> = ({name, description, label, redirectUrl, useDele
   };
 
   return (
-    <Form name="delete-entity-form">
-      <ConfigurationCard
-        title={`Delete this ${label}`}
-        description={description}
-        onConfirm={onConfirm}
-        isWarning
-        confirmButtonText="Delete"
-        forceEnableButtons
-      />
-    </Form>
+    <CardForm
+      name="delete-entity-form"
+      title={`Delete this ${label}`}
+      description={description}
+      confirmLabel="Delete"
+      isWarning
+      wasTouched
+      onConfirm={onConfirm}
+    />
   );
 };
 

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
@@ -26,12 +26,6 @@ export const StyledHeader = styled.div`
   flex: 1;
 `;
 
-export const HeaderAction = styled.div`
-  display: flex;
-  align-items: center;
-  margin-left: 8px;
-`;
-
 export const StyledChildren = styled.div<{$isActionsVisible: boolean}>`
   padding: 20px;
 

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
@@ -26,10 +26,8 @@ export const StyledHeader = styled.div`
   flex: 1;
 `;
 
-export const StyledChildren = styled.div<{$isActionsVisible: boolean}>`
+export const StyledChildren = styled.div`
   padding: 20px;
-
-  ${({$isActionsVisible}) => (!$isActionsVisible ? 'cursor: not-allowed' : '')}
 `;
 
 export const StyledFooter = styled.div`

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useRef, useState} from 'react';
+import React, {ReactNode, useRef, useState} from 'react';
 
 import {Form} from 'antd';
 
@@ -26,17 +26,17 @@ import {
 } from './ConfigurationCard.styled';
 
 type ConfigurationCardProps = {
-  title: string;
-  description: string | ReactElement;
-  headerAction?: ReactElement;
+  title: ReactNode;
+  description: ReactNode;
+  headerAction?: ReactNode;
   isWarning?: boolean;
-  footerText?: React.ReactNode;
+  footerText?: ReactNode;
   onConfirm?: () => Promise<ErrorNotification | void> | void;
   confirmButtonText?: string;
   onCancel?: () => void;
   isButtonsDisabled?: boolean;
   forceEnableButtons?: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
   isEditable?: boolean;
   enabled?: boolean;
 };

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -13,7 +13,6 @@ import Colors from '@styles/Colors';
 import {NotificationContent} from '../Notification';
 
 import {
-  HeaderAction,
   StyledChildren,
   StyledContainer,
   StyledErrorsContainer,
@@ -28,7 +27,6 @@ import {
 type ConfigurationCardProps = {
   title: ReactNode;
   description: ReactNode;
-  headerAction?: ReactNode;
   isWarning?: boolean;
   footerText?: ReactNode;
   onConfirm?: () => Promise<ErrorNotification | void> | void;
@@ -45,7 +43,6 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
   const {
     title,
     description,
-    headerAction,
     isWarning = false,
     onConfirm,
     onCancel,
@@ -73,7 +70,6 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
             {description}
           </Text>
         </StyledHeader>
-        {headerAction && <HeaderAction>{headerAction}</HeaderAction>}
       </StyledHeaderContainer>
       {children ? (
         <>

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode, useRef, useState} from 'react';
+import React, {ReactNode, useRef} from 'react';
 
 import {Form} from 'antd';
 
@@ -6,7 +6,7 @@ import {Button, Text} from '@custom-antd';
 
 import useInViewport from '@hooks/useInViewport';
 
-import {ErrorNotification, ErrorNotificationConfig} from '@models/notifications';
+import {ErrorNotificationConfig} from '@models/notifications';
 
 import Colors from '@styles/Colors';
 
@@ -29,7 +29,7 @@ type ConfigurationCardProps = {
   description: ReactNode;
   isWarning?: boolean;
   footerText?: ReactNode;
-  onConfirm?: () => Promise<ErrorNotification | void> | void;
+  onConfirm?: () => Promise<void> | void;
   confirmButtonText?: string;
   onCancel?: () => void;
   isButtonsDisabled?: boolean;
@@ -37,10 +37,12 @@ type ConfigurationCardProps = {
   children?: ReactNode;
   isEditable?: boolean;
   enabled?: boolean;
+  errors?: ErrorNotificationConfig[];
 };
 
 const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
   const {
+    errors,
     title,
     description,
     isWarning = false,
@@ -54,10 +56,12 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
     isEditable = true,
     enabled = true,
   } = props;
-  const [errors, setErrors] = useState<ErrorNotificationConfig[] | null>(null);
-
   const topRef = useRef<HTMLDivElement>(null);
   const inTopInViewport = useInViewport(topRef);
+
+  if (errors && !inTopInViewport && topRef?.current) {
+    topRef.current.scrollIntoView();
+  }
 
   return (
     <StyledContainer isWarning={isWarning}>
@@ -103,33 +107,11 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
 
                 return (
                   <StyledFooterButtonsContainer>
-                    <Button
-                      onClick={() => {
-                        onCancel?.();
-                        setErrors(null);
-                      }}
-                      $customType="secondary"
-                      hidden={!onCancel || disabled}
-                    >
+                    <Button onClick={onCancel} $customType="secondary" hidden={!onCancel || disabled}>
                       Cancel
                     </Button>
                     <Button
-                      onClick={() => {
-                        setErrors(null);
-                        Promise.resolve(validateFields?.())
-                          .then(() => onConfirm?.())
-                          .catch((err: ErrorNotification) => {
-                            if ('errors' in err) {
-                              setErrors(err.errors);
-                            } else if (err.title || err.message) {
-                              setErrors([err]);
-                            }
-
-                            if (!inTopInViewport && topRef && topRef.current) {
-                              topRef.current.scrollIntoView();
-                            }
-                          });
-                      }}
+                      onClick={onConfirm}
                       $customType={isWarning ? 'warning' : 'primary'}
                       disabled={disabled}
                       hidden={!onConfirm}

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -28,17 +28,14 @@ type ConfigurationCardProps = {
   title: ReactNode;
   description: ReactNode;
   isWarning?: boolean;
-  footerText?: ReactNode;
-  onConfirm?: () => Promise<void> | void;
-  confirmButtonText?: string;
-  onCancel?: () => void;
-  isButtonsDisabled?: boolean;
-  forceEnableButtons?: boolean;
+  footer?: ReactNode;
+  confirmLabel?: string;
+  wasTouched?: boolean;
   children?: ReactNode;
-  isEditable?: boolean;
-  enabled?: boolean;
+  readOnly?: boolean;
   loading?: boolean;
   errors?: ErrorNotificationConfig[];
+  onCancel?: () => void;
 };
 
 const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
@@ -46,16 +43,13 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
     errors,
     title,
     description,
-    isWarning = false,
-    onConfirm,
     onCancel,
-    footerText,
+    footer,
     children,
-    confirmButtonText = 'Save',
-    isButtonsDisabled,
-    forceEnableButtons,
-    isEditable = true,
-    enabled = true,
+    confirmLabel = 'Save',
+    wasTouched,
+    isWarning = false,
+    readOnly = false,
     loading = false,
   } = props;
   const topRef = useRef<HTMLDivElement>(null);
@@ -77,56 +71,48 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
           </Text>
         </StyledHeader>
       </StyledHeaderContainer>
-      {children ? (
-        <>
-          <StyledErrorsContainer>
-            {errors?.map(x => (
-              <StyledNotificationContainer key={x.title}>
-                <NotificationContent status="failed" message={x.message} title={x.title} />
-              </StyledNotificationContainer>
-            )) || null}
-          </StyledErrorsContainer>
-          <StyledChildren $isActionsVisible={enabled || !isEditable}>{children}</StyledChildren>
-        </>
+      {children && errors?.length ? (
+        <StyledErrorsContainer>
+          {errors?.map(x => (
+            <StyledNotificationContainer key={x.title}>
+              <NotificationContent status="failed" message={x.message} title={x.title} />
+            </StyledNotificationContainer>
+          )) || null}
+        </StyledErrorsContainer>
       ) : null}
-      {(enabled && onConfirm) || footerText ? (
+      {children ? <StyledChildren>{children}</StyledChildren> : null}
+      {!readOnly || footer ? (
         <StyledFooter>
-          {footerText && (
+          {footer ? (
             <StyledFooterText>
               <Text className="regular middle" color={Colors.slate400}>
-                {footerText}
+                {footer}
               </Text>
             </StyledFooterText>
-          )}
-          {enabled ? (
+          ) : null}
+          {readOnly ? null : (
             <Form.Item noStyle shouldUpdate>
-              {({isFieldsTouched, getFieldsValue, validateFields}) => {
-                let disabled = isButtonsDisabled || (getFieldsValue() && !isFieldsTouched());
-
-                if (forceEnableButtons) {
-                  disabled = false;
-                }
+              {({isFieldsTouched, getFieldsValue}) => {
+                const buttonsDisabled = loading || (wasTouched ? false : getFieldsValue() && !isFieldsTouched());
 
                 return (
                   <StyledFooterButtonsContainer>
-                    <Button onClick={onCancel} $customType="secondary" hidden={!onCancel || disabled || loading}>
+                    <Button onClick={onCancel} $customType="secondary" hidden={!onCancel || buttonsDisabled}>
                       Cancel
                     </Button>
                     <Button
-                      onClick={onConfirm}
                       $customType={isWarning ? 'warning' : 'primary'}
-                      disabled={disabled || loading}
+                      disabled={buttonsDisabled}
                       loading={loading}
-                      hidden={!onConfirm}
                       htmlType="submit"
                     >
-                      {confirmButtonText}
+                      {confirmLabel}
                     </Button>
                   </StyledFooterButtonsContainer>
                 );
               }}
             </Form.Item>
-          ) : null}
+          )}
         </StyledFooter>
       ) : null}
     </StyledContainer>

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -37,6 +37,7 @@ type ConfigurationCardProps = {
   children?: ReactNode;
   isEditable?: boolean;
   enabled?: boolean;
+  loading?: boolean;
   errors?: ErrorNotificationConfig[];
 };
 
@@ -55,6 +56,7 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
     forceEnableButtons,
     isEditable = true,
     enabled = true,
+    loading = false,
   } = props;
   const topRef = useRef<HTMLDivElement>(null);
   const inTopInViewport = useInViewport(topRef);
@@ -107,13 +109,14 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
 
                 return (
                   <StyledFooterButtonsContainer>
-                    <Button onClick={onCancel} $customType="secondary" hidden={!onCancel || disabled}>
+                    <Button onClick={onCancel} $customType="secondary" hidden={!onCancel || disabled || loading}>
                       Cancel
                     </Button>
                     <Button
                       onClick={onConfirm}
                       $customType={isWarning ? 'warning' : 'primary'}
-                      disabled={disabled}
+                      disabled={disabled || loading}
+                      loading={loading}
                       hidden={!onConfirm}
                       htmlType="submit"
                     >

--- a/src/components/molecules/Definition/Definition.tsx
+++ b/src/components/molecules/Definition/Definition.tsx
@@ -1,7 +1,5 @@
 import React, {PropsWithChildren, Suspense, useContext, useEffect, useState} from 'react';
 
-import {Form} from 'antd';
-
 import {MutationDefinition, QueryDefinition} from '@reduxjs/toolkit/dist/query';
 import {UseMutation, UseQuery} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 
@@ -16,7 +14,9 @@ import {FullWidthSpace} from '@custom-antd';
 
 import useClusterVersionMatch from '@hooks/useClusterVersionMatch';
 
-import {ConfigurationCard, InlineNotification, notificationCall} from '@molecules';
+import {InlineNotification, notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {displayDefaultNotificationFlow} from '@utils/notification';
 
@@ -105,39 +105,37 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
           }
         />
       )}
-      <Form name="definition-form">
-        <ConfigurationCard
-          title="Definition"
-          description={`Validate and update your ${label} configuration`}
-          onConfirm={onSave}
-          onCancel={() => {
-            setValue(definition);
-            setWasTouched(false);
-          }}
-          isButtonsDisabled={!isSupported || !wasTouched}
-          forceEnableButtons={isSupported && wasTouched}
-          enabled={isSupported}
-        >
-          {isDefinitionLoading ? (
-            <DefinitionSkeleton />
-          ) : definition ? (
-            <Suspense fallback={<DefinitionSkeleton />}>
-              <KubernetesResourceEditor
-                value={value}
-                disabled={!isSupported}
-                onChange={newValue => {
-                  setValue(newValue);
-                  setWasTouched(true);
-                }}
-                crdUrl={crdUrl}
-                overrideSchema={overrideSchema}
-              />
-            </Suspense>
-          ) : (
-            <Pre> No definition data</Pre>
-          )}
-        </ConfigurationCard>
-      </Form>
+      <CardForm
+        name="definition-form"
+        title="Definition"
+        description={`Validate and update your ${label} configuration`}
+        onConfirm={onSave}
+        onCancel={() => {
+          setValue(definition);
+          setWasTouched(false);
+        }}
+        readOnly={!isSupported}
+        wasTouched={wasTouched}
+      >
+        {isDefinitionLoading ? (
+          <DefinitionSkeleton />
+        ) : definition ? (
+          <Suspense fallback={<DefinitionSkeleton />}>
+            <KubernetesResourceEditor
+              value={value}
+              disabled={!isSupported}
+              onChange={newValue => {
+                setValue(newValue);
+                setWasTouched(true);
+              }}
+              crdUrl={crdUrl}
+              overrideSchema={overrideSchema}
+            />
+          </Suspense>
+        ) : (
+          <Pre> No definition data</Pre>
+        )}
+      </CardForm>
     </FullWidthSpace>
   );
 };

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -1,4 +1,4 @@
-import {Children, FC, PropsWithChildren, ReactNode, useEffect, useRef, useState} from 'react';
+import {Children, FC, PropsWithChildren, ReactNode, useEffect, useState} from 'react';
 
 import {Form, FormInstance} from 'antd';
 import {FormLayout} from 'antd/lib/form/Form';
@@ -54,10 +54,10 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   onConfirm,
   onCancel,
 }) => {
+  const [currentForm] = Form.useForm(form);
   const [currentInitialValues, setCurrentInitialValues] = useState(initialValues);
   const [errors, setErrors] = useState<ErrorNotificationConfig[]>();
   const [loading, setLoading] = useState<boolean>();
-  const validateFieldsRef = useRef<() => Promise<any>>();
 
   const cancel = useLastCallback(() => {
     setErrors(undefined);
@@ -76,7 +76,8 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
     }
     setErrors(undefined);
     setLoading(true);
-    Promise.resolve(validateFieldsRef.current?.())
+    Promise.resolve()
+      .then(() => currentForm.validateFields())
       .then(onConfirm)
       .catch((err: ErrorNotification) => {
         if ('errors' in err) {
@@ -103,7 +104,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
     <Form
       layout={layout}
       initialValues={currentInitialValues}
-      form={form}
+      form={currentForm}
       labelAlign={labelAlign}
       name={name}
       disabled={disabled || loading}
@@ -111,29 +112,24 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
       onFinish={confirm}
     >
       <Form.Item noStyle shouldUpdate>
-        {({validateFields}) => {
-          validateFieldsRef.current = validateFields;
-          return (
-            <ConfigurationCard
-              title={title}
-              description={description}
-              footer={footer}
-              confirmLabel={confirmLabel}
-              wasTouched={wasTouched}
-              readOnly={readOnly}
-              loading={loading}
-              isWarning={isWarning}
-              errors={errors}
-              onCancel={form || onCancel ? cancel : undefined}
-            >
-              {Children.count(children) ? (
-                <FullWidthSpace size={spacing} direction="vertical">
-                  {children}
-                </FullWidthSpace>
-              ) : null}
-            </ConfigurationCard>
-          );
-        }}
+        <ConfigurationCard
+          title={title}
+          description={description}
+          footer={footer}
+          confirmLabel={confirmLabel}
+          wasTouched={wasTouched}
+          readOnly={readOnly}
+          loading={loading}
+          isWarning={isWarning}
+          errors={errors}
+          onCancel={form || onCancel ? cancel : undefined}
+        >
+          {Children.count(children) ? (
+            <FullWidthSpace size={spacing} direction="vertical">
+              {children}
+            </FullWidthSpace>
+          ) : null}
+        </ConfigurationCard>
       </Form.Item>
     </Form>
   );

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -2,6 +2,7 @@ import {Children, FC, PropsWithChildren, ReactNode, useEffect, useState} from 'r
 import {useDeepCompareEffect} from 'react-use';
 
 import {Form, FormInstance} from 'antd';
+import {FormLayout} from 'antd/lib/form/Form';
 import {FormLabelAlign} from 'antd/lib/form/interface';
 
 import {FullWidthSpace} from '@custom-antd';
@@ -21,6 +22,7 @@ interface CardFormProps {
   isWarning?: boolean;
   form?: FormInstance;
   labelAlign?: FormLabelAlign;
+  layout?: FormLayout;
   initialValues?: any;
   confirmLabel?: string;
   onFieldsChange?: (...args: any) => void;
@@ -36,6 +38,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   description,
   footer,
   labelAlign,
+  layout = 'vertical',
   form,
   initialValues,
   disabled,
@@ -63,6 +66,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
 
   return (
     <Form
+      layout={layout}
       initialValues={currentInitialValues}
       form={form}
       labelAlign={labelAlign}

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -26,6 +26,7 @@ interface CardFormProps {
   initialValues?: any;
   confirmLabel?: string;
   onFieldsChange?: (...args: any) => void;
+  spacing?: number;
   onConfirm?: () => void;
   onCancel?: () => void;
 }
@@ -46,6 +47,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   wasTouched,
   isWarning,
   confirmLabel,
+  spacing,
   children,
   onFieldsChange,
   onConfirm,
@@ -87,7 +89,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
         onCancel={form || onCancel ? cancel : undefined}
       >
         {Children.count(children) ? (
-          <FullWidthSpace size={32} direction="vertical">
+          <FullWidthSpace size={spacing} direction="vertical">
             {children}
           </FullWidthSpace>
         ) : null}

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -1,4 +1,5 @@
-import {Children, FC, PropsWithChildren, ReactNode} from 'react';
+import {Children, FC, PropsWithChildren, ReactNode, useEffect, useState} from 'react';
+import {useDeepCompareEffect} from 'react-use';
 
 import {Form, FormInstance} from 'antd';
 import {FormLabelAlign} from 'antd/lib/form/interface';
@@ -8,7 +9,6 @@ import {FullWidthSpace} from '@custom-antd';
 import {useLastCallback} from '@hooks/useLastCallback';
 
 import {ConfigurationCard} from '@molecules';
-import {useDeepCompareEffect} from 'react-use';
 
 interface CardFormProps {
   name: string;
@@ -50,13 +50,20 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
 }) => {
   const cancel = useLastCallback(onCancel ?? (() => form?.resetFields()));
 
+  const [currentInitialValues, setCurrentInitialValues] = useState(initialValues);
+
   useDeepCompareEffect(() => {
     form?.setFieldsValue(initialValues);
-    form?.resetFields();
+    setCurrentInitialValues(initialValues);
   }, [initialValues]);
+
+  useEffect(() => {
+    cancel();
+  }, [currentInitialValues]);
+
   return (
     <Form
-      initialValues={initialValues}
+      initialValues={currentInitialValues}
       form={form}
       labelAlign={labelAlign}
       name={name}

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -1,9 +1,10 @@
 import {Children, FC, PropsWithChildren, ReactNode, useEffect, useState} from 'react';
-import {useDeepCompareEffect} from 'react-use';
 
 import {Form, FormInstance} from 'antd';
 import {FormLayout} from 'antd/lib/form/Form';
 import {FormLabelAlign} from 'antd/lib/form/interface';
+
+import {isEqual} from 'lodash';
 
 import {FullWidthSpace} from '@custom-antd';
 
@@ -57,9 +58,11 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
 
   const [currentInitialValues, setCurrentInitialValues] = useState(initialValues);
 
-  useDeepCompareEffect(() => {
-    form?.setFieldsValue(initialValues);
-    setCurrentInitialValues(initialValues);
+  useEffect(() => {
+    if (form && !isEqual(initialValues, currentInitialValues)) {
+      form?.setFieldsValue(initialValues);
+      setCurrentInitialValues(initialValues);
+    }
   }, [initialValues]);
 
   useEffect(() => {

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -58,10 +58,14 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
 }) => {
   const [currentInitialValues, setCurrentInitialValues] = useState(initialValues);
   const [errors, setErrors] = useState<ErrorNotificationConfig[]>();
+  const [loading, setLoading] = useState<boolean>();
   const validateFieldsRef = useRef<() => Promise<any>>();
 
   const cancel = useLastCallback(() => {
     setErrors(undefined);
+    if (loading) {
+      return;
+    }
     if (onCancel) {
       onCancel();
     } else {
@@ -69,7 +73,11 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
     }
   });
   const confirm = useLastCallback(() => {
+    if (loading) {
+      return;
+    }
     setErrors(undefined);
+    setLoading(true);
     Promise.resolve(validateFieldsRef.current?.())
       .then(onConfirm)
       .catch((err: ErrorNotification) => {
@@ -78,6 +86,9 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
         } else if (err.title || err.message) {
           setErrors([err]);
         }
+      })
+      .then(() => {
+        setLoading(false);
       });
   });
 
@@ -97,7 +108,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
       form={form}
       labelAlign={labelAlign}
       name={name}
-      disabled={disabled}
+      disabled={disabled || loading}
       onFieldsChange={onFieldsChange}
       onFinish={confirm}
     >
@@ -112,6 +123,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
               confirmButtonText={confirmLabel}
               forceEnableButtons={wasTouched}
               enabled={!readOnly}
+              loading={loading}
               isWarning={isWarning}
               errors={errors}
               onConfirm={noop}

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -34,8 +34,6 @@ interface CardFormProps {
   onCancel?: () => void;
 }
 
-const noop = () => {};
-
 const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   name,
   title,
@@ -119,14 +117,13 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
             <ConfigurationCard
               title={title}
               description={description}
-              footerText={footer}
-              confirmButtonText={confirmLabel}
-              forceEnableButtons={wasTouched}
-              enabled={!readOnly}
+              footer={footer}
+              confirmLabel={confirmLabel}
+              wasTouched={wasTouched}
+              readOnly={readOnly}
               loading={loading}
               isWarning={isWarning}
               errors={errors}
-              onConfirm={noop}
               onCancel={form || onCancel ? cancel : undefined}
             >
               {Children.count(children) ? (

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -1,0 +1,83 @@
+import {Children, FC, PropsWithChildren, ReactNode} from 'react';
+
+import {Form, FormInstance} from 'antd';
+import {FormLabelAlign} from 'antd/lib/form/interface';
+
+import {FullWidthSpace} from '@custom-antd';
+
+import {useLastCallback} from '@hooks/useLastCallback';
+
+import {ConfigurationCard} from '@molecules';
+
+interface CardFormProps {
+  name: string;
+  title: ReactNode;
+  description: ReactNode;
+  footer?: ReactNode;
+  disabled?: boolean;
+  readOnly?: boolean;
+  wasTouched?: boolean;
+  isWarning?: boolean;
+  form?: FormInstance;
+  labelAlign?: FormLabelAlign;
+  initialValues?: any;
+  confirmLabel?: string;
+  onFieldsChange?: (...args: any) => void;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}
+
+const noop = () => {};
+
+const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
+  name,
+  title,
+  description,
+  footer,
+  labelAlign,
+  form,
+  initialValues,
+  disabled,
+  readOnly,
+  wasTouched,
+  isWarning,
+  confirmLabel,
+  children,
+  onFieldsChange,
+  onConfirm,
+  onCancel,
+}) => {
+  const cancel = useLastCallback(onCancel ?? (() => form?.resetFields()));
+  return (
+    <Form
+      layout="vertical" // FIXME: Is it needed?
+      initialValues={initialValues}
+      form={form}
+      labelAlign={labelAlign}
+      name={name}
+      disabled={disabled}
+      onFieldsChange={onFieldsChange}
+      onFinish={onConfirm}
+    >
+      <ConfigurationCard
+        title={title}
+        description={description}
+        footerText={footer}
+        confirmButtonText={confirmLabel}
+        forceEnableButtons={wasTouched}
+        enabled={!readOnly}
+        isWarning={isWarning}
+        onConfirm={noop}
+        onCancel={form || onCancel ? cancel : undefined}
+      >
+        {Children.count(children) ? (
+          <FullWidthSpace size={32} direction="vertical">
+            {children}
+          </FullWidthSpace>
+        ) : null}
+      </ConfigurationCard>
+    </Form>
+  );
+};
+
+export default CardForm;

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -8,6 +8,7 @@ import {FullWidthSpace} from '@custom-antd';
 import {useLastCallback} from '@hooks/useLastCallback';
 
 import {ConfigurationCard} from '@molecules';
+import {useDeepCompareEffect} from 'react-use';
 
 interface CardFormProps {
   name: string;
@@ -48,9 +49,13 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   onCancel,
 }) => {
   const cancel = useLastCallback(onCancel ?? (() => form?.resetFields()));
+
+  useDeepCompareEffect(() => {
+    form?.setFieldsValue(initialValues);
+    form?.resetFields();
+  }, [initialValues]);
   return (
     <Form
-      layout="vertical" // FIXME: Is it needed?
       initialValues={initialValues}
       form={form}
       labelAlign={labelAlign}

--- a/src/components/organisms/CardForm/index.ts
+++ b/src/components/organisms/CardForm/index.ts
@@ -1,0 +1,1 @@
+export {default} from './CardForm';

--- a/src/components/organisms/EntityDetails/Settings/SettingsGeneral/Labels.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsGeneral/Labels.tsx
@@ -1,8 +1,5 @@
 import {useState} from 'react';
 
-import {Form} from 'antd';
-
-import {nanoid} from '@reduxjs/toolkit';
 import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import {MutationDefinition} from '@reduxjs/toolkit/query';
 
@@ -10,8 +7,10 @@ import {capitalize} from 'lodash';
 
 import {Option} from '@models/form';
 
-import {ConfigurationCard, LabelsSelect, notificationCall} from '@molecules';
+import {LabelsSelect, notificationCall} from '@molecules';
 import {decomposeLabels} from '@molecules/LabelsSelect/utils';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -32,7 +31,6 @@ const Labels: React.FC<LabelsProps> = ({label, useUpdateEntity}) => {
 
   const [localLabels, setLocalLabels] = useState<readonly Option[]>([]);
   const [wasTouched, setWasTouched] = useState(false);
-  const [labelsKey, setLabelsKey] = useState(nanoid());
 
   if (!details) {
     return null;
@@ -56,7 +54,6 @@ const Labels: React.FC<LabelsProps> = ({label, useUpdateEntity}) => {
   };
 
   const onCancel = () => {
-    setLabelsKey(nanoid());
     setLocalLabels(entityLabels);
     setWasTouched(false);
   };
@@ -67,19 +64,17 @@ const Labels: React.FC<LabelsProps> = ({label, useUpdateEntity}) => {
   };
 
   return (
-    <Form name="labels-form">
-      <ConfigurationCard
-        title="Labels"
-        description={`Define the labels you want to add for this ${label}`}
-        isButtonsDisabled={!wasTouched}
-        onConfirm={onSave}
-        onCancel={onCancel}
-        enabled={mayEdit}
-        forceEnableButtons={wasTouched}
-      >
-        <LabelsSelect key={`labels_${labelsKey}`} onChange={onChange} defaultLabels={entityLabels} />
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="labels-form"
+      title="Labels"
+      description={`Define the labels you want to add for this ${label}`}
+      disabled={!mayEdit}
+      wasTouched={wasTouched}
+      onConfirm={onSave}
+      onCancel={onCancel}
+    >
+      <LabelsSelect onChange={onChange} defaultLabels={entityLabels} />
+    </CardForm>
   );
 };
 

--- a/src/components/organisms/EntityDetails/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsGeneral/NameNDescription.tsx
@@ -5,9 +5,11 @@ import {MutationDefinition} from '@reduxjs/toolkit/query';
 
 import {capitalize} from 'lodash';
 
-import {FormItem, FullWidthSpace} from '@custom-antd';
+import {FormItem} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -62,26 +64,22 @@ const NameNDescription: React.FC<NameNDescriptionProps> = ({label, useUpdateEnti
   };
 
   return (
-    <Form form={form} name="general-settings-name-description" initialValues={{name, description}} disabled={!mayEdit}>
-      <ConfigurationCard
-        title={`${capitalize(label)} name & description`}
-        description="Define the name and description of the project which will be displayed across the Dashboard and CLI"
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          <FormItem name="name" rules={[required]}>
-            <Input placeholder="Name" disabled />
-          </FormItem>
-          <FormItem name="description">
-            <TextArea placeholder="Description" autoSize={{minRows: 2, maxRows: 3}} />
-          </FormItem>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="general-settings-name-description"
+      title={`${capitalize(label)} name & description`}
+      description="Define the name and description of the project which will be displayed across the Dashboard and CLI"
+      form={form}
+      initialValues={{name, description}}
+      disabled={!mayEdit}
+      onConfirm={onSave}
+    >
+      <FormItem name="name" rules={[required]}>
+        <Input placeholder="Name" disabled />
+      </FormItem>
+      <FormItem name="description">
+        <TextArea placeholder="Description" autoSize={{minRows: 2, maxRows: 3}} />
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/organisms/EntityDetails/Settings/SettingsGeneral/NameNDescription.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsGeneral/NameNDescription.tsx
@@ -68,6 +68,7 @@ const NameNDescription: React.FC<NameNDescriptionProps> = ({label, useUpdateEnti
       name="general-settings-name-description"
       title={`${capitalize(label)} name & description`}
       description="Define the name and description of the project which will be displayed across the Dashboard and CLI"
+      spacing={32}
       form={form}
       initialValues={{name, description}}
       disabled={!mayEdit}

--- a/src/components/organisms/EntityDetails/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsScheduling/Schedule.tsx
@@ -101,6 +101,7 @@ const Schedule: React.FC<ScheduleProps> = ({label, useUpdateEntity}) => {
       name="schedule-form"
       title="Schedule"
       description={`You can add a cronjob like schedule for your ${label} which will then be executed automatically.`}
+      spacing={32}
       wasTouched={wasTouched}
       disabled={!mayEdit}
       onConfirm={onSave}

--- a/src/components/organisms/EntityDetails/Settings/SettingsScheduling/Schedule.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsScheduling/Schedule.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from 'react';
 
 import {WarningOutlined} from '@ant-design/icons';
-import {Form, Select, Tooltip} from 'antd';
+import {Select, Tooltip} from 'antd';
 
 import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import {MutationDefinition} from '@reduxjs/toolkit/query';
@@ -9,9 +9,11 @@ import {MutationDefinition} from '@reduxjs/toolkit/query';
 import parser from 'cron-parser';
 import {capitalize} from 'lodash';
 
-import {FullWidthSpace, Text} from '@custom-antd';
+import {Text} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -34,7 +36,7 @@ interface ScheduleProps {
 
 const Schedule: React.FC<ScheduleProps> = ({label, useUpdateEntity}) => {
   const {details} = useEntityDetailsPick('details');
-  const enabled = usePermission(Permissions.editEntity);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const [updateEntity] = useUpdateEntity();
 
@@ -95,84 +97,70 @@ const Schedule: React.FC<ScheduleProps> = ({label, useUpdateEntity}) => {
   const [minute, hour, day, month, dayOfWeek] = cronString.split(' ');
 
   return (
-    <Form name="schedule-form">
-      <ConfigurationCard
-        title="Schedule"
-        description={`You can add a cronjob like schedule for your ${label} which will then be executed automatically.`}
-        onConfirm={onSave}
-        onCancel={onCancel}
-        isButtonsDisabled={!wasTouched}
-        enabled={enabled}
-        forceEnableButtons={wasTouched}
-      >
-        <FullWidthSpace direction="vertical" size={32}>
+    <CardForm
+      name="schedule-form"
+      title="Schedule"
+      description={`You can add a cronjob like schedule for your ${label} which will then be executed automatically.`}
+      wasTouched={wasTouched}
+      disabled={!mayEdit}
+      onConfirm={onSave}
+      onCancel={onCancel}
+    >
+      <StyledColumn>
+        <Text className="middle regular">Schedule template</Text>
+        <Select
+          disabled={!mayEdit}
+          placeholder="Quick select a schedule template"
+          style={{width: '100%'}}
+          options={quickOptions}
+          onSelect={(value: string) => {
+            setCronString(value);
+            setWasTouched(true);
+          }}
+          value={templateValue}
+        />
+      </StyledColumn>
+      {templateValue ? (
+        <>
           <StyledColumn>
-            <Text className="middle regular">Schedule template</Text>
-            <Select
-              disabled={!enabled}
-              placeholder="Quick select a schedule template"
-              style={{width: '100%'}}
-              options={quickOptions}
-              onSelect={(value: string) => {
-                setCronString(value);
-                setWasTouched(true);
-              }}
-              value={templateValue}
-            />
+            <Text className="middle regular">Cron Format</Text>
+            <StyledCronFormat>
+              <CronInput title="Minute" disabled={!mayEdit} value={minute} onChange={value => onCronInput(value, 0)} />
+              <CronInput title="Hour" disabled={!mayEdit} value={hour} onChange={value => onCronInput(value, 1)} />
+              <CronInput title="Day" disabled={!mayEdit} value={day} onChange={value => onCronInput(value, 2)} />
+              <CronInput title="Month" disabled={!mayEdit} value={month} onChange={value => onCronInput(value, 3)} />
+              <CronInput
+                title="Day / Week"
+                disabled={!mayEdit}
+                value={dayOfWeek}
+                onChange={value => onCronInput(value, 4)}
+              />
+            </StyledCronFormat>
           </StyledColumn>
-          {templateValue ? (
-            <>
-              <StyledColumn>
-                <Text className="middle regular">Cron Format</Text>
-                <StyledCronFormat>
-                  <CronInput
-                    title="Minute"
-                    disabled={!enabled}
-                    value={minute}
-                    onChange={value => onCronInput(value, 0)}
-                  />
-                  <CronInput title="Hour" disabled={!enabled} value={hour} onChange={value => onCronInput(value, 1)} />
-                  <CronInput title="Day" disabled={!enabled} value={day} onChange={value => onCronInput(value, 2)} />
-                  <CronInput
-                    title="Month"
-                    disabled={!enabled}
-                    value={month}
-                    onChange={value => onCronInput(value, 3)}
-                  />
-                  <CronInput
-                    title="Day / Week"
-                    disabled={!enabled}
-                    value={dayOfWeek}
-                    onChange={value => onCronInput(value, 4)}
-                  />
-                </StyledCronFormat>
-              </StyledColumn>
-              <StyledRow>
-                <StyledColumn>
-                  <Text className="middle regular" style={{color: isValidFormat ? Colors.slate200 : Colors.amber400}}>
-                    Cron Preview{' '}
-                    {!isValidFormat ? (
-                      <Tooltip title="Cron input is invalid">
-                        <WarningOutlined />
-                      </Tooltip>
-                    ) : null}
-                  </Text>
-                  <Text style={{fontFamily: Fonts.robotoMono, color: Colors.slate400}} className="middle regular">
-                    {cronString}
-                  </Text>
-                </StyledColumn>
-                <StyledColumn>
-                  <Text className="middle regular">Next Execution</Text>
-                  <Text style={{color: Colors.slate400}} className="middle regular">
-                    <NextExecution value={nextExecution} />
-                  </Text>
-                </StyledColumn>
-              </StyledRow>
-            </>
-          ) : null}
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+          <StyledRow>
+            <StyledColumn>
+              <Text className="middle regular" style={{color: isValidFormat ? Colors.slate200 : Colors.amber400}}>
+                Cron Preview{' '}
+                {!isValidFormat ? (
+                  <Tooltip title="Cron input is invalid">
+                    <WarningOutlined />
+                  </Tooltip>
+                ) : null}
+              </Text>
+              <Text style={{fontFamily: Fonts.robotoMono, color: Colors.slate400}} className="middle regular">
+                {cronString}
+              </Text>
+            </StyledColumn>
+            <StyledColumn>
+              <Text className="middle regular">Next Execution</Text>
+              <Text style={{color: Colors.slate400}} className="middle regular">
+                <NextExecution value={nextExecution} />
+              </Text>
+            </StyledColumn>
+          </StyledRow>
+        </>
+      ) : null}
+    </CardForm>
   );
 };
 

--- a/src/components/organisms/EntityDetails/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsVariables/Variables.tsx
@@ -108,6 +108,7 @@ const Variables: React.FC<VariablesProps> = ({description, useUpdateEntity}) => 
       title="Variables & Secrets"
       description={description}
       footer={footer}
+      form={form}
       disabled={!mayEdit}
       onFieldsChange={onFieldsChange}
       onConfirm={onSaveForm}

--- a/src/components/organisms/EntityDetails/Settings/SettingsVariables/Variables.tsx
+++ b/src/components/organisms/EntityDetails/Settings/SettingsVariables/Variables.tsx
@@ -9,7 +9,9 @@ import {ExternalLink} from '@atoms';
 
 import {VariableInForm} from '@models/variable';
 
-import {ConfigurationCard, TestsVariablesList, notificationCall} from '@molecules';
+import {TestsVariablesList, notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -66,55 +68,52 @@ const Variables: React.FC<VariablesProps> = ({description, useUpdateEntity}) => 
       });
   };
 
-  return (
-    <Form
-      form={form}
-      onFieldsChange={(_: any) => {
-        if (_[0]) {
-          const action = _[0];
+  const onFieldsChange = (_: any) => {
+    if (_[0]) {
+      const action = _[0];
 
-          const actionValue = action.value;
+      const actionValue = action.value;
 
-          if (!Array.isArray(actionValue)) {
-            const actionFieldIndex = action.name[1];
-            const isTypeChanged = action.name[2] === 'type';
-            const neededFieldValue = form.getFieldValue('variables-list')[actionFieldIndex];
+      if (!Array.isArray(actionValue)) {
+        const actionFieldIndex = action.name[1];
+        const isTypeChanged = action.name[2] === 'type';
+        const neededFieldValue = form.getFieldValue('variables-list')[actionFieldIndex];
 
-            if (isTypeChanged) {
-              try {
-                if (actionValue === 'secretRef') {
-                  delete neededFieldValue.value;
-                } else {
-                  delete neededFieldValue.secretRefName;
-                  delete neededFieldValue.secretRefKey;
-                }
-              } catch (err) {
-                // eslint-disable-next-line no-console
-                console.log('err: ', err);
-              }
+        if (isTypeChanged) {
+          try {
+            if (actionValue === 'secretRef') {
+              delete neededFieldValue.value;
+            } else {
+              delete neededFieldValue.secretRefName;
+              delete neededFieldValue.secretRefKey;
             }
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.log('err: ', err);
           }
         }
-      }}
+      }
+    }
+  };
+
+  const footer = (
+    <>
+      Learn more about <ExternalLink href={externalLinks.variables}>Environment variables</ExternalLink>
+    </>
+  );
+
+  return (
+    <CardForm
+      name="variables-form"
+      title="Variables & Secrets"
+      description={description}
+      footer={footer}
       disabled={!mayEdit}
+      onFieldsChange={onFieldsChange}
+      onConfirm={onSaveForm}
     >
-      <ConfigurationCard
-        title="Variables & Secrets"
-        description={description}
-        footerText={
-          <>
-            Learn more about <ExternalLink href={externalLinks.variables}>Environment variables</ExternalLink>
-          </>
-        }
-        onConfirm={onSaveForm}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <TestsVariablesList data={variables} form={form} />
-      </ConfigurationCard>
-    </Form>
+      <TestsVariablesList data={variables} form={form} />
+    </CardForm>
   );
 };
 

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -5,3 +5,4 @@ export {ConditionFormItems} from './TriggersFormItems';
 export {ActionFormItems} from './TriggersFormItems';
 export {default as ExecutionDrawer, ExecutionDrawerHeader} from './ExecutionDrawer';
 export {default as ExecutionsTable} from './ExecutionsTable';
+export {default as CardForm} from './CardForm';

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import {DeleteOutlined} from '@ant-design/icons';
 import {Form, Input} from 'antd';
 
@@ -47,12 +45,6 @@ const Arguments: React.FC = () => {
       .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', 'Arguments were successfully updated.'));
   };
-
-  useEffect(() => {
-    form.setFieldsValue({
-      arguments: current!.executor.args,
-    });
-  }, [current!.executor.args]);
 
   return (
     <CardForm

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Arguments.tsx
@@ -5,7 +5,9 @@ import {Form, Input} from 'antd';
 
 import {Button, FormIconWrapper, FormItem, FormRow, FullWidthSpace} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -53,47 +55,39 @@ const Arguments: React.FC = () => {
   }, [current!.executor.args]);
 
   return (
-    <Form
+    <CardForm
       form={form}
-      name="executor-settings-arguments-list"
       initialValues={{arguments: current!.executor.args}}
-      layout="vertical"
+      name="executor-settings-arguments-list"
+      title="Arguments for your command"
+      description="Define the arguments for your command"
       disabled={!mayEdit}
+      onConfirm={onSubmit}
     >
-      <ConfigurationCard
-        title="Arguments for your command"
-        description="Define the arguments for your command"
-        onConfirm={onSubmit}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <Form.List name="arguments">
-          {(fields, {add, remove}) => (
-            <FullWidthSpace size={20} direction="vertical">
-              {fields.map(({key, name, ...restField}) => {
-                return (
-                  <FormRow key={key}>
-                    <FormItem {...restField} name={[name]} rules={[required]}>
-                      <Input placeholder="Your argument value" />
-                    </FormItem>
-                    <FormIconWrapper>
-                      <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
-                    </FormIconWrapper>
-                  </FormRow>
-                );
-              })}
-              <StyledButtonsContainer>
-                <Button $customType="secondary" onClick={() => add('')}>
-                  Add a new argument
-                </Button>
-              </StyledButtonsContainer>
-            </FullWidthSpace>
-          )}
-        </Form.List>
-      </ConfigurationCard>
-    </Form>
+      <Form.List name="arguments">
+        {(fields, {add, remove}) => (
+          <FullWidthSpace size={20} direction="vertical">
+            {fields.map(({key, name, ...restField}) => {
+              return (
+                <FormRow key={key}>
+                  <FormItem {...restField} name={[name]} rules={[required]}>
+                    <Input placeholder="Your argument value" />
+                  </FormItem>
+                  <FormIconWrapper>
+                    <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
+                  </FormIconWrapper>
+                </FormRow>
+              );
+            })}
+            <StyledButtonsContainer>
+              <Button $customType="secondary" onClick={() => add('')}>
+                Add a new argument
+              </Button>
+            </StyledButtonsContainer>
+          </FullWidthSpace>
+        )}
+      </Form.List>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -4,7 +4,9 @@ import {Form} from 'antd';
 
 import {CommandInput} from '@atoms';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -49,27 +51,19 @@ const Command: React.FC = () => {
   }, [current!.executor.command]);
 
   return (
-    <Form
-      form={form}
+    <CardForm
       name="general-settings-name-type"
+      title="Command"
+      description="Define the command your image needs to run"
+      form={form}
       initialValues={{command: current!.executor.command?.join(' ')}}
-      layout="vertical"
       disabled={!mayEdit}
+      onConfirm={onSubmit}
     >
-      <ConfigurationCard
-        title="Command"
-        description="Define the command your image needs to run"
-        onConfirm={onSubmit}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <Form.Item label="Command" name="command" style={{flex: 1, marginBottom: '0'}}>
-          <CommandInput />
-        </Form.Item>
-      </ConfigurationCard>
-    </Form>
+      <Form.Item label="Command" name="command" style={{flex: 1, marginBottom: '0'}}>
+        <CommandInput />
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/CommandAndArguments/Command.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import {Form} from 'antd';
 
 import {CommandInput} from '@atoms';
@@ -43,12 +41,6 @@ const Command: React.FC = () => {
       .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', 'Command was successfully updated.'));
   };
-
-  useEffect(() => {
-    form.setFieldsValue({
-      command: current!.executor.command?.join(' '),
-    });
-  }, [current!.executor.command]);
 
   return (
     <CardForm

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -4,7 +4,9 @@ import {Form, Input} from 'antd';
 
 import {Executor} from '@models/executors';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -49,27 +51,19 @@ const ContainerImagePanel: React.FC = () => {
   }, [image]);
 
   return (
-    <Form form={form} name="general-settings-name-type" initialValues={{image}} layout="vertical" disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Container image"
-        description="Define the image you want to use for this executor. We defer by default to Dockerhub - but you can also insert a URL to your very own image"
-        onConfirm={onSubmit}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <Form.Item
-          label="Container image"
-          required
-          name="image"
-          rules={[required]}
-          style={{flex: 1, marginBottom: '0'}}
-        >
-          <Input placeholder="Container image" />
-        </Form.Item>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="general-settings-name-type"
+      title="Container image"
+      description="Define the image you want to use for this executor. We defer by default to Dockerhub - but you can also insert a URL to your very own image"
+      form={form}
+      initialValues={{image}}
+      disabled={!mayEdit}
+      onConfirm={onSubmit}
+    >
+      <Form.Item label="Container image" required name="image" rules={[required]} style={{flex: 1, marginBottom: '0'}}>
+        <Input placeholder="Container image" />
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/ContainerImagePanel.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import {Form, Input} from 'antd';
 
 import {Executor} from '@models/executors';
@@ -45,10 +43,6 @@ const ContainerImagePanel: React.FC = () => {
       .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', 'Container image was successfully updated.'));
   };
-
-  useEffect(() => {
-    form.setFieldsValue({image});
-  }, [image]);
 
   return (
     <CardForm

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -2,7 +2,9 @@ import {useEffect} from 'react';
 
 import {Form, Input} from 'antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -49,27 +51,19 @@ const PrivateRegistry: React.FC = () => {
   }, [privateRegistry]);
 
   return (
-    <Form
-      form={form}
+    <CardForm
       name="general-settings-name-type"
+      title="Private registry"
+      description="In case your image is on a private registry please add the name of your credential secret."
+      form={form}
       initialValues={{privateRegistry}}
-      layout="vertical"
       disabled={!mayEdit}
+      onConfirm={onSubmit}
     >
-      <ConfigurationCard
-        title="Private registry"
-        description="In case your image is on a private registry please add the name of your credential secret."
-        onConfirm={onSubmit}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <Form.Item label="Secret ref name" name="privateRegistry" style={{flex: 1, marginBottom: '0'}}>
-          <Input placeholder="Secret ref name" />
-        </Form.Item>
-      </ConfigurationCard>
-    </Form>
+      <Form.Item label="Secret ref name" name="privateRegistry" style={{flex: 1, marginBottom: '0'}}>
+        <Input placeholder="Secret ref name" />
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/ContainerImage/PrivateRegistry.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import {Form, Input} from 'antd';
 
 import {notificationCall} from '@molecules';
@@ -45,10 +43,6 @@ const PrivateRegistry: React.FC = () => {
       .then(displayDefaultNotificationFlow)
       .then(() => notificationCall('passed', 'Private registry was successfully updated.'));
   };
-
-  useEffect(() => {
-    form.setFieldsValue({privateRegistry});
-  }, [privateRegistry]);
 
   return (
     <CardForm

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/NameNType.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/NameNType.tsx
@@ -4,7 +4,7 @@ import {Form} from 'antd';
 
 import {Input} from '@custom-antd';
 
-import {ConfigurationCard} from '@molecules';
+import {CardForm} from '@organisms';
 
 import {useExecutorsPick} from '@store/executors';
 
@@ -24,28 +24,21 @@ const NameNType: React.FC = () => {
   }, [name, type]);
 
   return (
-    <Form form={form} name="general-settings-name-type" initialValues={{name, type}} layout="vertical" disabled>
-      <ConfigurationCard
-        title="Executor name & type"
-        description="Define the name and type of the executor which will be displayed across the Dashboard and CLI"
-        onConfirm={() => {
-          form.submit();
-        }}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        isButtonsDisabled
-        enabled={false}
-        isEditable={false}
-      >
-        <Form.Item label="Name" name="name">
-          <Input placeholder="e.g.: my-container-executor" disabled />
-        </Form.Item>
-        <Form.Item label="Type" name="type" style={{flex: 1, marginBottom: '0'}}>
-          <Input placeholder="e.g.: my-executor/type" disabled />
-        </Form.Item>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="general-settings-name-type"
+      title="Executor name & type"
+      description="Define the name and type of the executor which will be displayed across the Dashboard and CLI"
+      form={form}
+      initialValues={{name, type}}
+      readOnly
+    >
+      <Form.Item label="Name" name="name">
+        <Input placeholder="e.g.: my-container-executor" disabled />
+      </Form.Item>
+      <Form.Item label="Type" name="type" style={{flex: 1, marginBottom: '0'}}>
+        <Input placeholder="e.g.: my-executor/type" disabled />
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/NameNType.tsx
+++ b/src/components/pages/Executors/ExecutorDetails/ExecutorSettings/General/NameNType.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 
 import {Form} from 'antd';
 
@@ -18,10 +18,6 @@ const NameNType: React.FC = () => {
   const {current} = useExecutorsPick('current');
   const {name} = current!;
   const type = current!.executor.types?.[0] ?? '';
-
-  useEffect(() => {
-    form.setFieldsValue({name, type});
-  }, [name, type]);
 
   return (
     <CardForm

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -1,5 +1,3 @@
-import {useState} from 'react';
-
 import {Form, Input} from 'antd';
 
 import {ExternalLink} from '@atoms';
@@ -23,8 +21,6 @@ type ApiEndpointFormValues = {
 const ApiEndpoint: React.FC = () => {
   const [form] = Form.useForm<ApiEndpointFormValues>();
 
-  const [isLoading, setIsLoading] = useState(false);
-
   const apiEndpoint = useApiEndpoint();
   const updateApiEndpoint = useUpdateApiEndpoint();
   const disabled = isApiEndpointLocked();
@@ -39,15 +35,10 @@ const ApiEndpoint: React.FC = () => {
       }
     } catch (error) {
       notificationCall('failed', 'Could not receive data from the specified API endpoint');
-    } finally {
-      setIsLoading(false);
     }
   };
 
-  const onSave = () => {
-    setIsLoading(true);
-    checkApiEndpoint(form.getFieldValue('endpoint'));
-  };
+  const onSave = () => checkApiEndpoint(form.getFieldValue('endpoint'));
 
   const footer = (
     <Text className="regular middle" color={`${Colors.slate400}`}>
@@ -63,7 +54,6 @@ const ApiEndpoint: React.FC = () => {
       form={form}
       initialValues={{endpoint: apiEndpoint}}
       footer={footer}
-      confirmLabel={isLoading ? 'Loading...' : 'Save'} // FIXME: Abstract?
       disabled={disabled}
       onConfirm={onSave}
     >

--- a/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
+++ b/src/components/pages/GlobalSettings/General/ApiEndpoint.tsx
@@ -4,9 +4,11 @@ import {Form, Input} from 'antd';
 
 import {ExternalLink} from '@atoms';
 
-import {FormItem, FullWidthSpace, Text} from '@custom-antd';
+import {FormItem, Text} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {isApiEndpointLocked, useApiEndpoint, useUpdateApiEndpoint} from '@services/apiEndpoint';
 
@@ -42,44 +44,33 @@ const ApiEndpoint: React.FC = () => {
     }
   };
 
-  const onSave = (values: ApiEndpointFormValues) => {
+  const onSave = () => {
     setIsLoading(true);
-    checkApiEndpoint(values.endpoint);
+    checkApiEndpoint(form.getFieldValue('endpoint'));
   };
 
+  const footer = (
+    <Text className="regular middle" color={`${Colors.slate400}`}>
+      Learn more about <ExternalLink href={externalLinks.dashboardNotWorking}>Testkube API endpoints</ExternalLink>
+    </Text>
+  );
+
   return (
-    <Form
-      form={form}
-      onFinish={onSave}
+    <CardForm
       name="global-settings-api-endpoint"
+      title="Testkube API endpoint"
+      description="Please provide the TestKube API endpoint for your installation. The endpoint needs to be accessible from your browser"
+      form={form}
       initialValues={{endpoint: apiEndpoint}}
+      footer={footer}
+      confirmLabel={isLoading ? 'Loading...' : 'Save'} // FIXME: Abstract?
       disabled={disabled}
+      onConfirm={onSave}
     >
-      <ConfigurationCard
-        title="Testkube API endpoint"
-        description="Please provide the TestKube API endpoint for your installation. The endpoint needs to be accessible from your browser"
-        footerText={
-          <Text className="regular middle" color={`${Colors.slate400}`}>
-            Learn more about{' '}
-            <ExternalLink href={externalLinks.dashboardNotWorking}>testkube API endpoints</ExternalLink>
-          </Text>
-        }
-        onConfirm={() => {
-          form.submit();
-        }}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        confirmButtonText={isLoading ? 'Loading...' : 'Save'}
-        enabled={!disabled}
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          <FormItem name="endpoint">
-            <Input placeholder="Endpoint" />
-          </FormItem>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+      <FormItem name="endpoint">
+        <Input placeholder="Endpoint" />
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/GlobalSettings/General/ConnectCloud.tsx
+++ b/src/components/pages/GlobalSettings/General/ConnectCloud.tsx
@@ -15,12 +15,13 @@ const ConnectCloud: React.FC = () => {
     <ConfigurationCard
       title="Connect to Testkube Cloud"
       description="Connect your current Testkube instance to Testkube Cloud. You can always safely disconnect."
-      footerText={
+      footer={
         <Text className="regular middle" color={Colors.slate400}>
           Learn more about{' '}
           <ExternalLink href={externalLinks.transitionFromOSS}>connecting to Testkube Cloud</ExternalLink>
         </Text>
       }
+      readOnly
     >
       <FullWidthSpace size={32} direction="vertical" style={{textAlign: 'center'}}>
         <FullWidthSpace size={20} direction="vertical">

--- a/src/components/pages/GlobalSettings/General/YourInstallation/YourInstallation.tsx
+++ b/src/components/pages/GlobalSettings/General/YourInstallation/YourInstallation.tsx
@@ -21,7 +21,11 @@ const YourInstallation: React.FC = () => {
   const helmChartVersion = `${versionRegex.test(helmchartVersion) ? 'v' : ''}${helmchartVersion}`;
 
   return (
-    <ConfigurationCard title="Your installation" description="Details about your current Testkube installation">
+    <ConfigurationCard
+      title="Your installation"
+      description="Details about your current Testkube installation"
+      readOnly
+    >
       <FullWidthSpace size={32} direction="vertical">
         <YourInstallationContainer>
           <YourInstallationItem label="Namespace" value={namespace} />

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 
 import {Form} from 'antd';
 
@@ -41,12 +41,11 @@ const Authentication: React.FC = () => {
   const [isClearedToken, setIsClearedToken] = useState(!tokenSecret);
   const [isClearedUsername, setIsClearedUsername] = useState(!usernameSecret);
 
-  useEffect(() => {
-    form.setFieldsValue(defaults);
+  const onCancel = () => {
     form.resetFields();
     setIsClearedToken(!tokenSecret);
     setIsClearedUsername(!usernameSecret);
-  }, [repository]);
+  };
 
   const onFinish = () => {
     const values = form.getFieldsValue();
@@ -80,6 +79,7 @@ const Authentication: React.FC = () => {
       disabled={!mayEdit}
       wasTouched={Boolean((tokenSecret && isClearedToken) || (usernameSecret && isClearedUsername))}
       onConfirm={onFinish}
+      onCancel={onCancel}
     >
       <SecretFormItem
         name="username"

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -74,6 +74,7 @@ const Authentication: React.FC = () => {
       name="general-settings-authentication"
       title="Authentication"
       description="Add authentication related information required by your git repository"
+      spacing={24}
       form={form}
       initialValues={defaults}
       disabled={!mayEdit}

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/Authentication.tsx
@@ -2,11 +2,11 @@ import {useEffect, useState} from 'react';
 
 import {Form} from 'antd';
 
-import {FullWidthSpace} from '@custom-antd';
-
 import {ErrorNotificationConfig} from '@models/notifications';
 
-import {ConfigurationCard, SecretFormItem, notificationCall} from '@molecules';
+import {SecretFormItem, notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -71,39 +71,29 @@ const Authentication: React.FC = () => {
   };
 
   return (
-    <Form
+    <CardForm
+      name="general-settings-authentication"
+      title="Authentication"
+      description="Add authentication related information required by your git repository"
       form={form}
       initialValues={defaults}
-      name="general-settings-authentication"
-      layout="vertical"
       disabled={!mayEdit}
+      wasTouched={Boolean((tokenSecret && isClearedToken) || (usernameSecret && isClearedUsername))}
+      onConfirm={onFinish}
     >
-      <ConfigurationCard
-        title="Authentication"
-        description="Add authentication related information required by your git repository"
-        onConfirm={onFinish}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-        forceEnableButtons={Boolean((tokenSecret && isClearedToken) || (usernameSecret && isClearedUsername))}
-      >
-        <FullWidthSpace size={24} direction="vertical">
-          <SecretFormItem
-            name="username"
-            label="Git username"
-            isClearedValue={isClearedUsername}
-            setIsClearedValue={setIsClearedUsername}
-          />
-          <SecretFormItem
-            name="token"
-            label="Git token"
-            isClearedValue={isClearedToken}
-            setIsClearedValue={setIsClearedToken}
-          />
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+      <SecretFormItem
+        name="username"
+        label="Git username"
+        isClearedValue={isClearedUsername}
+        setIsClearedValue={setIsClearedUsername}
+      />
+      <SecretFormItem
+        name="token"
+        label="Git token"
+        isClearedValue={isClearedToken}
+        setIsClearedValue={setIsClearedToken}
+      />
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -29,10 +29,6 @@ const NameNUrl: React.FC = () => {
 
   const [updateSource] = useUpdateSourceMutation();
 
-  const name = current!.name;
-  const uri = current!.repository?.uri;
-  const defaults = {name, uri};
-
   const onFinish = () => {
     const values = form.getFieldsValue();
 
@@ -61,7 +57,7 @@ const NameNUrl: React.FC = () => {
       title="Source name & repository URL"
       description="Define the name and repository URL of the source which will be later available in your tests."
       form={form}
-      initialValues={defaults}
+      initialValues={{name: current!.name, uri: current!.repository?.uri}}
       disabled={!mayEdit}
       onConfirm={onFinish}
     >

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -1,5 +1,3 @@
-import {useEffect} from 'react';
-
 import {Form} from 'antd';
 
 import {Input} from '@custom-antd';
@@ -34,11 +32,6 @@ const NameNUrl: React.FC = () => {
   const name = current!.name;
   const uri = current!.repository?.uri;
   const defaults = {name, uri};
-
-  useEffect(() => {
-    form.setFieldsValue(defaults);
-    form.resetFields();
-  }, [name, uri]);
 
   const onFinish = () => {
     const values = form.getFieldsValue();

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -56,6 +56,7 @@ const NameNUrl: React.FC = () => {
       name="general-settings-name-url"
       title="Source name & repository URL"
       description="Define the name and repository URL of the source which will be later available in your tests."
+      spacing={24}
       form={form}
       initialValues={{name: current!.name, uri: current!.repository?.uri}}
       disabled={!mayEdit}

--- a/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
+++ b/src/components/pages/Sources/SourceDetails/SourceSettings/General/NameNUrl.tsx
@@ -4,7 +4,9 @@ import {Form} from 'antd';
 
 import {Input} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -61,24 +63,22 @@ const NameNUrl: React.FC = () => {
   };
 
   return (
-    <Form form={form} name="general-settings-name-url" initialValues={defaults} layout="vertical" disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Source name & repository URL"
-        description="Define the name and repository URL of the source which will be later available in your tests."
-        onConfirm={onFinish}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <Form.Item label="Name" required name="name" rules={[required]}>
-          <Input placeholder="e.g.: my-git-test-repository" disabled />
-        </Form.Item>
-        <Form.Item label="Git repository URL" required name="uri" rules={[required]} style={{flex: 1, marginBottom: 0}}>
-          <Input placeholder="e.g.: https://github.com/myCompany/myRepo.git" />
-        </Form.Item>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="general-settings-name-url"
+      title="Source name & repository URL"
+      description="Define the name and repository URL of the source which will be later available in your tests."
+      form={form}
+      initialValues={defaults}
+      disabled={!mayEdit}
+      onConfirm={onFinish}
+    >
+      <Form.Item label="Name" required name="name" rules={[required]}>
+        <Input placeholder="e.g.: my-git-test-repository" disabled />
+      </Form.Item>
+      <Form.Item label="Git repository URL" required name="uri" rules={[required]} style={{flex: 1, marginBottom: 0}}>
+        <Input placeholder="e.g.: https://github.com/myCompany/myRepo.git" />
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/TestSuites/TestSuiteDetails/TestSuiteSettings/SettingsTests/SettingsTests.tsx
+++ b/src/components/pages/TestSuites/TestSuiteDetails/TestSuiteSettings/SettingsTests/SettingsTests.tsx
@@ -1,7 +1,5 @@
 import {memo, useContext, useEffect, useMemo, useState} from 'react';
 
-import {Form} from 'antd';
-
 import {nanoid} from '@reduxjs/toolkit';
 
 import pick from 'lodash/pick';
@@ -17,7 +15,9 @@ import useClusterVersionMatch from '@hooks/useClusterVersionMatch';
 import {TestSuiteStepTest} from '@models/test';
 import {LocalStep, TestSuite} from '@models/testSuite';
 
-import {ConfigurationCard, InlineNotification, notificationCall} from '@molecules';
+import {InlineNotification, notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -151,59 +151,63 @@ const SettingsTests = () => {
       });
   };
 
-  return (
-    <FullWidthSpace size={16} direction="vertical">
-      {!isV2 ? null : (
-        <InlineNotification
-          type="error"
-          title="Your agent needs to be updated"
-          description={
-            <>
-              You are running an older agent on this environment. Updating your Testkube will enable parallel tests and
-              other new features.
-            </>
-          }
+  const v2Notification = !isV2 ? null : (
+    <InlineNotification
+      type="error"
+      title="Your agent needs to be updated"
+      description={
+        <>
+          You are running an older agent on this environment. Updating your Testkube will enable parallel tests and
+          other new features.
+        </>
+      }
+    />
+  );
+
+  const footer = (
+    <>
+      Learn more about <ExternalLink href={externalLinks.testSuitesCreating}>Tests in a test suite</ExternalLink>
+    </>
+  );
+
+  const form = (
+    <CardForm
+      name="define-tests-form"
+      title="Tests"
+      description="Define the tests and their order of execution for this test suite"
+      footer={footer}
+      disabled={!mayEdit}
+      wasTouched={wasTouched}
+      onConfirm={onSave}
+      onCancel={() => setSteps(initialSteps)}
+    >
+      {!steps?.length ? (
+        <EmptyTestsContainer>
+          <Title level={2} className="text-center">
+            This test suite doesn&#39;t have any tests yet
+          </Title>
+          <Button $customType="primary" onClick={() => showTestModal(-0.5)}>
+            Add your first test
+          </Button>
+        </EmptyTestsContainer>
+      ) : (
+        <TestSuiteStepsFlow
+          steps={steps}
+          setSteps={setSteps}
+          showTestModal={showTestModal}
+          showDelayModal={showDelayModal}
+          isV2={isV2}
         />
       )}
-      <Form name="define-tests-form">
-        <ConfigurationCard
-          title="Tests"
-          description="Define the tests and their order of execution for this test suite"
-          footerText={
-            <>
-              Learn more about{' '}
-              <ExternalLink href={externalLinks.testSuitesCreating}>Tests in a test suite</ExternalLink>
-            </>
-          }
-          onConfirm={onSave}
-          onCancel={() => setSteps(initialSteps)}
-          isButtonsDisabled={!wasTouched}
-          isEditable={mayEdit}
-          enabled={mayEdit}
-          forceEnableButtons={wasTouched}
-        >
-          {!steps?.length ? (
-            <EmptyTestsContainer>
-              <Title level={2} className="text-center">
-                This test suite doesn&#39;t have any tests yet
-              </Title>
-              <Button $customType="primary" onClick={() => showTestModal(-0.5)}>
-                Add your first test
-              </Button>
-            </EmptyTestsContainer>
-          ) : (
-            <TestSuiteStepsFlow
-              steps={steps}
-              setSteps={setSteps}
-              showTestModal={showTestModal}
-              showDelayModal={showDelayModal}
-              isV2={isV2}
-            />
-          )}
-          <DelayModal visible={isDelayModalVisible} onClose={() => setIsDelayModalVisible(false)} onSubmit={addDelay} />
-          <TestModal visible={isTestModalVisible} onClose={() => setIsTestModalVisible(false)} onSubmit={addTest} />
-        </ConfigurationCard>
-      </Form>
+      <DelayModal visible={isDelayModalVisible} onClose={() => setIsDelayModalVisible(false)} onSubmit={addDelay} />
+      <TestModal visible={isTestModalVisible} onClose={() => setIsTestModalVisible(false)} onSubmit={addTest} />
+    </CardForm>
+  );
+
+  return (
+    <FullWidthSpace size={16} direction="vertical">
+      {v2Notification}
+      {form}
     </FullWidthSpace>
   );
 };

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useRef, useState} from 'react';
+import React, {useContext, useRef, useState} from 'react';
 
 import {Form, Input} from 'antd';
 
@@ -66,12 +66,6 @@ const TestSuiteCreationModalContent: React.FC = () => {
         }
       });
   };
-
-  useEffect(() => {
-    return () => {
-      form.resetFields();
-    };
-  }, []);
 
   return (
     <Form

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsExecution/PostRun.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsExecution/PostRun.tsx
@@ -2,9 +2,11 @@ import {Form} from 'antd';
 
 import {CommandInput} from '@atoms';
 
-import {FormItem, FullWidthSpace} from '@custom-antd';
+import {FormItem} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -50,28 +52,19 @@ const PostRun: React.FC = () => {
   };
 
   return (
-    <Form
-      form={form}
+    <CardForm
       name="execution-settings-post-run"
+      title="Post-Run phase"
+      description="You can run a command or a script (relative to your source root) which will be executed after the test itself has ended."
+      form={form}
       initialValues={{command}}
       disabled={!isPostRunAvailable}
-      layout="vertical"
+      onConfirm={onSave}
     >
-      <ConfigurationCard
-        title="Post-Run phase"
-        description="You can run a command or a script (relative to your source root) which will be executed after the test itself has ended."
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-        }}
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          <FormItem name="command" label="Command">
-            <CommandInput />
-          </FormItem>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+      <FormItem name="command" label="Command">
+        <CommandInput />
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsExecution/PreRun.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsExecution/PreRun.tsx
@@ -2,9 +2,11 @@ import {Form} from 'antd';
 
 import {CommandInput} from '@atoms';
 
-import {FormItem, FullWidthSpace} from '@custom-antd';
+import {FormItem} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -50,28 +52,19 @@ const PreRun: React.FC = () => {
   };
 
   return (
-    <Form
-      form={form}
+    <CardForm
       name="execution-settings-pre-run"
+      title="Pre-Run phase"
+      description="You can run a command or a script (relative to your source root) which will be executed before the test itself is started."
+      form={form}
       initialValues={{command}}
       disabled={!isPreRunAvailable}
-      layout="vertical"
+      onConfirm={onSave}
     >
-      <ConfigurationCard
-        title="Pre-Run phase"
-        description="You can run a command or a script (relative to your source root) which will be executed before the test itself is started."
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-        }}
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          <FormItem name="command" label="Command">
-            <CommandInput />
-          </FormItem>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+      <FormItem name="command" label="Command">
+        <CommandInput />
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsGeneral/FailureHandling.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsGeneral/FailureHandling.tsx
@@ -2,7 +2,9 @@ import {Form, Popover} from 'antd';
 
 import {Checkbox, FormItem, Text} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -58,26 +60,24 @@ const FailureHandling: React.FC = () => {
   };
 
   return (
-    <Form form={form} initialValues={{negativeTest}} name="general-settings-failure-handling" disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Failure handling"
-        description="Define how Testkube should treat occurring errors."
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <FormItem name="negativeTest" valuePropName="checked">
-          <Checkbox>
-            Invert test result
-            <Popover content={popoverContent}>
-              <StyledQuestionCircleOutlined />
-            </Popover>
-          </Checkbox>
-        </FormItem>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="general-settings-failure-handling"
+      title="Failure handling"
+      description="Define how Testkube should treat occurring errors."
+      form={form}
+      initialValues={{negativeTest}}
+      disabled={!mayEdit}
+      onConfirm={onSave}
+    >
+      <FormItem name="negativeTest" valuePropName="checked">
+        <Checkbox>
+          Invert test result
+          <Popover content={popoverContent}>
+            <StyledQuestionCircleOutlined />
+          </Popover>
+        </Checkbox>
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsGeneral/Timeout.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsGeneral/Timeout.tsx
@@ -2,9 +2,11 @@ import {Form, Input} from 'antd';
 
 import {ExternalLink} from '@atoms';
 
-import {FormItem, FullWidthSpace, Text} from '@custom-antd';
+import {FormItem, Text} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -48,34 +50,27 @@ const Timeout: React.FC = () => {
       .then(() => notificationCall('passed', 'Test Timeout was successfully updated.'));
   };
 
+  const footer = (
+    <Text className="regular middle">
+      Learn more about <ExternalLink href={externalLinks.addingTimeout}>Timeouts</ExternalLink>
+    </Text>
+  );
+
   return (
-    <Form
-      form={form}
+    <CardForm
       name="general-settings-name-description"
+      title="Timeout"
+      description="Define the timeout in seconds after which this test will fail."
+      footer={footer}
+      form={form}
       initialValues={{activeDeadlineSeconds: executionRequest?.activeDeadlineSeconds}}
       disabled={!mayEdit}
+      onConfirm={onSave}
     >
-      <ConfigurationCard
-        title="Timeout"
-        description="Define the timeout in seconds after which this test will fail."
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-        footerText={
-          <Text className="regular middle">
-            Learn more about <ExternalLink href={externalLinks.addingTimeout}>Timeouts</ExternalLink>
-          </Text>
-        }
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          <FormItem name="activeDeadlineSeconds" rules={[digits]}>
-            <Input placeholder="Timeout in seconds" />
-          </FormItem>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+      <FormItem name="activeDeadlineSeconds" rules={[digits]}>
+        <Input placeholder="Timeout in seconds" />
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsTest/Source.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsTest/Source.tsx
@@ -4,12 +4,11 @@ import {Form, Select} from 'antd';
 
 import {ExternalLink} from '@atoms';
 
-import {FormItem, FullWidthSpace} from '@custom-antd';
+import {FormItem} from '@custom-antd';
 
 import {Test} from '@models/test';
 
-import {ConfigurationCard} from '@molecules';
-
+import {CardForm} from '@organisms';
 import {
   CustomSourceEditFormFields,
   FileContentFields,
@@ -91,71 +90,68 @@ const Source: React.FC<SourceProps> = props => {
     });
   };
 
+  const onCancel = () => {
+    form.resetFields();
+    setIsClearedUsername(!additionalFormValues.username);
+    setIsClearedToken(!additionalFormValues.token);
+  };
+
+  const footer = (
+    <>
+      Learn more about <ExternalLink href={externalLinks.sourcesDocumentation}>test sources</ExternalLink>
+    </>
+  );
+
   return (
-    <Form
-      form={form}
+    <CardForm
       name="test-settings-source"
-      initialValues={{testSource: source, ...additionalFormValues}}
-      layout="vertical"
+      title="Source"
+      description="Define the source for your test"
+      footer={footer}
       labelAlign="right"
+      form={form}
+      initialValues={{testSource: source, ...additionalFormValues}}
       disabled={!mayEdit}
+      wasTouched={Boolean(
+        (isClearedToken && additionalFormValues.token) || (isClearedUsername && additionalFormValues.username)
+      )}
+      onConfirm={onSave}
+      onCancel={onCancel}
     >
-      <ConfigurationCard
-        title="Source"
-        description="Define the source for your test"
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-          setIsClearedUsername(!additionalFormValues.username);
-          setIsClearedToken(!additionalFormValues.token);
-        }}
-        footerText={
-          <>
-            Learn more about <ExternalLink href={externalLinks.sourcesDocumentation}>test sources</ExternalLink>
-          </>
-        }
-        forceEnableButtons={Boolean(
-          (isClearedToken && additionalFormValues.token) || (isClearedUsername && additionalFormValues.username)
-        )}
-        enabled={mayEdit}
+      <FormItem name="testSource" rules={[required]}>
+        <Select showSearch options={sourcesOptions} />
+      </FormItem>
+      <Form.Item
+        noStyle
+        shouldUpdate={(prevValues, currentValues) => prevValues.testSource !== currentValues.testSource}
       >
-        <FullWidthSpace size={24} direction="vertical">
-          <FormItem name="testSource" rules={[required]}>
-            <Select showSearch options={sourcesOptions} />
-          </FormItem>
-          <Form.Item
-            noStyle
-            shouldUpdate={(prevValues, currentValues) => prevValues.testSource !== currentValues.testSource}
-          >
-            {({getFieldValue}) => {
-              const testSource = getSourceFieldValue(getFieldValue);
+        {({getFieldValue}) => {
+          const testSource = getSourceFieldValue(getFieldValue);
 
-              if (!testSource) {
-                return null;
-              }
+          if (!testSource) {
+            return null;
+          }
 
-              const executorType = selectedExecutor?.executor.meta?.iconURI || 'unknown';
+          const executorType = selectedExecutor?.executor.meta?.iconURI || 'unknown';
 
-              const childrenProps: Record<SourceType, Partial<Props>> = {
-                git: {
-                  executorType,
-                  isClearedToken,
-                  isClearedUsername,
-                  setIsClearedToken,
-                  setIsClearedUsername,
-                  getFieldValue,
-                },
-                custom: {executorType},
-                string: {},
-                'file-uri': {},
-              };
+          const childrenProps: Record<SourceType, Partial<Props>> = {
+            git: {
+              executorType,
+              isClearedToken,
+              isClearedUsername,
+              setIsClearedToken,
+              setIsClearedUsername,
+              getFieldValue,
+            },
+            custom: {executorType},
+            string: {},
+            'file-uri': {},
+          };
 
-              return getAdditionalFieldsComponent(testSource, additionalFields, childrenProps[testSource]);
-            }}
-          </Form.Item>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+          return getAdditionalFieldsComponent(testSource, additionalFields, childrenProps[testSource]);
+        }}
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsTest/Source.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsTest/Source.tsx
@@ -109,6 +109,7 @@ const Source: React.FC<SourceProps> = props => {
       description="Define the source for your test"
       footer={footer}
       labelAlign="right"
+      spacing={24}
       form={form}
       initialValues={{testSource: source, ...additionalFormValues}}
       disabled={!mayEdit}

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsTest/TestType.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsTest/TestType.tsx
@@ -4,9 +4,9 @@ import {Form, Select} from 'antd';
 
 import {ExternalLink} from '@atoms';
 
-import {FormItem, FullWidthSpace} from '@custom-antd';
+import {FormItem} from '@custom-antd';
 
-import {ConfigurationCard} from '@molecules';
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -38,29 +38,27 @@ const TestType: React.FC<TestTypeProps> = props => {
     return updateTest({type: form.getFieldValue('type')});
   };
 
+  const footer = (
+    <>
+      Learn more about <ExternalLink href={externalLinks.testTypes}>test types and executors</ExternalLink>
+    </>
+  );
+
   return (
-    <Form form={form} onFinish={onSave} name="test-settings-test-type" initialValues={{type}} disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Test type"
-        description="Define the test type for this test."
-        onConfirm={onSave}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        footerText={
-          <>
-            Learn more about <ExternalLink href={externalLinks.testTypes}>test types and executors</ExternalLink>
-          </>
-        }
-        enabled={mayEdit}
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          <FormItem name="type" rules={[required]}>
-            <Select showSearch options={remappedExecutors} />
-          </FormItem>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="test-settings-test-type"
+      title="Test type"
+      description="Define the test type for this test."
+      footer={footer}
+      form={form}
+      initialValues={{type}}
+      disabled={!mayEdit}
+      onConfirm={onSave}
+    >
+      <FormItem name="type" rules={[required]}>
+        <Select showSearch options={remappedExecutors} />
+      </FormItem>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Tests/TestDetails/TestSettings/SettingsVariables/Arguments.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/SettingsVariables/Arguments.tsx
@@ -8,7 +8,9 @@ import {Button, FullWidthSpace, Text} from '@custom-antd';
 
 import {Test} from '@models/test';
 
-import {ConfigurationCard, CopyCommand, notificationCall} from '@molecules';
+import {CopyCommand, notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -39,7 +41,6 @@ const Arguments: React.FC = () => {
 
   const [argsValue, setArgsValue] = useState(entityArgs.join(' ') || '');
   const [isPrettified, setPrettifiedState] = useState(true);
-  const [isButtonsDisabled, setIsButtonsDisabled] = useState(true);
 
   const onSaveForm = () => {
     const values = form.getFieldsValue();
@@ -69,7 +70,11 @@ const Arguments: React.FC = () => {
     }
     const args = (form.getFieldValue('args') as string).replace(/\s+/g, ' ').trim();
     setArgsValue(args);
-    setIsButtonsDisabled(false);
+  };
+
+  const onCancel = () => {
+    setArgsValue(entityArgs.join(' '));
+    form.setFieldValue(['args'], entityArgs.join(' '));
   };
 
   const prettifyArgs = () => {
@@ -86,57 +91,50 @@ const Arguments: React.FC = () => {
     prettifyArgs();
   }, []);
 
+  const footer = (
+    <>
+      Learn more about <ExternalLink href={externalLinks.arguments}>Arguments</ExternalLink>
+    </>
+  );
+
   return (
-    <Form
-      form={form}
+    <CardForm
       name="general-settings-name-description"
-      onChange={onChange}
+      title="Arguments"
+      description="Define arguments which will be passed to the test executor."
+      footer={footer}
+      form={form}
       initialValues={{args: argsValue}}
       disabled={!mayEdit}
+      onFieldsChange={onChange}
+      onConfirm={onSaveForm}
+      onCancel={onCancel}
     >
-      <ConfigurationCard
-        title="Arguments"
-        description="Define arguments which will be passed to the test executor."
-        footerText={
-          <>
-            Learn more about <ExternalLink href={externalLinks.arguments}>Arguments</ExternalLink>
-          </>
-        }
-        isButtonsDisabled={isButtonsDisabled}
-        onConfirm={onSaveForm}
-        onCancel={() => {
-          setArgsValue(entityArgs.join(' '));
-          form.setFieldValue(['args'], entityArgs.join(' '));
-          setIsButtonsDisabled(true);
-        }}
-        enabled={mayEdit}
-      >
-        <ArgumentsWrapper>
-          <CopyCommand command={argsValue} isBordered additionalPrefix="executor-binary" />
-          <FullWidthSpace size={16} direction="vertical">
-            <Text className="regular middle" color={Colors.slate400}>
-              Arguments passed to the executor (concat and passed directly to the executor)
-            </Text>
+      <ArgumentsWrapper>
+        <CopyCommand command={argsValue} isBordered additionalPrefix="executor-binary" />
+        <FullWidthSpace size={16} direction="vertical">
+          <Text className="regular middle" color={Colors.slate400}>
+            Arguments passed to the executor (concat and passed directly to the executor)
+          </Text>
 
-            <Form.Item name="args" style={{marginBottom: 0, marginTop: 0}}>
-              <Input.TextArea
-                autoSize={{
-                  minRows: 8,
-                }}
-                className="args-textarea"
-                placeholder={`--flag="value value"
+          <Form.Item name="args" style={{marginBottom: 0, marginTop: 0}}>
+            <Input.TextArea
+              autoSize={{
+                minRows: 8,
+              }}
+              className="args-textarea"
+              placeholder={`--flag="value value"
 --flag-123=value
 value
 `}
-              />
-            </Form.Item>
-            <Button onClick={prettifyArgs} $customType="secondary" disabled={isPrettified}>
-              Prettify
-            </Button>
-          </FullWidthSpace>
-        </ArgumentsWrapper>
-      </ConfigurationCard>
-    </Form>
+            />
+          </Form.Item>
+          <Button onClick={prettifyArgs} $customType="secondary" disabled={isPrettified}>
+            Prettify
+          </Button>
+        </FullWidthSpace>
+      </ArgumentsWrapper>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/General/Name.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/General/Name.tsx
@@ -11,15 +11,13 @@ const Name: React.FC = () => {
 
   const [form] = Form.useForm();
 
-  const name = current?.name;
-
   return (
     <CardForm
       name="general-settings-name"
       title="Trigger name"
       description="Define the name of your trigger"
       form={form}
-      initialValues={{name}}
+      initialValues={{name: current?.name}}
       readOnly
     >
       <Form.Item label="Name" name="name">

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/General/Name.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/General/Name.tsx
@@ -2,61 +2,30 @@ import {Form} from 'antd';
 
 import {Input} from '@custom-antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {CardForm} from '@organisms';
 
-import {Permissions, usePermission} from '@permissions/base';
-
-import {useUpdateTriggerByIdMutation} from '@services/triggers';
-
-import {useTriggersField} from '@store/triggers';
-
-import {displayDefaultNotificationFlow} from '@utils/notification';
+import {useTriggersPick} from '@store/triggers';
 
 const Name: React.FC = () => {
-  const [currentTrigger, setCurrentTrigger] = useTriggersField('current');
-
-  const mayEdit = usePermission(Permissions.editEntity);
-
-  const [updateTrigger] = useUpdateTriggerByIdMutation();
+  const {current} = useTriggersPick('current');
 
   const [form] = Form.useForm();
 
-  const name = currentTrigger?.name;
-
-  const onFinish = () => {
-    const values = form.getFieldsValue();
-
-    const body = {
-      ...currentTrigger!,
-      name: values.name,
-    };
-
-    return updateTrigger(body)
-      .then(displayDefaultNotificationFlow)
-      .then(() => {
-        notificationCall('passed', 'Trigger was successfully updated.');
-        setCurrentTrigger(body);
-      });
-  };
+  const name = current?.name;
 
   return (
-    <Form form={form} name="general-settings-name" initialValues={{name}} layout="vertical" disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Trigger name"
-        description="Define the name of your trigger"
-        onConfirm={onFinish}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        isButtonsDisabled
-        enabled={false}
-        isEditable={false}
-      >
-        <Form.Item label="Name" name="name">
-          <Input placeholder="e.g.: my-test-trigger" disabled />
-        </Form.Item>
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="general-settings-name"
+      title="Trigger name"
+      description="Define the name of your trigger"
+      form={form}
+      initialValues={{name}}
+      readOnly
+    >
+      <Form.Item label="Name" name="name">
+        <Input placeholder="e.g.: my-test-trigger" disabled />
+      </Form.Item>
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/TriggerAction.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/TriggerAction.tsx
@@ -25,8 +25,6 @@ const TriggerAction: React.FC = () => {
 
   const [form] = Form.useForm();
 
-  const initialValues = getActionFormValues(currentTrigger!);
-
   const onFinish = () => {
     const values = form.getFieldsValue();
 
@@ -55,7 +53,7 @@ const TriggerAction: React.FC = () => {
       title="Action"
       description="Define the action to be performed on testkube once the conditions are met."
       form={form}
-      initialValues={initialValues}
+      initialValues={getActionFormValues(currentTrigger!)}
       disabled={!mayEdit}
       onConfirm={onFinish}
     >

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/TriggerAction.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/TriggerAction.tsx
@@ -1,8 +1,8 @@
 import {Form} from 'antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
 
-import {ActionFormItems} from '@organisms';
+import {ActionFormItems, CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -50,19 +50,17 @@ const TriggerAction: React.FC = () => {
   };
 
   return (
-    <Form form={form} name="trigger-action" initialValues={initialValues} layout="vertical" disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Action"
-        description="Define the action to be performed on testkube once the conditions are met."
-        onConfirm={onFinish}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <ActionFormItems />
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="trigger-action"
+      title="Action"
+      description="Define the action to be performed on testkube once the conditions are met."
+      form={form}
+      initialValues={initialValues}
+      disabled={!mayEdit}
+      onConfirm={onFinish}
+    >
+      <ActionFormItems />
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
@@ -1,8 +1,8 @@
 import {Form} from 'antd';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
 
-import {ConditionFormItems} from '@organisms';
+import {CardForm, ConditionFormItems} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -52,19 +52,17 @@ const Condition: React.FC = () => {
   };
 
   return (
-    <Form form={form} name="trigger-condition" initialValues={initialValues} layout="vertical" disabled={!mayEdit}>
-      <ConfigurationCard
-        title="Trigger condition"
-        description="Define the conditions to be met for the trigger to be called."
-        onConfirm={onFinish}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <ConditionFormItems />
-      </ConfigurationCard>
-    </Form>
+    <CardForm
+      name="trigger-condition"
+      title="Trigger condition"
+      description="Define the conditions to be met for the trigger to be called."
+      form={form}
+      initialValues={initialValues}
+      disabled={!mayEdit}
+      onConfirm={onFinish}
+    >
+      <ConditionFormItems />
+    </CardForm>
   );
 };
 

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
@@ -25,8 +25,6 @@ const Condition: React.FC = () => {
 
   const [form] = Form.useForm();
 
-  const initialValues = getConditionFormValues(currentTrigger!);
-
   const onFinish = () => {
     const values = form.getFieldsValue();
 
@@ -57,7 +55,7 @@ const Condition: React.FC = () => {
       title="Trigger condition"
       description="Define the conditions to be met for the trigger to be called."
       form={form}
-      initialValues={initialValues}
+      initialValues={getConditionFormValues(currentTrigger!)}
       disabled={!mayEdit}
       onConfirm={onFinish}
     >

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/ResourceCondition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/ResourceCondition.tsx
@@ -5,7 +5,9 @@ import {Button, FormIconWrapper, FormItem, FormItemLabel, FormRow, FullWidthSpac
 
 import {TestTrigger, TriggerConditionStatus} from '@models/triggers';
 
-import {ConfigurationCard, notificationCall} from '@molecules';
+import {notificationCall} from '@molecules';
+
+import {CardForm} from '@organisms';
 
 import {Permissions, usePermission} from '@permissions/base';
 
@@ -59,96 +61,86 @@ const ResourceCondition: React.FC = () => {
   ];
 
   return (
-    <Form
-      form={form}
+    <CardForm
       name="trigger-resource-conditions"
+      title="Trigger resource condition"
+      description="Fine grain the status conditions for your selected resource."
+      form={form}
       initialValues={{
         timeout: currentTrigger?.conditionSpec?.timeout,
         conditions: currentTrigger?.conditionSpec?.conditions || [],
       }}
-      layout="vertical"
       disabled={!mayEdit}
+      onConfirm={onFinish}
     >
-      <ConfigurationCard
-        title="Trigger resource condition"
-        description="Fine grain the status conditions for your selected resource."
-        onConfirm={onFinish}
-        onCancel={() => {
-          form.resetFields();
-        }}
-        enabled={mayEdit}
-      >
-        <FullWidthSpace size={32} direction="vertical">
-          {isResourceConditionsListEmpty ? null : (
-            <FormItem
-              name="timeout"
-              label={
-                <FormItemLabel
-                  text="Delay in ms"
-                  tooltipMessage="Add the delay in ms the test trigger waits for conditions"
-                />
-              }
-            >
-              <InputNumber
-                controls={false}
-                placeholder="Delay"
-                max={2 ** 31 - 1} // Int32 max value
-                style={{width: '100%'}}
-              />
-            </FormItem>
-          )}
-          <Form.List name="conditions" initialValue={[]}>
-            {(fields, {add, remove}) => (
-              <FullWidthSpace size={16} direction="vertical">
-                {!isResourceConditionsListEmpty ? (
-                  <FullWidthSpace direction="vertical" size={16}>
-                    {fields.length &&
-                      fields?.map(({key, name, ...restField}) => {
-                        return (
-                          <FormRow key={key}>
-                            <FormItem {...restField} name={[name, 'type']} rules={[requiredNoText]} flex={2}>
-                              <Select
-                                options={keyMap?.conditions?.map(condition => ({
-                                  label: condition,
-                                  value: condition,
-                                }))}
-                                placeholder="Type"
-                              />
-                            </FormItem>
-                            <FormItem {...restField} name={[name, 'status']} rules={[requiredNoText]} flex={2}>
-                              <Select options={selectOptions} placeholder="Status" />
-                            </FormItem>
-                            <FormItem {...restField} name={[name, 'reason']} flex={4}>
-                              <Input placeholder="Reason" />
-                            </FormItem>
-                            <FormIconWrapper>
-                              <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
-                            </FormIconWrapper>
-                          </FormRow>
-                        );
-                      })}
-                  </FullWidthSpace>
-                ) : null}
-                <FormRow justify="center">
-                  <Button
-                    $customType="secondary"
-                    onClick={() =>
-                      add({
-                        type: null,
-                        status: null,
-                        reason: null,
-                      })
-                    }
-                  >
-                    Add a new condition
-                  </Button>
-                </FormRow>
+      {isResourceConditionsListEmpty ? null : (
+        <FormItem
+          name="timeout"
+          label={
+            <FormItemLabel
+              text="Delay in ms"
+              tooltipMessage="Add the delay in ms the test trigger waits for conditions"
+            />
+          }
+        >
+          <InputNumber
+            controls={false}
+            placeholder="Delay"
+            max={2 ** 31 - 1} // Int32 max value
+            style={{width: '100%'}}
+          />
+        </FormItem>
+      )}
+      <Form.List name="conditions" initialValue={[]}>
+        {(fields, {add, remove}) => (
+          <FullWidthSpace size={16} direction="vertical">
+            {!isResourceConditionsListEmpty ? (
+              <FullWidthSpace direction="vertical" size={16}>
+                {fields.length &&
+                  fields?.map(({key, name, ...restField}) => {
+                    return (
+                      <FormRow key={key}>
+                        <FormItem {...restField} name={[name, 'type']} rules={[requiredNoText]} flex={2}>
+                          <Select
+                            options={keyMap?.conditions?.map(condition => ({
+                              label: condition,
+                              value: condition,
+                            }))}
+                            placeholder="Type"
+                          />
+                        </FormItem>
+                        <FormItem {...restField} name={[name, 'status']} rules={[requiredNoText]} flex={2}>
+                          <Select options={selectOptions} placeholder="Status" />
+                        </FormItem>
+                        <FormItem {...restField} name={[name, 'reason']} flex={4}>
+                          <Input placeholder="Reason" />
+                        </FormItem>
+                        <FormIconWrapper>
+                          <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
+                        </FormIconWrapper>
+                      </FormRow>
+                    );
+                  })}
               </FullWidthSpace>
-            )}
-          </Form.List>
-        </FullWidthSpace>
-      </ConfigurationCard>
-    </Form>
+            ) : null}
+            <FormRow justify="center">
+              <Button
+                $customType="secondary"
+                onClick={() =>
+                  add({
+                    type: null,
+                    status: null,
+                    reason: null,
+                  })
+                }
+              >
+                Add a new condition
+              </Button>
+            </FormRow>
+          </FullWidthSpace>
+        )}
+      </Form.List>
+    </CardForm>
   );
 };
 


### PR DESCRIPTION
This PR tries to unify the forms, to use `CardForm` instead of multiple components in a few different ways.

The logic behinds stay mostly the same, the interfaces have been simplified though. Some features (i.e. loading) that have been implemented in part of forms have become the generic solution now.

## Changes

- *chore:* simplify `ConfigurationCard` interface a little
- *fix:* make `FullWidthSpace` block flex instead of inline-flex
- *tech/feat:* add `CardForm` that replaces common `Form`+`ConfigurationCard`+`FullWidthSpace` tandem
  - use it when it's possible
  - support error handling generically
  - support loading state generically

## Fixes

- https://github.com/kubeshop/testkube/issues/3787

## How to test it

- Go through forms on https://testkube-dashboard-git-dawid-techsimplify-770d15-testkube-cloud.vercel.app/?~api_server_endpoint=https://dev.testkube.io/results/v1

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
