### PR TITLE
fix: ignore commit hash for the cluster version check

### DIFF
--- a/packages/web/src/hooks/useClusterVersionMatch.spec.tsx
+++ b/packages/web/src/hooks/useClusterVersionMatch.spec.tsx
@@ -42,4 +42,18 @@ describe('useClusterVersionMatch', () => {
 
     expect(result.current).toBe(true);
   });
+
+  it('should use default value for commit hash', () => {
+    const requiredVersion = 'v1.20.0';
+
+    const {result: result1} = renderHook(() => useClusterVersionMatch(requiredVersion, true), {
+      wrapper: createWrapper('9f0b87f'),
+    });
+    const {result: result2} = renderHook(() => useClusterVersionMatch(requiredVersion, false), {
+      wrapper: createWrapper('9f0b87f'),
+    });
+
+    expect(result1.current).toBe(true);
+    expect(result2.current).toBe(false);
+  });
 });

--- a/packages/web/src/hooks/useClusterVersionMatch.ts
+++ b/packages/web/src/hooks/useClusterVersionMatch.ts
@@ -5,7 +5,8 @@ import {useClusterPlugin} from '@plugins/cluster/hooks';
 const useClusterVersionMatch = <T>(match: string, defaults?: T): boolean | T => {
   const useClusterDetails = useClusterPlugin.select(x => x.useClusterDetails);
   const clusterVersion = useClusterDetails(x => x.version);
-  return clusterVersion == null ? (defaults as T) : matchesVersion(clusterVersion, match);
+  const isHash = !/^v?[0-9]+\./.test(clusterVersion || '');
+  return clusterVersion == null || isHash ? (defaults as T) : matchesVersion(clusterVersion, match);
 };
 
 export default useClusterVersionMatch;


### PR DESCRIPTION
## Changes

- ignore commit hash for the cluster version check
   - it was trying to compare commit hash with regular version using semver

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
