### PR TITLE
fix: REACT_APP environment variables resolution

### DIFF
--- a/packages/web/scripts/env.sh
+++ b/packages/web/scripts/env.sh
@@ -12,7 +12,7 @@ if [ -f "$rootDir/.env" ]; then
 fi
 
 OUT="$1"
-VARIABLES="$(env | grep '^REACT_APP_')"
+VARIABLES="$(env | grep '^REACT_APP_' | sed 's/=.*//')"
 
 set -- $VARIABLES
 echo "window._env_ = {" > "$OUT"


### PR DESCRIPTION
## Changes

- the `env.sh` script was generating invalid JS, like `{REACT_APP_XYZ=abc: "abc"}`

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
