### PR TITLE
fix: improve coverage collection for unit tests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,19 +3,16 @@ version: '2'
 checks:
   method-complexity:
     config:
-      threshold: 8
+      threshold: 13
   method-lines:
     config:
       threshold: 100
-  method-count:
-    config:
-      threshold: 25
   similar-code:
     config:
-      threshold: 20
+      threshold: 45
   identical-code:
     config:
-      threshold: 15
+      threshold: 25
 
 plugins:
   nodesecurity:
@@ -38,6 +35,8 @@ exclude_patterns:
   - '**/dist/'
   - '**/build/'
   - '**/coverage/'
+  - '**/playwright-report/'
+  - 'packages/e2e-tests/'
   - '**/spec/'
   - '**/*.d.ts'
   - '**/*.spec.ts'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,46 @@
+version: '2'
+
+checks:
+  method-complexity:
+    config:
+      threshold: 8
+  method-lines:
+    config:
+      threshold: 100
+  method-count:
+    config:
+      threshold: 25
+  similar-code:
+    config:
+      threshold: 20
+  identical-code:
+    config:
+      threshold: 15
+
+plugins:
+  nodesecurity:
+    enabled: true
+  git-legal:
+    enabled: true
+  fixme:
+    enabled: true
+    config:
+      strings:
+        - FIXME
+        - TODO
+  shellcheck:
+    enabled: true
+  structure:
+    enabled: true
+
+exclude_patterns:
+  - '**/dist/'
+  - '**/build/'
+  - '**/spec/'
+  - '**/*.d.ts'
+  - '**/*.spec.ts'
+  - '**/*.spec.tsx'
+  - '**/.prettierrc.js'
+  - '**/commitlint.config.js'
+  - '**/jest.config.js'
+  - '**/craco.config.js'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,8 +34,10 @@ plugins:
     enabled: true
 
 exclude_patterns:
+  - '**/node_modules/'
   - '**/dist/'
   - '**/build/'
+  - '**/coverage/'
   - '**/spec/'
   - '**/*.d.ts'
   - '**/*.spec.ts'

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,7 @@ Dockerfile
 **/dist
 *.log
 
+# generated
+/coverage
+packages/*/coverage
 **/.eslintcache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Send coverage to CodeClimate
-        uses: paambaati/codeclimate-action@v2.2.4
+        uses: paambaati/codeclimate-action@v5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,12 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: Testing dashboard
-        if: always()
-        run: npm run test
+        run: npm run test:coverage
+
+      - name: Send coverage to CodeClimate
+        uses: paambaati/codeclimate-action@v2.2.4
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        with:
+          coverageLocations: |
+            ${{github.workspace}}/coverage/lcov.info:lcov

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ yarn-debug.log*
 yarn-error.log*
 *.swp
 
-# cache
-.eslintcache
+# generated
+/coverage
+packages/*/coverage
+**/.eslintcache

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 const {dirname, resolve, join} = require('node:path');
 const {readdirSync, existsSync} = require('node:fs');
+const micromatch = require('micromatch');
+const glob = require('glob');
 
 function readConfig(filePath) {
   const absFilePath = resolve(filePath);
@@ -14,13 +16,45 @@ function readConfig(filePath) {
   return result;
 }
 
+function escapeRegexWord(filePath) {
+  return filePath.replace(/[^a-z0-9]/gi, $ => `\\${$}`);
+}
+
 const packages = readdirSync(join(__dirname, 'packages')).filter(name =>
   existsSync(join(__dirname, 'packages', name, 'jest.config.js'))
 );
 
+const projects = packages.map(name => ({
+  ...readConfig(join(__dirname, 'packages', name, 'jest.config.js')),
+  rootDir: join(__dirname, 'packages', name),
+}));
+
+const files = glob.sync(`${join(__dirname, 'packages')}/**`, {ignore: '**/node_modules/**'});
+
+const coveragePatterns = projects.map(project =>
+  (project.collectCoverageFrom || []).map(pattern => {
+    if (pattern.includes('<rootDir>')) {
+      return pattern.replace('<rootDir>', project.rootDir);
+    }
+    if (/^!?\//.test(pattern)) {
+      return pattern;
+    }
+    return pattern.startsWith('!') ? `!${project.rootDir}/${pattern.substring(1)}` : `${project.rootDir}/${pattern}`;
+  })
+);
+
+const coverageFiles = coveragePatterns.flatMap(patterns =>
+  files.filter(filePath => micromatch.isMatch(filePath, patterns))
+);
+
 module.exports = {
-  projects: packages.map(name => ({
-    ...readConfig(join(__dirname, 'packages', name, 'jest.config.js')),
-    rootDir: join(__dirname, 'packages', name),
-  })),
+  projects,
+  // Hack to inherit coverage patterns from projects
+  collectCoverageFrom: ['**/*.{ts,tsx}'],
+  coveragePathIgnorePatterns: [
+    `^(?!${escapeRegexWord(__dirname)}\\/${coverageFiles
+      .map(filePath => filePath.replace(`${__dirname}/`, ''))
+      .map(escapeRegexWord)
+      .join('|')})$).*$`,
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "start": "npm run -w @testkube/web start",
     "build": "npm run --workspaces --if-present build",
     "test": "npx jest",
+    "test:coverage": "npx jest --collect-coverage --coverage-reporters lcov",
     "test:watch": "npx jest --watch --detectOpenHandles",
     "test:update": "npm run -w @testkube/web test:update",
     "e2e": "npm run -w @testkube/e2e-tests e2e",

--- a/packages/web/src/components/organisms/TriggersFormItems/ResourceTriggerSelect/ResourceTriggerSelect.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ResourceTriggerSelect/ResourceTriggerSelect.tsx
@@ -59,7 +59,7 @@ const ResourceTriggerSelect: FC<ResourceTriggerSelectProps> = ({...props}) => {
       {testsData.length > 0 ? (
         <OptGroup label="Tests">
           {testsData.map(item => (
-            <Option key={item.name}>
+            <Option key={item.name} title={item.name}>
               <StyledResourceOptionWrapper>
                 <ExecutorIcon type={getTestExecutorIcon(executors, item.type)} />
                 <Text className="regular middle">{item.name}</Text>
@@ -71,7 +71,7 @@ const ResourceTriggerSelect: FC<ResourceTriggerSelectProps> = ({...props}) => {
       {testSuitesData.length > 0 ? (
         <OptGroup label="Test Suites">
           {testSuitesData.map(item => (
-            <Option key={item.name}>
+            <Option key={item.name} title={item.name}>
               <StyledResourceOptionWrapper>
                 <TestSuitesIcon fill={Colors.slate100} />
                 <Text className="regular middle">{item.name}</Text>

--- a/packages/web/src/components/pages/TestSuites/TestSuiteDetails/TestSuiteSettings/SettingsTests/Modals/TestModal.tsx
+++ b/packages/web/src/components/pages/TestSuites/TestSuiteDetails/TestSuiteSettings/SettingsTests/Modals/TestModal.tsx
@@ -84,7 +84,7 @@ const TestModal: React.FC<TestModalProps> = props => {
         >
           <Select onChange={setTestValue} value={testValue} showSearch placeholder="Select a test..." size="middle">
             {allTestsData.map(item => (
-              <Option value={item.name} key={item.name}>
+              <Option value={item.name} key={item.name} title={item.name}>
                 <StyledOptionWrapper>
                   <ExecutorIcon type={item.type} />
                   <Text className="regular middle">{item.name}</Text>


### PR DESCRIPTION
## Changes

- improve coverage collection for global `npx jest` / `npm test` command
  - `collectCoverageFrom` settings from `projects` are ignored, so need to be set on the top level
- fix E2E tests for Triggers
- add CodeClimate configuration
   - set pretty loose thresholds
   - send test coverage to CodeClimate

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
