### PR TITLE
fix: support offline agents correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {DashboardContext, MainContext} from '@contexts';
 import {EndpointModal, MessagePanel, notificationCall} from '@molecules';
 
 import {
+  ClusterRequired,
   EndpointProcessing,
   Executors,
   GlobalSettings,
@@ -162,11 +163,13 @@ const App: React.FC<AppProps> = ({plugins}) => {
         ) : null}
         <EndpointModal visible={isEndpointModalVisible} setModalState={setEndpointModalState} />
         <Routes>
-          <Route path="tests/*" element={<Tests />} />
-          <Route path="test-suites/*" element={<TestSuites />} />
-          <Route path="executors/*" element={<Executors />} />
-          <Route path="sources/*" element={<Sources />} />
-          <Route path="triggers/*" element={<Triggers />} />
+          <Route element={<ClusterRequired />}>
+            <Route path="tests/*" element={<Tests />} />
+            <Route path="test-suites/*" element={<TestSuites />} />
+            <Route path="executors/*" element={<Executors />} />
+            <Route path="sources/*" element={<Sources />} />
+            <Route path="triggers/*" element={<Triggers />} />
+          </Route>
           <Route path="settings" element={<GlobalSettings />} />
           <Route
             path="/apiEndpoint"

--- a/src/components/pages/ClusterRequired/ClusterRequired.tsx
+++ b/src/components/pages/ClusterRequired/ClusterRequired.tsx
@@ -1,0 +1,13 @@
+import {FC, PropsWithChildren, useContext} from 'react';
+import {Outlet} from 'react-router-dom';
+
+import {MainContext} from '@contexts';
+
+import Offline from '@pages/Offline';
+
+const ClusterRequired: FC<PropsWithChildren<{}>> = ({children}) => {
+  const {isClusterAvailable} = useContext(MainContext);
+  return isClusterAvailable ? <Outlet /> : <Offline />;
+};
+
+export default ClusterRequired;

--- a/src/components/pages/ClusterRequired/index.ts
+++ b/src/components/pages/ClusterRequired/index.ts
@@ -1,0 +1,1 @@
+export {default} from './ClusterRequired';

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -14,8 +14,6 @@ import {EntityGrid} from '@molecules';
 
 import {PageBlueprint} from '@organisms';
 
-import Loading from '@pages/Loading';
-
 import {Permissions, usePermission} from '@permissions/base';
 
 import {useApiEndpoint} from '@services/apiEndpoint';
@@ -47,10 +45,6 @@ const Executors: React.FC = () => {
   useEffect(() => {
     safeRefetch(refetch);
   }, [apiEndpoint]);
-
-  if (!executors) {
-    return <Loading />;
-  }
 
   return (
     <PageBlueprint

--- a/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
+++ b/src/components/pages/Executors/ExecutorsList/ExecutorsList.tsx
@@ -14,6 +14,8 @@ import {EntityGrid} from '@molecules';
 
 import {PageBlueprint} from '@organisms';
 
+import {Error} from '@pages';
+
 import {Permissions, usePermission} from '@permissions/base';
 
 import {useApiEndpoint} from '@services/apiEndpoint';
@@ -38,13 +40,17 @@ const Executors: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = useState('custom');
   const [isAddExecutorModalVisible, setAddExecutorModalVisibility] = useState(false);
 
-  const {data: executors, isLoading, refetch} = useGetExecutorsQuery(null, {skip: !isClusterAvailable});
+  const {data: executors, isLoading, error, refetch} = useGetExecutorsQuery(null, {skip: !isClusterAvailable});
 
   const customExecutors = executors?.filter(executorItem => executorItem.executor.executorType === 'container') || [];
 
   useEffect(() => {
     safeRefetch(refetch);
   }, [apiEndpoint]);
+
+  if (error) {
+    return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
+  }
 
   return (
     <PageBlueprint

--- a/src/components/pages/Loading/Loading.tsx
+++ b/src/components/pages/Loading/Loading.tsx
@@ -1,17 +1,11 @@
-import {useState} from 'react';
-
 import {LoadingOutlined} from '@ant-design/icons';
 
 import {LoadingContainer} from './Loading.styled';
 
-const Loading = () => {
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState(0);
-
-  return (
-    <LoadingContainer>
-      <LoadingOutlined />
-    </LoadingContainer>
-  );
-};
+const Loading = () => (
+  <LoadingContainer>
+    <LoadingOutlined />
+  </LoadingContainer>
+);
 
 export default Loading;

--- a/src/components/pages/Offline/Offline.styled.tsx
+++ b/src/components/pages/Offline/Offline.styled.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+import Colors from '@styles/Colors';
+
+export const OfflineContainer = styled.div`
+  align-self: center;
+  text-align: center;
+  margin: auto;
+  color: ${Colors.slate400};
+`;
+
+export const OfflineIcon = styled.div`
+  font-size: 64px;
+  color: ${Colors.rose600};
+`;

--- a/src/components/pages/Offline/Offline.tsx
+++ b/src/components/pages/Offline/Offline.tsx
@@ -1,0 +1,16 @@
+import {CloudSyncOutlined} from '@ant-design/icons';
+
+import {OfflineContainer, OfflineIcon} from './Offline.styled';
+
+const Offline = () => {
+  return (
+    <OfflineContainer>
+      <OfflineIcon>
+        <CloudSyncOutlined />
+      </OfflineIcon>
+      <div>Your cluster is offline.</div>
+    </OfflineContainer>
+  );
+};
+
+export default Offline;

--- a/src/components/pages/Offline/index.ts
+++ b/src/components/pages/Offline/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Offline';

--- a/src/components/pages/Sources/SourcesList/SourcesList.tsx
+++ b/src/components/pages/Sources/SourcesList/SourcesList.tsx
@@ -12,8 +12,6 @@ import {EntityGrid} from '@molecules';
 
 import {PageBlueprint} from '@organisms';
 
-import Loading from '@pages/Loading';
-
 import {Permissions, usePermission} from '@permissions/base';
 
 import {useGetSourcesQuery} from '@services/sources';
@@ -38,10 +36,6 @@ const Sources: React.FC = () => {
   useEffect(() => {
     safeRefetch(refetch);
   }, [location]);
-
-  if (!sources) {
-    return <Loading />;
-  }
 
   return (
     <PageBlueprint

--- a/src/components/pages/Sources/SourcesList/SourcesList.tsx
+++ b/src/components/pages/Sources/SourcesList/SourcesList.tsx
@@ -12,6 +12,8 @@ import {EntityGrid} from '@molecules';
 
 import {PageBlueprint} from '@organisms';
 
+import {Error} from '@pages';
+
 import {Permissions, usePermission} from '@permissions/base';
 
 import {useGetSourcesQuery} from '@services/sources';
@@ -28,7 +30,7 @@ const Sources: React.FC = () => {
   const {location} = useContext(DashboardContext);
   const openDetails = useDashboardNavigate(({name}: {name: string}) => `/sources/${name}`);
 
-  const {data: sources, refetch, isLoading} = useGetSourcesQuery(null, {skip: !isClusterAvailable});
+  const {data: sources, refetch, error, isLoading} = useGetSourcesQuery(null, {skip: !isClusterAvailable});
 
   const [isAddSourceModalVisible, setAddSourceModalVisibility] = useState(false);
   const mayCreate = usePermission(Permissions.createEntity);
@@ -36,6 +38,10 @@ const Sources: React.FC = () => {
   useEffect(() => {
     safeRefetch(refetch);
   }, [location]);
+
+  if (error) {
+    return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
+  }
 
   return (
     <PageBlueprint

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuitesList.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuitesList.tsx
@@ -11,6 +11,8 @@ import {notificationCall} from '@molecules';
 
 import {EntityListContent} from '@organisms';
 
+import {Error} from '@pages';
+
 import {usePluginSlot} from '@plugins/hooks';
 
 import {useAbortAllTestSuiteExecutionsMutation, useGetTestSuitesQuery} from '@services/testSuites';
@@ -39,6 +41,7 @@ const TestSuitesList: FC = () => {
 
   const {
     data: testSuites,
+    error,
     isLoading,
     isFetching,
   } = useGetTestSuitesQuery(filters || null, {
@@ -56,6 +59,10 @@ const TestSuitesList: FC = () => {
         notificationCall('failed', 'Something went wrong during test suite execution abortion');
       });
   }, []);
+
+  if (error) {
+    return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
+  }
 
   return (
     <EntityListContent

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuitesList.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuitesList.tsx
@@ -38,6 +38,7 @@ const createModal: ModalConfig = {
 const TestSuitesList: FC = () => {
   const {isClusterAvailable} = useContext(MainContext);
   const [filters, setFilters] = useTestSuitesField('filters');
+  const pageTitleAddon = usePluginSlot('testSuitesListTitleAddon');
 
   const {
     data: testSuites,
@@ -72,7 +73,7 @@ const TestSuitesList: FC = () => {
       onItemAbort={onItemAbort}
       entity="test-suites"
       pageTitle="Test Suites"
-      pageTitleAddon={usePluginSlot('testSuitesListTitleAddon')}
+      pageTitleAddon={pageTitleAddon}
       addEntityButtonText="Add a new test suite"
       pageDescription={PageDescription}
       emptyDataComponent={EmptyTestSuites}

--- a/src/components/pages/Tests/TestsList/TestsList.tsx
+++ b/src/components/pages/Tests/TestsList/TestsList.tsx
@@ -13,6 +13,8 @@ import {notificationCall} from '@molecules';
 
 import {EntityListContent} from '@organisms';
 
+import {Error} from '@pages';
+
 import {useAbortAllTestExecutionsMutation, useGetTestsQuery} from '@services/tests';
 
 import {initialFilters, useTestsField, useTestsSync} from '@store/tests';
@@ -47,6 +49,7 @@ const TestsList: FC = () => {
     data: tests,
     isLoading,
     isFetching,
+    error,
   } = useGetTestsQuery(filters, {
     pollingInterval: PollingIntervals.everySecond,
     skip: !isClusterAvailable,
@@ -62,6 +65,10 @@ const TestsList: FC = () => {
         notificationCall('failed', 'Something went wrong during test execution abortion');
       });
   }, []);
+
+  if (error) {
+    return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
+  }
 
   return (
     <EntityListContent

--- a/src/components/pages/Triggers/TriggersList/TriggersList.tsx
+++ b/src/components/pages/Triggers/TriggersList/TriggersList.tsx
@@ -12,6 +12,8 @@ import {EntityGrid} from '@molecules';
 
 import {PageBlueprint} from '@organisms';
 
+import {Error} from '@pages';
+
 import {Permissions, usePermission} from '@permissions/base';
 
 import {useGetTriggersListQuery} from '@services/triggers';
@@ -28,7 +30,7 @@ const TriggersList: React.FC = () => {
   const {location} = useContext(DashboardContext);
   const openDetails = useDashboardNavigate(({name}: {name: string}) => `/triggers/${name}`);
 
-  const {data: triggers, refetch, isLoading} = useGetTriggersListQuery(null, {skip: !isClusterAvailable});
+  const {data: triggers, refetch, error, isLoading} = useGetTriggersListQuery(null, {skip: !isClusterAvailable});
 
   const [isAddTriggerModalVisible, setAddTriggerModalVisibility] = useState(false);
   const mayCreate = usePermission(Permissions.createEntity);
@@ -36,6 +38,10 @@ const TriggersList: React.FC = () => {
   useEffect(() => {
     safeRefetch(refetch);
   }, [location]);
+
+  if (error) {
+    return <Error title={(error as any)?.data?.title} description={(error as any)?.data?.detail} />;
+  }
 
   return (
     <PageBlueprint

--- a/src/components/pages/Triggers/TriggersList/TriggersList.tsx
+++ b/src/components/pages/Triggers/TriggersList/TriggersList.tsx
@@ -28,7 +28,7 @@ const TriggersList: React.FC = () => {
   const {location} = useContext(DashboardContext);
   const openDetails = useDashboardNavigate(({name}: {name: string}) => `/triggers/${name}`);
 
-  const {data: triggersList = [], refetch, isLoading} = useGetTriggersListQuery(null, {skip: !isClusterAvailable});
+  const {data: triggers, refetch, isLoading} = useGetTriggersListQuery(null, {skip: !isClusterAvailable});
 
   const [isAddTriggerModalVisible, setAddTriggerModalVisibility] = useState(false);
   const mayCreate = usePermission(Permissions.createEntity);
@@ -60,7 +60,7 @@ const TriggersList: React.FC = () => {
     >
       <EntityGrid
         maxColumns={3}
-        data={triggersList}
+        data={triggers}
         Component={TriggerCard}
         componentProps={{onClick: openDetails}}
         empty={<EmptyTriggers onButtonClick={() => setAddTriggerModalVisibility(true)} />}

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -9,3 +9,4 @@ export {default as ErrorBoundary} from './ErrorBoundary';
 export {default as GlobalSettings} from './GlobalSettings';
 export {default as Loading} from './Loading';
 export {default as Error} from './Error';
+export {default as ClusterRequired} from './ClusterRequired';

--- a/src/store/executors.ts
+++ b/src/store/executors.ts
@@ -20,14 +20,14 @@ const createExecutorsSlice: StateCreator<ExecutorsSlice> = set => ({
   featuresMap: {},
 
   setExecutors(rawExecutors): void {
-    const executors = rawExecutors.map(executor => {
+    const executors = rawExecutors?.map(executor => {
       const iconURI = executor.executor?.meta?.iconURI;
       if (!iconURI || isURL(iconURI)) {
         return {...executor, displayName: capitalize(iconURI)};
       }
       return {...executor, displayName: executor.name};
     });
-    const featuresMap: Record<string, ExecutorFeature[]> = executors.reduce(
+    const featuresMap: Record<string, ExecutorFeature[]> = (executors || []).reduce(
       (acc, {executor: {features, types}}) => types.reduce((acc2, type) => ({...acc2, [type]: features || []}), acc),
       {}
     );


### PR DESCRIPTION
Right now, when the cluster is offline, we either throw error (like on executors) or show a loader or wrong empty page.

## Changes

- Fix error thrown when there is a problem with executors retrieval
- Show nicely information that the cluster is offline

## Fixes

-

## How to test it

-

## screenshots

| <img width="1920" alt="Zrzut ekranu 2023-08-22 o 16 48 06" src="https://github.com/kubeshop/testkube-dashboard/assets/3843526/2cc07e7c-d30a-4ba9-bf5e-3a81ef337c6b"> |
|-|


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
