### PR TITLE
chore: delete isBannerAvailable from MainContext

### DIFF
--- a/src/contexts/MainContext.ts
+++ b/src/contexts/MainContext.ts
@@ -6,8 +6,6 @@ export type MainContextProps = {
   clusterConfig?: ClusterConfig;
   clusterVersion?: string;
   isClusterAvailable: boolean;
-  isDashboardBannerVisible?: boolean;
-  setIsDashboardBannerVisible?: (isVisible: boolean) => void;
 };
 
 // @ts-ignore


### PR DESCRIPTION
It was used only in Cloud and has become obsolete in https://github.com/kubeshop/testkube-cloud-ui/pull/403.

## Changes

- delete it

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
