### PR TITLE
fix: allow empty resource identifier for webhooks / refactor LabelsSelect / improve Triggers behavior

### DIFF
--- a/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.styled.tsx
+++ b/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.styled.tsx
@@ -21,16 +21,21 @@ export const StyledMultiLabel = styled.div`
   padding: 3px 5px;
 `;
 
-export const customStyles: (validation?: boolean) => StylesConfig<Option, true, GroupBase<Option>> = (
-  validation = true
-) => ({
+export const customStyles: (
+  validation?: boolean,
+  stylePlaceholderAsValue?: boolean
+) => StylesConfig<Option, true, GroupBase<Option>> = (validation = true, stylePlaceholderAsValue = false) => ({
   container: styles => ({...styles, width: '100%'}),
   input: styles => ({...styles, color: Colors.slate200, fontWeight: 400}),
   valueContainer: (styles, props) => ({
     ...styles,
     backgroundColor: props.isDisabled ? 'transparent' : Colors.slate800,
   }),
-  placeholder: styles => ({...styles, color: Colors.slate500, fontWeight: 400}),
+  placeholder: styles => ({
+    ...styles,
+    color: stylePlaceholderAsValue ? Colors.slate200 : Colors.slate500,
+    fontWeight: 400,
+  }),
   control: (styles, props) => ({
     ...styles,
     borderColor: validation ? 'transparent' : Colors.pink500,

--- a/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.styled.tsx
+++ b/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.styled.tsx
@@ -24,6 +24,7 @@ export const StyledMultiLabel = styled.div`
 export const customStyles: (validation?: boolean) => StylesConfig<Option, true, GroupBase<Option>> = (
   validation = true
 ) => ({
+  container: styles => ({...styles, width: '100%'}),
   input: styles => ({...styles, color: Colors.slate200, fontWeight: 400}),
   valueContainer: (styles, props) => ({
     ...styles,

--- a/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.tsx
+++ b/src/components/atoms/CreatableMultiSelect/CreatableMultiSelect.tsx
@@ -29,6 +29,7 @@ type MultiSelectProps = {
   dataTest?: string;
   disabled?: boolean;
   menuPlacement?: 'auto' | 'bottom' | 'top';
+  stylePlaceholderAsValue?: boolean;
 };
 
 const CreatableMultiSelect: React.FC<MultiSelectProps> = props => {
@@ -47,6 +48,7 @@ const CreatableMultiSelect: React.FC<MultiSelectProps> = props => {
     dataTest,
     disabled = false,
     menuPlacement = 'bottom',
+    stylePlaceholderAsValue = false,
   } = props;
 
   const ref = useRef(null);
@@ -83,7 +85,7 @@ const CreatableMultiSelect: React.FC<MultiSelectProps> = props => {
       }}
       formatCreateLabel={formatCreateLabel}
       theme={customTheme}
-      styles={customStyles(validation)}
+      styles={customStyles(validation, stylePlaceholderAsValue)}
       components={{
         Option: CustomOptionComponent,
         MultiValueLabel: CustomMultiValueLabelComponent,

--- a/src/components/molecules/LabelsSelect/LabelsSelect.tsx
+++ b/src/components/molecules/LabelsSelect/LabelsSelect.tsx
@@ -23,6 +23,7 @@ type LabelsSelectProps = {
   validation?: boolean;
   menuPlacement?: 'auto' | 'bottom' | 'top';
   disabled?: boolean;
+  stylePlaceholderAsValue?: boolean;
 };
 
 const isValidLabel = (value?: string) => {
@@ -38,6 +39,7 @@ const LabelsSelect: React.FC<LabelsSelectProps> = props => {
     validation,
     menuPlacement,
     disabled,
+    stylePlaceholderAsValue,
   } = props;
   const {isClusterAvailable} = useContext(MainContext);
 
@@ -83,6 +85,7 @@ const LabelsSelect: React.FC<LabelsSelectProps> = props => {
       menuPlacement={menuPlacement}
       dataTest="labels"
       disabled={disabled}
+      stylePlaceholderAsValue={stylePlaceholderAsValue}
     />
   );
 };

--- a/src/components/molecules/LabelsSelect/LabelsSelect.tsx
+++ b/src/components/molecules/LabelsSelect/LabelsSelect.tsx
@@ -1,74 +1,67 @@
-import React, {useContext} from 'react';
+import React, {useContext, useMemo} from 'react';
 
 import {CreatableMultiSelect} from '@atoms';
 import {LabelsMultiValueLabel, LabelsOption} from '@atoms/CreatableMultiSelect/CustomComponents';
 
 import {MainContext} from '@contexts';
 
-import {Option} from '@models/form';
+import {useLastCallback} from '@hooks/useLastCallback';
 
-import {Permissions, usePermission} from '@permissions/base';
+import {Option} from '@models/form';
 
 import {useGetLabelsQuery} from '@services/labels';
 
 import {PollingIntervals} from '@utils/numbers';
 
-import {composeLabels, labelRegex} from './utils';
+import {labelRegex} from './utils';
 
 type LabelsSelectProps = {
-  value?: Option[];
-  onChange?: (value: readonly Option[]) => void;
-  defaultLabels?: Record<string, Option>;
-  options?: {[key: string]: string[]};
+  value?: string[];
+  onChange?: (value: readonly string[]) => void;
+  options?: string[];
   placeholder?: string;
   validation?: boolean;
   menuPlacement?: 'auto' | 'bottom' | 'top';
+  disabled?: boolean;
 };
 
 const isValidLabel = (value?: string) => {
   return value != null && labelRegex.test(value);
 };
 
-// TODO: Refactor it to be actual onChange/value input
 const LabelsSelect: React.FC<LabelsSelectProps> = props => {
   const {
     onChange,
     value,
-    defaultLabels,
     options,
     placeholder = 'Add or create new labels',
     validation,
     menuPlacement,
+    disabled,
   } = props;
-  // TODO: Check if it's actually expected, as it's used in multiple places
-  const isSelectDisabled = !usePermission(Permissions.editEntity);
-
   const {isClusterAvailable} = useContext(MainContext);
 
+  // TODO: Extract it outside?
   const {data, isFetching} = useGetLabelsQuery(null, {
     pollingInterval: PollingIntervals.default,
     skip: Boolean(options) || !isClusterAvailable,
   });
 
-  const formattedDefaultLabels = composeLabels(defaultLabels);
+  const formattedValue = useMemo(() => (value || []).map(label => ({label, value: label})), [value]);
 
-  const formattedOptions: Option[] = Object.entries(options || data || {})
-    .map(([key, v]) => {
-      return v.map(item => {
-        const labelString = `${key}${item ? `:${item}` : ''}`;
+  const formattedOptions: Option[] = useMemo(() => {
+    const finalOptions =
+      options ||
+      Object.entries(data || {}).flatMap(([key, items]) => items.map(item => `${key}${item ? `:${item}` : ''}`));
+    return finalOptions.map(label => ({label, value: label}));
+  }, [options, data]);
 
-        return {
-          label: labelString,
-          value: labelString,
-        };
-      });
-    })
-    .flat();
+  const change = useLastCallback((newValue: readonly Option[]) => onChange?.(newValue.map(x => x.value as string)));
 
   return (
     <CreatableMultiSelect
-      value={value}
-      onChange={onChange}
+      value={formattedValue}
+      onChange={change}
       placeholder={placeholder}
       formatCreateLabel={(inputString: string) => {
         if (typeof inputString === 'string' && inputString.includes(':')) {
@@ -81,7 +74,6 @@ const LabelsSelect: React.FC<LabelsSelectProps> = props => {
 
         return 'Create: You need to add a : separator to create this label';
       }}
-      defaultValue={formattedDefaultLabels}
       options={formattedOptions}
       CustomOptionComponent={LabelsOption}
       CustomMultiValueLabelComponent={LabelsMultiValueLabel}
@@ -90,7 +82,7 @@ const LabelsSelect: React.FC<LabelsSelectProps> = props => {
       validation={validation}
       menuPlacement={menuPlacement}
       dataTest="labels"
-      disabled={isSelectDisabled}
+      disabled={disabled}
     />
   );
 };

--- a/src/components/molecules/LabelsSelect/utils.ts
+++ b/src/components/molecules/LabelsSelect/utils.ts
@@ -1,36 +1,16 @@
-import {Option} from '@models/form';
-
-export const decomposeLabels = (labels: readonly Option[]): Record<string, string> => {
-  return labels.reduce((previousValue, currentValue: Option) => {
-    const labelString = currentValue.value;
-
-    if (typeof labelString === 'string' && labelString.includes(':')) {
-      const [key, ...rest] = labelString.split(':');
-      return {
-        ...previousValue,
-        [key.trim()]: rest.join(':').trim(),
-      };
+export const decomposeLabels = (labels: readonly string[]): Record<string, string> => {
+  return labels.reduce((previousValue, currentValue: string) => {
+    if (!currentValue.includes(':')) {
+      return {...previousValue, [currentValue]: ''};
     }
-
-    return {
-      ...previousValue,
-      [labelString]: '',
-    };
+    const [key, ...rest] = currentValue.split(':');
+    const value = rest.join(':');
+    return {...previousValue, [key.trim()]: value.trim()};
   }, {});
 };
 
-export const composeLabels = (labelsObject?: Record<string, Option>): Option[] => {
-  return Object.entries(labelsObject || {}).map(([key, value]) => {
-    if (value.label && value.value && value.value === value.label) {
-      return value;
-    }
-    const labelString = `${key}${value ? `:${value}` : ''}`;
-
-    return {
-      label: labelString,
-      value: labelString,
-    };
-  });
+export const composeLabels = (labelsObject?: Record<string, string>): string[] => {
+  return Object.entries(labelsObject || {}).map(([key, value]) => `${key}${value ? `:${value}` : ''}`);
 };
 
 export const labelRegex =

--- a/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
+++ b/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
@@ -36,27 +36,18 @@ const ActionFormItems = () => {
       <Form.Item label="Testkube action" required name="action" rules={[required]}>
         <Select options={actionOptions} placeholder="Select a testkube related action" />
       </Form.Item>
-      <Form.Item noStyle shouldUpdate>
-        {({getFieldValue, getFieldError}) => {
-          const label = getFieldValue('testLabelSelector');
-          const isValid = !(getFieldError('resourceLabelSelector').length > 0);
-
-          return (
-            <Space size={16} direction="vertical" style={{width: '100%'}}>
-              <TriggerSelectorSwitcher value={switcherValue} onChange={setSwitcherValue} />
-              {switcherValue === 'label' ? (
-                <Form.Item label="Testkube resource" required name="testLabelSelector" rules={[required]}>
-                  <LabelsSelect defaultLabels={label} validation={isValid} />
-                </Form.Item>
-              ) : (
-                <Form.Item label="Testkube resource" required name="testNameSelector" rules={[required]}>
-                  <ResourceTriggerSelect />
-                </Form.Item>
-              )}
-            </Space>
-          );
-        }}
-      </Form.Item>
+      <Space size={16} direction="vertical" style={{width: '100%'}}>
+        <TriggerSelectorSwitcher value={switcherValue} onChange={setSwitcherValue} />
+        {switcherValue === 'label' ? (
+          <Form.Item label="Testkube resource" required name="testLabelSelector" rules={[required]}>
+            <LabelsSelect />
+          </Form.Item>
+        ) : (
+          <Form.Item label="Testkube resource" required name="testNameSelector" rules={[required]}>
+            <ResourceTriggerSelect />
+          </Form.Item>
+        )}
+      </Space>
     </>
   );
 };

--- a/src/components/organisms/TriggersFormItems/ConditionFormItems.tsx
+++ b/src/components/organisms/TriggersFormItems/ConditionFormItems.tsx
@@ -29,37 +29,28 @@ const ConditionFormItems = () => {
       <Form.Item label="K8s resource" required name="resource" rules={[required]}>
         <Select options={resourcesOptions} placeholder="Select a K8s resource" />
       </Form.Item>
-      <Form.Item noStyle shouldUpdate>
-        {({getFieldValue, getFieldError}) => {
-          const label = getFieldValue('resourceLabelSelector');
-          const isValid = !(getFieldError('resourceLabelSelector').length > 0);
-
-          return (
-            <Space size={16} direction="vertical" style={{width: '100%'}}>
-              <TriggerSelectorSwitcher value={switcherValue} onChange={setSwitcherValue} />
-              {switcherValue === 'label' ? (
-                <Form.Item
-                  label={
-                    <>
-                      Resource identifier
-                      <LabelSelectorHelpIcon />
-                    </>
-                  }
-                  required
-                  name="resourceLabelSelector"
-                  rules={[required]}
-                >
-                  <LabelsSelect defaultLabels={label} validation={isValid} />
-                </Form.Item>
-              ) : (
-                <Form.Item label="Resource identifier" required name="resourceNameSelector" rules={[required]}>
-                  <Input placeholder="e.g.: namespace/resource-name" />
-                </Form.Item>
-              )}
-            </Space>
-          );
-        }}
-      </Form.Item>
+      <Space size={16} direction="vertical" style={{width: '100%'}}>
+        <TriggerSelectorSwitcher value={switcherValue} onChange={setSwitcherValue} />
+        {switcherValue === 'label' ? (
+          <Form.Item
+            label={
+              <>
+                Resource identifier
+                <LabelSelectorHelpIcon />
+              </>
+            }
+            required
+            name="resourceLabelSelector"
+            rules={[required]}
+          >
+            <LabelsSelect />
+          </Form.Item>
+        ) : (
+          <Form.Item label="Resource identifier" required name="resourceNameSelector" rules={[required]}>
+            <Input placeholder="e.g.: namespace/resource-name" />
+          </Form.Item>
+        )}
+      </Space>
       <Form.Item noStyle shouldUpdate>
         {({getFieldValue}) => {
           const triggerResource = getFieldValue('resource');
@@ -71,7 +62,11 @@ const ConditionFormItems = () => {
 
           return (
             <Form.Item label="Triggered event" name="event" rules={[required]}>
-              <Select options={eventsOptions} disabled={!triggerResource} placeholder="Select cluster event" />
+              <Select
+                options={eventsOptions}
+                disabled={eventsOptions.length === 0 ? true : undefined}
+                placeholder="Select cluster event"
+              />
             </Form.Item>
           );
         }}

--- a/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
+++ b/src/components/pages/TestSuites/TestSuitesList/TestSuiteCreationModalContent/TestSuiteCreationModalContent.tsx
@@ -13,7 +13,6 @@ import {Option} from '@models/form';
 import {ErrorNotificationConfig} from '@models/notifications';
 
 import {LabelsSelect, NotificationContent} from '@molecules';
-import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 
 import {useAddTestSuiteMutation} from '@services/testSuites';
 
@@ -40,7 +39,6 @@ const TestSuiteCreationModalContent: React.FC = () => {
   const openSettings = useDashboardNavigate((name: string) => `/test-suites/${name}/settings/tests`);
 
   const [addTestSuite, {isLoading}] = useAddTestSuiteMutation();
-  const [localLabels, setLocalLabels] = useState<readonly Option[]>([]);
 
   const [error, setError] = useState<ErrorNotificationConfig | undefined>(undefined);
 
@@ -48,10 +46,7 @@ const TestSuiteCreationModalContent: React.FC = () => {
   const inTopInViewport = useInViewport(topRef);
 
   const onFinish = (values: TestSuiteCreationModalFormValues) => {
-    addTestSuite({
-      ...values,
-      labels: decomposeLabels(localLabels),
-    })
+    addTestSuite(values)
       .then(displayDefaultNotificationFlow)
       .then(res => {
         telemetry.event('createTestSuite');
@@ -84,7 +79,9 @@ const TestSuiteCreationModalContent: React.FC = () => {
         <FormItem name="description">
           <TextArea placeholder="Description" autoSize={{minRows: 4, maxRows: 6}} />
         </FormItem>
-        <LabelsSelect onChange={setLocalLabels} />
+        <FormItem name="labels">
+          <LabelsSelect />
+        </FormItem>
         <FormItem shouldUpdate>
           {({isFieldsTouched}) => (
             <Button

--- a/src/components/pages/Tests/TestsList/TestCreationModalContent/CreationModal.styled.tsx
+++ b/src/components/pages/Tests/TestsList/TestCreationModalContent/CreationModal.styled.tsx
@@ -9,10 +9,6 @@ export const StyledFormSpace = styled(FullWidthSpace)`
   }
 `;
 
-export const LabelsWrapper = styled.div`
-  width: 100%;
-`;
-
 export const TestCreationModalWrapper = styled.div`
   display: flex;
 `;

--- a/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationForm.tsx
+++ b/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationForm.tsx
@@ -14,7 +14,6 @@ import {SourceWithRepository} from '@models/sources';
 import {Test} from '@models/test';
 
 import {LabelsSelect, NotificationContent} from '@molecules';
-import {decomposeLabels} from '@molecules/LabelsSelect/utils';
 
 import {
   CustomCreationFormFields,
@@ -36,7 +35,7 @@ import {
   testSourceBaseOptions,
 } from '@utils/sources';
 
-import {LabelsWrapper, StyledFormSpace} from './CreationModal.styled';
+import {StyledFormSpace} from './CreationModal.styled';
 
 type TestCreationFormValues = {
   name: string;
@@ -65,7 +64,6 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
   const remappedExecutors = remapExecutors(executors);
   const remappedCustomTestSources = remapTestSources(testSources);
 
-  const [localLabels, setLocalLabels] = useState<readonly Option[]>([]);
   const [error, setError] = useState<ErrorNotificationConfig | undefined>(undefined);
 
   const [addTest, {isLoading}] = useAddTestMutation();
@@ -79,7 +77,7 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
     const requestBody = {
       name: values.name,
       type: testType,
-      labels: decomposeLabels(localLabels),
+      labels: values.labels,
       content: getSourcePayload(values, testSources),
       ...getCustomSourceField(testSource),
     };
@@ -179,9 +177,7 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
 
             return (
               <FormItem label="Labels" name="labels">
-                <LabelsWrapper>
-                  <LabelsSelect onChange={setLocalLabels} menuPlacement="top" />
-                </LabelsWrapper>
+                <LabelsSelect menuPlacement="top" />
               </FormItem>
             );
           }}

--- a/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerDetails.tsx
@@ -60,7 +60,7 @@ const TriggerDetails = () => {
           {
             key: 'settings',
             label: 'Settings',
-            children: <TriggerSettings reload={reload} tab={settingsTab} onTabChange={setSettingsTab} />,
+            children: <TriggerSettings tab={settingsTab} onTabChange={setSettingsTab} />,
           },
         ]}
       />

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/Definition/Definition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/Definition/Definition.tsx
@@ -9,19 +9,14 @@ import {useTriggersField} from '@store/triggers';
 import {createSchemaOverride} from '@utils/createSchemaOverride';
 import {testkubeCRDBases} from '@utils/externalLinks';
 
-interface TriggerDefinitionProps {
-  reload: () => void;
-}
-
-const TriggerDefinition: FC<TriggerDefinitionProps> = ({reload}) => {
-  const [currentTrigger, setCurrentTrigger] = useTriggersField('current');
+const TriggerDefinition: FC = () => {
+  const [currentTrigger] = useTriggersField('current');
 
   return (
     <Definition
       useGetDefinitionQuery={useGetTriggerDefinitionQuery}
       useUpdateDefinitionMutation={useUpdateTriggerDefinitionMutation}
       label="trigger"
-      onUpdate={reload}
       name={currentTrigger!.name}
       crdUrl={testkubeCRDBases.triggers}
       overrideSchema={createSchemaOverride($ => {

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/TriggerAction.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerAction/TriggerAction.tsx
@@ -40,11 +40,7 @@ const TriggerAction: React.FC = () => {
 
     return updateTrigger(body)
       .then(displayDefaultNotificationFlow)
-      .then(res => {
-        notificationCall('passed', 'Trigger was successfully updated.');
-        setCurrentTrigger(res.data);
-        form.setFieldsValue(getActionFormValues(res.data));
-      });
+      .then(() => notificationCall('passed', 'Trigger was successfully updated.'));
   };
 
   return (

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/Condition.tsx
@@ -42,11 +42,7 @@ const Condition: React.FC = () => {
 
     return updateTrigger(body)
       .then(displayDefaultNotificationFlow)
-      .then(res => {
-        notificationCall('passed', 'Trigger was successfully updated.');
-        setCurrentTrigger(res.data);
-        form.setFieldsValue(getConditionFormValues(res.data));
-      });
+      .then(() => notificationCall('passed', 'Trigger was successfully updated.'));
   };
 
   return (

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/ResourceCondition.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerCondition/ResourceCondition.tsx
@@ -91,38 +91,33 @@ const ResourceCondition: React.FC = () => {
           />
         </FormItem>
       )}
-      <Form.List name="conditions" initialValue={[]}>
+      <Form.List name="conditions">
         {(fields, {add, remove}) => (
           <FullWidthSpace size={16} direction="vertical">
-            {!isResourceConditionsListEmpty ? (
-              <FullWidthSpace direction="vertical" size={16}>
-                {fields.length &&
-                  fields?.map(({key, name, ...restField}) => {
-                    return (
-                      <FormRow key={key}>
-                        <FormItem {...restField} name={[name, 'type']} rules={[requiredNoText]} flex={2}>
-                          <Select
-                            options={keyMap?.conditions?.map(condition => ({
-                              label: condition,
-                              value: condition,
-                            }))}
-                            placeholder="Type"
-                          />
-                        </FormItem>
-                        <FormItem {...restField} name={[name, 'status']} rules={[requiredNoText]} flex={2}>
-                          <Select options={selectOptions} placeholder="Status" />
-                        </FormItem>
-                        <FormItem {...restField} name={[name, 'reason']} flex={4}>
-                          <Input placeholder="Reason" />
-                        </FormItem>
-                        <FormIconWrapper>
-                          <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
-                        </FormIconWrapper>
-                      </FormRow>
-                    );
-                  })}
-              </FullWidthSpace>
-            ) : null}
+            <FullWidthSpace direction="vertical" size={16}>
+              {fields?.map(({key, name, ...restField}) => (
+                <FormRow key={key}>
+                  <FormItem {...restField} name={[name, 'type']} rules={[requiredNoText]} flex={2}>
+                    <Select
+                      options={keyMap?.conditions?.map(condition => ({
+                        label: condition,
+                        value: condition,
+                      }))}
+                      placeholder="Type"
+                    />
+                  </FormItem>
+                  <FormItem {...restField} name={[name, 'status']} rules={[requiredNoText]} flex={2}>
+                    <Select options={selectOptions} placeholder="Status" />
+                  </FormItem>
+                  <FormItem {...restField} name={[name, 'reason']} flex={4}>
+                    <Input placeholder="Reason" />
+                  </FormItem>
+                  <FormIconWrapper>
+                    <DeleteOutlined onClick={() => remove(name)} style={{fontSize: 21}} />
+                  </FormIconWrapper>
+                </FormRow>
+              ))}
+            </FullWidthSpace>
             <FormRow justify="center">
               <Button
                 $customType="secondary"

--- a/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
+++ b/src/components/pages/Triggers/TriggerDetails/TriggerSettings/TriggerSettings.tsx
@@ -8,12 +8,11 @@ import TriggerAction from './TriggerAction';
 import TriggerCondition from './TriggerCondition';
 
 interface TriggerSettingsProps {
-  reload: () => void;
   tab: string;
   onTabChange: (tab: string) => void;
 }
 
-const TriggerSettings: FC<TriggerSettingsProps> = ({reload, tab, onTabChange}) => (
+const TriggerSettings: FC<TriggerSettingsProps> = ({tab, onTabChange}) => (
   <SettingsLayout
     active={tab}
     onChange={onTabChange}
@@ -21,7 +20,7 @@ const TriggerSettings: FC<TriggerSettingsProps> = ({reload, tab, onTabChange}) =
       {id: 'general', label: 'General', children: <General />},
       {id: 'condition', label: 'Trigger Condition', children: <TriggerCondition />},
       {id: 'action', label: 'Trigger Action', children: <TriggerAction />},
-      {id: 'definition', label: 'Definition', children: <Definition reload={reload} />},
+      {id: 'definition', label: 'Definition', children: <Definition />},
     ]}
   />
 );

--- a/src/components/pages/Triggers/TriggersList/AddTriggerModal/AddTriggerModal.tsx
+++ b/src/components/pages/Triggers/TriggersList/AddTriggerModal/AddTriggerModal.tsx
@@ -9,7 +9,6 @@ import {Input, Text} from '@custom-antd';
 import {useDashboardNavigate} from '@hooks/useDashboardNavigate';
 import useInViewport from '@hooks/useInViewport';
 
-import {Option} from '@models/form';
 import {ErrorNotificationConfig} from '@models/notifications';
 
 import {NotificationContent} from '@molecules';
@@ -29,6 +28,13 @@ import ModalFirstStep from './ModalFirstStep';
 import ModalSecondStep from './ModalSecondStep';
 import {StepsEnum} from './types';
 
+interface FirstStepValues {
+  resource?: string;
+  event?: string;
+  resourceLabelSelector?: string[];
+  resourceNameSelector?: string;
+}
+
 const AddTriggerModal: React.FC = () => {
   const {namespace} = useClusterDetailsPick('namespace');
   const {isClusterAvailable} = useContext(MainContext);
@@ -42,7 +48,7 @@ const AddTriggerModal: React.FC = () => {
   const [error, setError] = useState<ErrorNotificationConfig | undefined>(undefined);
   const [currentStep, setCurrentStep] = useState(StepsEnum.condition);
   const [name, setName] = useState('');
-  const [firstStepValues, setFirstStepValues] = useState<Record<string, string | Option[]>>({});
+  const [firstStepValues, setFirstStepValues] = useState<FirstStepValues>({});
 
   const topRef = useRef<HTMLDivElement>(null);
   const inTopInViewport = useInViewport(topRef);
@@ -53,7 +59,7 @@ const AddTriggerModal: React.FC = () => {
     const values = form.getFieldsValue();
 
     const resourceSelector = getResourceIdentifierSelector(
-      firstStepValues.resourceLabelSelector || firstStepValues.resourceNameSelector,
+      firstStepValues.resourceLabelSelector || firstStepValues.resourceNameSelector!,
       namespace
     );
 

--- a/src/components/pages/Triggers/utils.ts
+++ b/src/components/pages/Triggers/utils.ts
@@ -1,12 +1,19 @@
-import {Option} from '@models/form';
 import {TestTrigger, TestTriggerSelector} from '@models/triggers';
 
-import {decomposeLabels} from '@molecules/LabelsSelect/utils';
+import {composeLabels, decomposeLabels} from '@molecules/LabelsSelect/utils';
 
 export const getResourceIdentifierSelector = (
-  formValue: string | readonly Option[],
+  formValue: string | string[],
   appNamespace: string
 ): TestTriggerSelector => {
+  if (Array.isArray(formValue)) {
+    return {
+      labelSelector: {
+        matchLabels: decomposeLabels(formValue),
+      },
+    };
+  }
+
   if (typeof formValue === 'string') {
     if (formValue.includes('/')) {
       const [namespace, name] = formValue.split('/');
@@ -23,14 +30,6 @@ export const getResourceIdentifierSelector = (
     };
   }
 
-  if (formValue.length) {
-    return {
-      labelSelector: {
-        matchLabels: decomposeLabels(formValue),
-      },
-    };
-  }
-
   // eslint-disable-next-line no-throw-literal
   throw 'Resource validation error';
 };
@@ -42,7 +41,7 @@ export const getConditionFormValues = (trigger: TestTrigger) => {
     event,
   } = trigger;
   const resourceNameSelector = name && namespace ? `${namespace}/${name}` : null;
-  const resourceLabelSelector = currentLabelSelector?.matchLabels;
+  const resourceLabelSelector = composeLabels(currentLabelSelector?.matchLabels);
 
   return {
     resource,
@@ -59,7 +58,7 @@ export const getActionFormValues = (trigger: TestTrigger) => {
     execution,
   } = trigger;
   const testNameSelector = name;
-  const testLabelSelector = currentLabelSelector?.matchLabels;
+  const testLabelSelector = composeLabels(currentLabelSelector?.matchLabels);
 
   return {
     testNameSelector,

--- a/src/components/pages/Webhooks/WebhookCreationModal/FirstStep.tsx
+++ b/src/components/pages/Webhooks/WebhookCreationModal/FirstStep.tsx
@@ -28,15 +28,14 @@ export const FirstStep: FC<FirstStepProps> = ({onStepChange}) => (
     </Text>
     <FormItem
       name="selector"
-      required
-      rules={[requiredNoText]}
       label={
         <>
           Resource identifier <LabelSelectorHelpIcon />
         </>
       }
+      required
     >
-      <LabelsSelect />
+      <LabelsSelect placeholder="All resources" stylePlaceholderAsValue />
     </FormItem>
     <FormItem name="events" required rules={[requiredNoText]} label="Triggered events">
       <CreatableMultiSelect

--- a/src/components/pages/Webhooks/WebhookCreationModal/FirstStep.tsx
+++ b/src/components/pages/Webhooks/WebhookCreationModal/FirstStep.tsx
@@ -38,18 +38,13 @@ export const FirstStep: FC<FirstStepProps> = ({onStepChange}) => (
     >
       <LabelsSelect />
     </FormItem>
-    <FormItem noStyle shouldUpdate>
-      {({getFieldError}) => (
-        <FormItem name="events" required rules={[requiredNoText]} label="Triggered events">
-          <CreatableMultiSelect
-            placeholder="Select Testkube resource"
-            options={webhookEvents}
-            menuPlacement="top"
-            formatCreateLabel={val => val}
-            validation={getFieldError('events').length === 0}
-          />
-        </FormItem>
-      )}
+    <FormItem name="events" required rules={[requiredNoText]} label="Triggered events">
+      <CreatableMultiSelect
+        placeholder="Select Testkube resource"
+        options={webhookEvents}
+        menuPlacement="top"
+        formatCreateLabel={val => val}
+      />
     </FormItem>
     <FullWidthSpace justify="flex-end">
       <Button

--- a/src/components/pages/Webhooks/WebhookCreationModal/FirstStep.tsx
+++ b/src/components/pages/Webhooks/WebhookCreationModal/FirstStep.tsx
@@ -26,22 +26,17 @@ export const FirstStep: FC<FirstStepProps> = ({onStepChange}) => (
     <Text color={Colors.slate400} className="regular middle">
       Define the conditions to be met for the trigger to be called.
     </Text>
-    <FormItem noStyle shouldUpdate>
-      {({getFieldError}) => (
-        <FormItem
-          name="selector"
-          required
-          rules={[requiredNoText]}
-          label={
-            <>
-              Resource identifier
-              <LabelSelectorHelpIcon />
-            </>
-          }
-        >
-          <LabelsSelect validation={getFieldError('selector').length === 0} />
-        </FormItem>
-      )}
+    <FormItem
+      name="selector"
+      required
+      rules={[requiredNoText]}
+      label={
+        <>
+          Resource identifier <LabelSelectorHelpIcon />
+        </>
+      }
+    >
+      <LabelsSelect />
     </FormItem>
     <FormItem noStyle shouldUpdate>
       {({getFieldError}) => (

--- a/src/components/pages/Webhooks/WebhookDetails/ConditionTab/Condition.tsx
+++ b/src/components/pages/Webhooks/WebhookDetails/ConditionTab/Condition.tsx
@@ -71,15 +71,14 @@ const Condition: FC = () => {
     >
       <FormItem
         name="labels"
-        required
-        rules={[requiredNoText]}
         label={
           <>
             Resource identifier <LabelSelectorHelpIcon />
           </>
         }
+        required
       >
-        <LabelsSelect />
+        <LabelsSelect placeholder="All resources" stylePlaceholderAsValue />
       </FormItem>
       <FormItem name="events" required rules={[requiredNoText]} label="Triggered events">
         <CreatableMultiSelect

--- a/src/components/pages/Webhooks/WebhookDetails/ConditionTab/Condition.tsx
+++ b/src/components/pages/Webhooks/WebhookDetails/ConditionTab/Condition.tsx
@@ -38,10 +38,7 @@ const Condition: FC = () => {
 
   const initialEvents = current!.events.map(item => ({label: item, value: item}));
   const initialLabels = useMemo(
-    () =>
-      decodeSelectorArray(current!.selector)
-        .map(({key, value}) => `${key}:${value}`)
-        .map(value => ({label: value, value})),
+    () => decodeSelectorArray(current!.selector).map(({key, value}) => `${key}:${value}`),
     [current!.selector]
   );
 
@@ -72,35 +69,25 @@ const Condition: FC = () => {
       disabled={!mayEdit}
       onConfirm={onFinish}
     >
-      <FormItem noStyle shouldUpdate>
-        {({getFieldError}) => (
-          <FormItem
-            name="labels"
-            required
-            rules={[requiredNoText]}
-            label={
-              <>
-                Resource identifier
-                <LabelSelectorHelpIcon />
-              </>
-            }
-          >
-            <LabelsSelect validation={getFieldError('labels').length === 0} />
-          </FormItem>
-        )}
+      <FormItem
+        name="labels"
+        required
+        rules={[requiredNoText]}
+        label={
+          <>
+            Resource identifier <LabelSelectorHelpIcon />
+          </>
+        }
+      >
+        <LabelsSelect />
       </FormItem>
-      <FormItem noStyle shouldUpdate>
-        {({getFieldError}) => (
-          <FormItem name="events" required rules={[requiredNoText]} label="Triggered events">
-            <CreatableMultiSelect
-              placeholder="Select Testkube resource"
-              options={webhookEvents}
-              menuPlacement="top"
-              formatCreateLabel={val => val}
-              validation={getFieldError('events').length === 0}
-            />
-          </FormItem>
-        )}
+      <FormItem name="events" required rules={[requiredNoText]} label="Triggered events">
+        <CreatableMultiSelect
+          placeholder="Select Testkube resource"
+          options={webhookEvents}
+          menuPlacement="top"
+          formatCreateLabel={val => val}
+        />
       </FormItem>
     </CardForm>
   );

--- a/src/components/pages/Webhooks/WebhooksList/WebhookCard.tsx
+++ b/src/components/pages/Webhooks/WebhooksList/WebhookCard.tsx
@@ -43,7 +43,7 @@ const WebhookCard: FC<WebhookCardProps> = ({item, onClick}) => {
             <Text className="small" color={Colors.slate500}>
               RESOURCE <LabelSelectorHelpIcon />
             </Text>
-            <LabelsList labels={labels} />
+            {selector ? <LabelsList labels={labels} /> : <Text className="small">All resources</Text>}
           </StyledMetricItem>
         </ItemColumn>
       </ItemRow>

--- a/src/services/triggers.ts
+++ b/src/services/triggers.ts
@@ -8,17 +8,20 @@ import {dynamicBaseQuery, memoizeQuery} from '@utils/fetchUtils';
 export const triggersApi = createApi({
   reducerPath: 'triggersApi',
   baseQuery: dynamicBaseQuery,
+  tagTypes: ['Trigger'],
   endpoints: builder => ({
     getTriggersKeyMap: builder.query<TriggersKeyMap, void | null>({
       query: () => ({url: `/keymap/triggers`}),
     }),
     getTriggersList: builder.query<TestTrigger[], void | null>({
       query: () => ({url: `/triggers`}),
+      providesTags: [{type: 'Trigger', id: 'LIST'}],
     }),
     getTriggerById: builder.query<TestTrigger, string>({
       query: id => ({
         url: `/triggers/${id}`,
       }),
+      providesTags: (res, err, id) => [{type: 'Trigger', id}],
     }),
     getTriggerDefinition: builder.query<string, string>({
       query: id => ({
@@ -26,6 +29,7 @@ export const triggersApi = createApi({
         responseHandler: 'text',
         headers: {accept: 'text/yaml'},
       }),
+      providesTags: (res, err, id) => [{type: 'Trigger', id}],
     }),
     createTrigger: builder.mutation<any, any>({
       query: body => ({
@@ -33,6 +37,7 @@ export const triggersApi = createApi({
         method: 'POST',
         body,
       }),
+      invalidatesTags: [{type: 'Trigger', id: 'LIST'}],
     }),
     updateTriggerById: builder.mutation<TestTrigger, TestTrigger>({
       query: body => ({
@@ -40,6 +45,10 @@ export const triggersApi = createApi({
         method: 'PATCH',
         body,
       }),
+      invalidatesTags: (res, err, {name: id}) => [
+        {type: 'Trigger', id: 'LIST'},
+        {type: 'Trigger', id},
+      ],
     }),
     updateTriggerDefinition: builder.mutation<any, YamlEditBody>({
       query: body => ({
@@ -48,19 +57,20 @@ export const triggersApi = createApi({
         headers: {'content-type': 'text/yaml'},
         body: body.value,
       }),
-    }),
-    updateTriggers: builder.mutation<void, any>({
-      query: body => ({
-        url: `/triggers`,
-        method: 'PATCH',
-        body,
-      }),
+      invalidatesTags: (res, err, {name: id}) => [
+        {type: 'Trigger', id: 'LIST'},
+        {type: 'Trigger', id},
+      ],
     }),
     deleteTrigger: builder.mutation<void, string>({
       query: id => ({
         url: `/triggers/${id}`,
         method: 'DELETE',
       }),
+      invalidatesTags: (res, err, id) => [
+        {type: 'Trigger', id: 'LIST'},
+        {type: 'Trigger', id},
+      ],
     }),
   }),
 });
@@ -73,7 +83,6 @@ export const {
   useGetTriggersKeyMapQuery,
   useCreateTriggerMutation,
   useGetTriggersListQuery,
-  useUpdateTriggersMutation,
   useGetTriggerByIdQuery,
   useGetTriggerDefinitionQuery,
   useDeleteTriggerMutation,

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -17,6 +17,7 @@ export const encodeSelector = (mapping: SelectorDictionary = {}): string =>
 export const decodeSelector = (selector: string = ''): SelectorDictionary =>
   selector
     .split(',')
+    .filter(Boolean)
     .map(v => v.split('=').map(x => x.trim()))
     .reduce((acc, [key, value]) => ({...acc, [key.trim()]: toString(value)}), {});
 


### PR DESCRIPTION
## Changes

- fix: allow empty resource identifier for Webhooks
  - show "All resources" then as a value-like placeholder
- fix: improve triggers behavior
  - invalidate local cache on changes automatically (in service), same as for other resources
- tech: refactor `LabelsList`
  - support passing `LabelsList` directly in `Form.Item` (use `value`/`onChange` properly)
- various small fixes required after `LabelsList` refactor

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
