### PR TITLE
fix: legacy URLs for the dashboard

### DIFF
--- a/src/DashboardRewrite.tsx
+++ b/src/DashboardRewrite.tsx
@@ -1,4 +1,4 @@
-import {FC, useContext, useLayoutEffect} from 'react';
+import {FC, useContext, useEffect} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {DashboardContext} from '@contexts';
@@ -16,7 +16,7 @@ const DashboardRewrite: FC<DashboardRewriteProps> = ({pattern, keepQuery = false
   const pathname = pattern.replace(/:([^/]+)/g, (_, key) => `${params[key]}`);
   const redirect = useDashboardNavigate(keepQuery ? {...location, pathname} : pathname, {replace: true});
 
-  useLayoutEffect(redirect, [pattern, keepQuery]);
+  useEffect(redirect, [pattern, keepQuery]);
 
   return null;
 };

--- a/src/components/pages/TestSuites/TestSuites.tsx
+++ b/src/components/pages/TestSuites/TestSuites.tsx
@@ -12,10 +12,10 @@ const TestSuites: FC = () => (
   <>
     <Routes>
       {/* Backwards compatibility */}
-      <Route path="executions/:id" element={<DashboardRewrite pattern="/tests/:id" />} />
+      <Route path="executions/:id" element={<DashboardRewrite pattern="/tests/:id" keepQuery />} />
       <Route
         path="executions/:id/execution/:execId"
-        element={<DashboardRewrite pattern="/tests/:id/executions/:execId" />}
+        element={<DashboardRewrite pattern="/tests/:id/executions/:execId" keepQuery />}
       />
 
       <Route index element={<TestSuitesList />} />

--- a/src/components/pages/Tests/Tests.tsx
+++ b/src/components/pages/Tests/Tests.tsx
@@ -12,10 +12,10 @@ const Tests: FC = () => (
   <>
     <Routes>
       {/* Backwards compatibility */}
-      <Route path="executions/:id" element={<DashboardRewrite pattern="/tests/:id" />} />
+      <Route path="executions/:id" element={<DashboardRewrite pattern="/tests/:id" keepQuery />} />
       <Route
         path="executions/:id/execution/:execId"
-        element={<DashboardRewrite pattern="/tests/:id/executions/:execId" />}
+        element={<DashboardRewrite pattern="/tests/:id/executions/:execId" keepQuery />}
       />
 
       <Route index element={<TestsList />} />


### PR DESCRIPTION
## Changes

- fix URLs backwards compatibility
  - `/tests/executions/<name>/[...]` was not working

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
