### PR TITLE
fix: don't get cluster info if it's not available

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,9 +81,8 @@ const App: React.FC<AppProps> = ({plugins}) => {
   }, [apiEndpoint]);
 
   useEffect(() => {
-    // Do not fire the effect if new endpoint is just being set up,
-    // or it can't be changed.
-    if (location.pathname === '/apiEndpoint') {
+    // Do not fire the effect if new endpoint is just being set up.
+    if (!isClusterAvailable || location.pathname === '/apiEndpoint') {
       return;
     }
 
@@ -106,7 +105,7 @@ const App: React.FC<AppProps> = ({plugins}) => {
           setEndpointModalState(true);
         }
       });
-  }, [apiEndpoint]);
+  }, [apiEndpoint, isClusterAvailable]);
 
   const scope = useMemo(() => {
     const pluginManager = createPluginManager();


### PR DESCRIPTION
## Changes

- don't get cluster info if it's not available

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
