### PR TITLE
fix: reset API cache after API endpoint is changed

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -25,6 +25,8 @@ import {BasePermissionsResolver, PermissionsProvider} from '@permissions/base';
 import createAiInsightsPlugin from '@plugins/definitions/ai-insights';
 import {Plugin} from '@plugins/types';
 
+import {resetRtkCache} from '@redux/store';
+
 import {useApiEndpoint} from '@services/apiEndpoint';
 import {useGetClusterConfigQuery} from '@services/config';
 
@@ -67,7 +69,6 @@ const AppRoot: React.FC = () => {
   const {currentData: clusterConfig, refetch: refetchClusterConfig} = useGetClusterConfigQuery(undefined, {
     skip: !apiEndpoint,
   });
-
   // Pause/resume telemetry based on the cluster settings
   useEffect(() => {
     if (clusterConfig?.enableTelemetry) {
@@ -97,6 +98,11 @@ const AppRoot: React.FC = () => {
   useEffect(() => {
     telemetry.pageView(`${location.pathname}${anonymizeQueryString(location.search)}`);
   }, [location.pathname, clusterConfig]);
+
+  // Reset the in-memory API cache on API endpoint change
+  useEffect(() => {
+    resetRtkCache();
+  }, [apiEndpoint]);
 
   // FIXME: Hack - for some reason, useEffect was not called on API endpoint change.
   useMemo(() => {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -10,6 +10,18 @@ import {testsApi} from '@services/tests';
 import {triggersApi} from '@services/triggers';
 import {webhooksApi} from '@services/webhooks';
 
+const rtkModules = [
+  testsApi,
+  testSuitesApi,
+  labelsApi,
+  executorsApi,
+  sourcesApi,
+  triggersApi,
+  configApi,
+  repositoryApi,
+  webhooksApi,
+];
+
 export const middlewares: Middleware[] = [
   testsApi.middleware,
   testSuitesApi.middleware,
@@ -32,6 +44,10 @@ export const reducers = {
   [configApi.reducerPath]: configApi.reducer,
   [repositoryApi.reducerPath]: repositoryApi.reducer,
   [webhooksApi.reducerPath]: webhooksApi.reducer,
+};
+
+export const resetRtkCache = () => {
+  rtkModules.forEach(api => api.util?.resetApiState());
 };
 
 export const store = configureStore({


### PR DESCRIPTION
## Changes

- Reset the data cached by RTK when the API endpoint is changed
   - Thanks to that, we avoid mixing data from different environments

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
