### PR TITLE
fix: configuration card mobile

### DIFF
--- a/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
+++ b/src/components/molecules/ConfigurationCard/ConfigurationCard.styled.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import {maxDevice} from '@src/styles/MediaQueries';
+
 import Colors from '@styles/Colors';
 
 export const StyledContainer = styled.div<{isWarning?: boolean}>`
@@ -43,6 +45,11 @@ export const StyledFooter = styled.div`
 
   padding: 20px;
   border-top: 1px solid ${Colors.slate800};
+
+  @media ${maxDevice.mobileL} {
+    flex-direction: column;
+    gap: 8px;
+  }
 `;
 
 export const StyledFooterButtonsContainer = styled.div`


### PR DESCRIPTION
This PR fixes footer of configuration card display on mobile.
<img width="357" alt="image" src="https://github.com/kubeshop/testkube-dashboard/assets/25755402/e778f612-27c2-4e3a-9f49-a964b1958386">


## Changes

-

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
