### PR TITLE
fix: make upload button clickable as a whole

### DIFF
--- a/src/components/atoms/UploadWithInput/UploadWithInput.tsx
+++ b/src/components/atoms/UploadWithInput/UploadWithInput.tsx
@@ -1,3 +1,5 @@
+import {FC, useCallback, useRef} from 'react';
+
 import {UploadChangeParam, UploadProps} from 'antd/lib/upload';
 
 import classNames from 'classnames';
@@ -18,8 +20,11 @@ type UploadWithInputProps = {
 
 const defaultBeforeUpload = () => false;
 
-const UploadWithInput: React.FC<UploadWithInputProps> = props => {
+const UploadWithInput: FC<UploadWithInputProps> = props => {
   const {onFileChange, beforeUpload = defaultBeforeUpload, value} = props;
+  const uploadRef = useRef<any>();
+  const onInputClick = useCallback(() => uploadRef.current?.upload.uploader.fileInput.click(), []);
+  const clear = useCallback(() => onFileChange(null), [onFileChange]);
 
   const inputClassNames = classNames({
     'not-empty': value?.fileName,
@@ -33,12 +38,11 @@ const UploadWithInput: React.FC<UploadWithInputProps> = props => {
         className={inputClassNames}
         value={value?.fileName || ''}
         allowClear
-        onChange={() => {
-          onFileChange(null);
-        }}
+        onPointerUpCapture={onInputClick}
+        onChange={clear}
         placeholder="Choose a file"
       />
-      <Upload maxCount={1} onChange={onFileChange} showUploadList={false} beforeUpload={beforeUpload} />
+      <Upload ref={uploadRef} maxCount={1} onChange={onFileChange} showUploadList={false} beforeUpload={beforeUpload} />
     </StyledUploadWithInputContainer>
   );
 };

--- a/src/components/custom-antd/Upload/Upload.tsx
+++ b/src/components/custom-antd/Upload/Upload.tsx
@@ -1,11 +1,16 @@
-import {Upload as AntdUpload, UploadProps as AntdUploadProps, Button} from 'antd';
+import {forwardRef} from 'react';
 
-const DefaultBrowseButton = <Button>Browse</Button>;
+import {Upload as AntdUpload, Button, UploadProps} from 'antd';
 
-const Upload: React.FC<AntdUploadProps> = props => {
-  const {children = DefaultBrowseButton, ...rest} = props;
+const defaultBrowseButton = <Button>Browse</Button>;
 
-  return <AntdUpload {...rest}>{children}</AntdUpload>;
-};
+const Upload = forwardRef<any, UploadProps>((props, ref) => {
+  const {children = defaultBrowseButton, ...rest} = props;
+  return (
+    <AntdUpload ref={ref} {...rest}>
+      {children}
+    </AntdUpload>
+  );
+});
 
 export default Upload;


### PR DESCRIPTION
## Changes

- Open File Browser when clicking on the file input

## Fixes

- kubeshop/testkube#4298

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
