### PR TITLE
fix: reset RTK store properly

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -25,7 +25,7 @@ import {BasePermissionsResolver, PermissionsProvider} from '@permissions/base';
 import createAiInsightsPlugin from '@plugins/definitions/ai-insights';
 import {Plugin} from '@plugins/types';
 
-import {resetRtkCache} from '@redux/store';
+import {resetRtkCache, store} from '@redux/store';
 
 import {useApiEndpoint} from '@services/apiEndpoint';
 import {useGetClusterConfigQuery} from '@services/config';
@@ -101,7 +101,7 @@ const AppRoot: React.FC = () => {
 
   // Reset the in-memory API cache on API endpoint change
   useEffect(() => {
-    resetRtkCache();
+    resetRtkCache(store);
   }, [apiEndpoint]);
 
   // FIXME: Hack - for some reason, useEffect was not called on API endpoint change.

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,4 +1,4 @@
-import {Middleware, configureStore} from '@reduxjs/toolkit';
+import {Middleware, Store, configureStore} from '@reduxjs/toolkit';
 
 import {configApi} from '@services/config';
 import {executorsApi} from '@services/executors';
@@ -46,8 +46,8 @@ export const reducers = {
   [webhooksApi.reducerPath]: webhooksApi.reducer,
 };
 
-export const resetRtkCache = () => {
-  rtkModules.forEach(api => api.util?.resetApiState());
+export const resetRtkCache = (targetStore: Store) => {
+  rtkModules.forEach(api => targetStore.dispatch(api.util?.resetApiState()));
 };
 
 export const store = configureStore({


### PR DESCRIPTION
## Changes

- reset RTK store properly
   - `util.resetApiState()` is an action creator only

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
