### PR TITLE
fix: "Scheduling" tab for Tests uses proper mutation now

### DIFF
--- a/src/components/pages/Tests/TestDetails/TestSettings/TestSettings.tsx
+++ b/src/components/pages/Tests/TestDetails/TestSettings/TestSettings.tsx
@@ -5,7 +5,7 @@ import {SettingsLayoutProps} from '@molecules/SettingsLayout/SettingsLayout';
 
 import {SettingsScheduling} from '@organisms/EntityDetails';
 
-import {useUpdateTestSuiteMutation} from '@services/testSuites';
+import {useUpdateTestMutation} from '@services/tests';
 
 import SettingsDefinition from './SettingsDefinition';
 import SettingsExecution from './SettingsExecution';
@@ -21,7 +21,7 @@ const tabs = [
   {
     id: 'scheduling',
     label: 'Scheduling',
-    children: <SettingsScheduling label="test" useUpdateEntity={useUpdateTestSuiteMutation} />,
+    children: <SettingsScheduling label="test" useUpdateEntity={useUpdateTestMutation} />,
   },
   {id: 'definition', label: 'Definition', children: <SettingsDefinition />},
 ];


### PR DESCRIPTION
## Changes

- use proper mutation for updating Tests schedule

## Fixes

- https://github.com/kubeshop/testkube/issues/4287

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
