### PR TITLE
fix: add missing fields for ConfigurationCard/CardForm

### DIFF
--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
@@ -26,6 +26,12 @@ export const StyledHeader = styled.div`
   flex: 1;
 `;
 
+export const HeaderAction = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 8px;
+`;
+
 export const StyledChildren = styled.div`
   padding: 20px;
 `;

--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.tsx
@@ -13,6 +13,7 @@ import Colors from '@styles/Colors';
 import {NotificationContent} from '../Notification';
 
 import {
+  HeaderAction,
   StyledChildren,
   StyledContainer,
   StyledErrorsContainer,
@@ -29,6 +30,7 @@ type ConfigurationCardProps = {
   description: ReactNode;
   isWarning?: boolean;
   footer?: ReactNode;
+  headerAction?: ReactNode;
   confirmLabel?: string;
   wasTouched?: boolean;
   children?: ReactNode;
@@ -43,6 +45,7 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
     errors,
     title,
     description,
+    headerAction,
     onCancel,
     footer,
     children,
@@ -70,6 +73,7 @@ const ConfigurationCard: React.FC<ConfigurationCardProps> = props => {
             {description}
           </Text>
         </StyledHeader>
+        {headerAction ? <HeaderAction>{headerAction}</HeaderAction> : null}
       </StyledHeaderContainer>
       {children && errors?.length ? (
         <StyledErrorsContainer>

--- a/src/components/organisms/CardForm/CardForm.tsx
+++ b/src/components/organisms/CardForm/CardForm.tsx
@@ -19,6 +19,7 @@ interface CardFormProps {
   title: ReactNode;
   description: ReactNode;
   footer?: ReactNode;
+  headerAction?: ReactNode;
   disabled?: boolean;
   readOnly?: boolean;
   wasTouched?: boolean;
@@ -29,6 +30,7 @@ interface CardFormProps {
   initialValues?: any;
   confirmLabel?: string;
   onFieldsChange?: (...args: any) => void;
+  onValuesChange?: (...args: any) => void;
   spacing?: number;
   onConfirm?: () => void;
   onCancel?: () => void;
@@ -39,6 +41,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   title,
   description,
   footer,
+  headerAction,
   labelAlign,
   layout = 'vertical',
   form,
@@ -51,6 +54,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
   spacing,
   children,
   onFieldsChange,
+  onValuesChange,
   onConfirm,
   onCancel,
 }) => {
@@ -109,6 +113,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
       name={name}
       disabled={disabled || loading}
       onFieldsChange={onFieldsChange}
+      onValuesChange={onValuesChange}
       onFinish={confirm}
     >
       <Form.Item noStyle shouldUpdate>
@@ -116,6 +121,7 @@ const CardForm: FC<PropsWithChildren<CardFormProps>> = ({
           title={title}
           description={description}
           footer={footer}
+          headerAction={headerAction}
           confirmLabel={confirmLabel}
           wasTouched={wasTouched}
           readOnly={readOnly}


### PR DESCRIPTION
## Changes

- add `headerAction` that is used for AI consent in Cloud
- add `onValuesChange` for `CardForm`, as it's used in Cloud

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
