### PR TITLE
fix: improve downloading artifacts

### DIFF
--- a/src/components/molecules/ArtifactsList/ArtifactsList.tsx
+++ b/src/components/molecules/ArtifactsList/ArtifactsList.tsx
@@ -76,7 +76,7 @@ const ArtifactsList: React.FC<ArtifactsListProps> = props => {
 
   return (
     <ArtifactsListContainer>
-      {artifacts.length > 2 ? (
+      {artifacts.length > 1 ? (
         <StyledDownloadAllContainer>
           <Button onClick={handleDownloadAll}>{!isDownloading ? 'Download all' : 'Downloading...'}</Button>
         </StyledDownloadAllContainer>

--- a/src/services/artifacts.ts
+++ b/src/services/artifacts.ts
@@ -55,7 +55,7 @@ export const downloadArtifact = async (
 
 export const downloadArtifactArchive = async (fileName: string, executionId: string) => {
   const url = `/executions/${executionId}/artifact-archive`;
-  const finalUrl = `${getApiEndpoint()}${getRtkBaseUrl('environment')}${url}`;
+  const finalUrl = `${getApiEndpoint()}${getRtkBaseUrl(undefined)}${url}`;
   const idToken = await getRtkIdToken();
 
   // Call the API to retrieve file or signed URL


### PR DESCRIPTION
## Changes

- stream the download when it's possible
  - earlier - it was downloading the file in background, and then returned to User full file at once
- handle errors
  - earlier - it would download error response in place of artifact
- pass the `routeToRequest` to handle it better in Cloud
  - so we may avoid going always to the Agent for the artifact

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
