### PR TITLE
[TKC-789] fix: improve Entity Details performance

### DIFF
--- a/packages/web/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
@@ -66,7 +66,7 @@ export const SvgWrapper = styled.div<{$isDetailsView?: boolean}>`
 `;
 
 export const BarWrapper = styled.div<{$margin: number}>`
-  &:not(:last-child) {
+  &:not(:first-of-type) {
     margin-right: ${props => props.$margin}px;
   }
 `;

--- a/packages/web/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
@@ -57,7 +57,10 @@ export const AxisLabel = styled.div<{$top: number}>`
 
 export const SvgWrapper = styled.div<{$isDetailsView?: boolean}>`
   display: flex;
+  flex-direction: row-reverse;
+  flex-wrap: nowrap;
   align-items: flex-end;
+  width: fit-content;
 
   ${props => (props.$isDetailsView ? 'padding-bottom: 50px;' : '')}
   ${props => (props.$isDetailsView ? 'padding-left: 75px;' : '')}
@@ -73,30 +76,16 @@ export const ClickableBar = styled.div<{
   $color: StatusColors;
   hoverColor: SecondaryStatusColors;
 }>`
-  transition: 0.3s;
+  position: relative;
+  transition: 0.3s background-color linear;
   cursor: pointer;
+  margin-right: 3px;
 
   background-color: ${props => props.$color};
   border-bottom: 3px solid ${props => props.$color};
 
   &:hover {
     background-color: ${props => props.hoverColor} !important;
-  }
-`;
-
-export const ClickableBarWrapper = styled.span<{borderTop: number; hoverColor: SecondaryStatusColors}>`
-  position: relative;
-
-  border-top: ${props => (props.borderTop ? `${props.borderTop}px` : '1px')} solid transparent;
-
-  padding-right: 3px;
-
-  cursor: pointer;
-
-  &:hover {
-    & > ${ClickableBar} {
-      background-color: ${props => props.hoverColor} !important;
-    }
   }
 `;
 
@@ -126,12 +115,13 @@ export const StyledPopoverContent = styled.div`
   gap: 4px;
 `;
 
-export const BarDate = styled.div<{
-  $height: number;
-}>`
+export const BarDate = styled.div.attrs<{$height: number}>(({$height}) => ({
+  style: {top: `${$height + 15}px`},
+}))<{$height: number}>`
   position: absolute;
-  top: ${({$height}) => $height + 15}px;
   left: -5px;
+  color: ${Colors.slate400};
+  font-size: 12px;
 
   white-space: nowrap;
 

--- a/packages/web/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/MetricsBarChart.styled.tsx
@@ -57,8 +57,7 @@ export const AxisLabel = styled.div<{$top: number}>`
 
 export const SvgWrapper = styled.div<{$isDetailsView?: boolean}>`
   display: flex;
-  flex-direction: row-reverse;
-  flex-wrap: nowrap;
+  flex-flow: row-reverse nowrap;
   align-items: flex-end;
   width: fit-content;
 

--- a/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltip.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltip.tsx
@@ -1,3 +1,7 @@
+import {memo} from 'react';
+
+import {useLastCallback} from '@hooks/useLastCallback';
+
 import {useEntityDetailsPick} from '@store/entityDetails';
 import {useExecutionDetailsPick} from '@store/executionDetails';
 
@@ -10,7 +14,10 @@ export type BarConfig = {
   height: number;
   color: StatusColors;
   hoverColor: SecondaryStatusColors;
-  tooltipData: any;
+  status: any;
+  duration: string;
+  name: string;
+  startTime: number;
   date?: string;
   chartHeight: number;
 };
@@ -18,7 +25,13 @@ export type BarConfig = {
 const BarWithTooltip: React.FC<BarConfig> = props => {
   const {executions} = useEntityDetailsPick('executions');
   const {open} = useExecutionDetailsPick('open');
-  return <BarWithTooltipPure {...props} executions={executions} onSelect={open} />;
+  const onSelect = useLastCallback((name: string) => {
+    const targetRecord = executions.results?.find((item: any) => item.name === name);
+    if (targetRecord) {
+      open(targetRecord.id);
+    }
+  });
+  return <BarWithTooltipPure {...props} onSelect={onSelect} />;
 };
 
-export default BarWithTooltip;
+export default memo(BarWithTooltip);

--- a/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltip.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltip.tsx
@@ -1,8 +1,5 @@
 import {memo} from 'react';
 
-import {useLastCallback} from '@hooks/useLastCallback';
-
-import {useEntityDetailsPick} from '@store/entityDetails';
 import {useExecutionDetailsPick} from '@store/executionDetails';
 
 import {SecondaryStatusColors, StatusColors} from '@styles/Colors';
@@ -23,15 +20,8 @@ export type BarConfig = {
 };
 
 const BarWithTooltip: React.FC<BarConfig> = props => {
-  const {executions} = useEntityDetailsPick('executions');
-  const {open} = useExecutionDetailsPick('open');
-  const onSelect = useLastCallback((name: string) => {
-    const targetRecord = executions.results?.find((item: any) => item.name === name);
-    if (targetRecord) {
-      open(targetRecord.id);
-    }
-  });
-  return <BarWithTooltipPure {...props} onSelect={onSelect} />;
+  const {openByName} = useExecutionDetailsPick('openByName');
+  return <BarWithTooltipPure {...props} onSelect={openByName} />;
 };
 
 export default memo(BarWithTooltip);

--- a/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltipPure.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltipPure.tsx
@@ -13,7 +13,6 @@ import {formatExecutionDate} from '@utils/formatDate';
 import {
   BarDate,
   ClickableBar,
-  ClickableBarWrapper,
   StyledPopoverContainer,
   StyledPopoverContent,
   StyledPopoverHeader,
@@ -24,23 +23,13 @@ import type {BarConfig} from './BarWithTooltip';
 const tooltipYOffsetMargin = 5;
 
 type BarConfigPure = BarConfig & {
-  executions: any;
   onSelect: (id: string) => void;
 };
 
 const BarWithTooltipPure: React.FC<BarConfigPure> = memo(props => {
-  const {width, height, color, tooltipData, hoverColor, date, chartHeight, executions, onSelect} = props;
-  const {status, duration, name, startTime} = tooltipData;
+  const {width, height, color, status, duration, name, startTime, chartHeight, hoverColor, date, onSelect} = props;
 
-  const onBarClicked = useCallback(() => {
-    if (executions?.results) {
-      const targetRecord = executions.results.find((item: any) => item.name === name);
-
-      if (targetRecord) {
-        onSelect(targetRecord.id);
-      }
-    }
-  }, [executions?.results, onSelect, name]);
+  const onBarClicked = useCallback(() => onSelect(name), [onSelect, name]);
 
   const popoverContent = useMemo(
     () => (
@@ -64,14 +53,9 @@ const BarWithTooltipPure: React.FC<BarConfigPure> = memo(props => {
 
   return (
     <Popover content={popoverContent} align={{offset: [0, chartHeight - height - tooltipYOffsetMargin]}}>
-      <ClickableBarWrapper borderTop={chartHeight - height} hoverColor={hoverColor} onClick={onBarClicked}>
-        <ClickableBar style={{height, width}} $color={color} hoverColor={hoverColor} />
-        {date ? (
-          <BarDate $height={height}>
-            <Text color={Colors.slate400}>{date}</Text>
-          </BarDate>
-        ) : null}
-      </ClickableBarWrapper>
+      <ClickableBar style={{height, width}} $color={color} hoverColor={hoverColor} onClick={onBarClicked}>
+        {date ? <BarDate $height={height}>{date}</BarDate> : undefined}
+      </ClickableBar>
     </Popover>
   );
 });

--- a/packages/web/src/components/molecules/MetricsBarChart/components/Chart.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/Chart.tsx
@@ -77,7 +77,7 @@ const Chart: React.FC<ChartProps> = props => {
 
   return (
     <SvgWrapper $isDetailsView={isDetailsView}>
-      <div ref={scrollRef} />
+      <span ref={scrollRef} />
       {renderedBarChart}
     </SvgWrapper>
   );

--- a/packages/web/src/components/molecules/MetricsBarChart/components/Chart.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/Chart.tsx
@@ -32,26 +32,16 @@ const Chart: React.FC<ChartProps> = props => {
   const renderedBarChart = useMemo(() => {
     let prevDay = getDayOfYear(new Date(chartData[0].startTime));
 
-    return chartData.map((barItem, index) => {
+    return chartData.map(barItem => {
       const {durationS, logDuration, status, name, startTime} = barItem;
 
       const barColor = StatusColors[status as keyof typeof StatusColors];
       const barHoverColor = SecondaryStatusColors[status as keyof typeof SecondaryStatusColors];
 
-      /*
-        if execution is running, bar height is 50% of chartHeight
-        PROPORTION ---- heightInPx / chartHeightInPx = logDurationInMs / maxValueInMs
-        so we basically say that bar value in px relates to 100% that is chartHeight
-        the same as bar value in milliseconds relates to 100% that is max Value in data set
-        we take that greatest value is basically set to 100% of chart height
-      */
-
       const height =
         status === 'running' || status === 'aborting' ? chartHeight / 2 : (logDuration * chartHeight) / maxValue;
 
       const formattedDuration = status === 'running' || status === 'aborting' ? 'running' : formatDuration(durationS);
-
-      const key = `${name}-bar-${index}`;
 
       const barProps = {
         height,
@@ -62,31 +52,33 @@ const Chart: React.FC<ChartProps> = props => {
       };
 
       if (isDetailsView) {
-        let showDate = false;
         const startTimeDate = new Date(startTime);
-        if (prevDay !== getDayOfYear(startTimeDate)) {
+        const showDate = prevDay !== getDayOfYear(startTimeDate);
+        if (showDate) {
           prevDay = getDayOfYear(startTimeDate);
-          showDate = true;
         }
         return (
           <BarWithTooltip
-            key={key}
-            chartHeight={chartHeight}
-            tooltipData={{duration: formattedDuration, status, name, startTime}}
+            key={name}
+            name={name}
+            status={status}
+            duration={formattedDuration}
+            startTime={startTime}
             date={showDate ? format(startTimeDate, 'd.M.yy') : undefined}
+            chartHeight={chartHeight}
             {...barProps}
           />
         );
       }
 
-      return <Bar $margin={barProps.margin} style={{height, width: barWidth, background: barProps.color}} key={key} />;
+      return <Bar $margin={barProps.margin} style={{height, width: barWidth, background: barProps.color}} key={name} />;
     });
-  }, [chartData]);
+  }, [chartData, barWidth, chartHeight, maxValue, barMargin, isDetailsView]);
 
   return (
     <SvgWrapper $isDetailsView={isDetailsView}>
-      {renderedBarChart}
       <div ref={scrollRef} />
+      {renderedBarChart}
     </SvgWrapper>
   );
 };

--- a/packages/web/src/components/molecules/MetricsBarChart/utils.ts
+++ b/packages/web/src/components/molecules/MetricsBarChart/utils.ts
@@ -29,27 +29,25 @@ export const getAxisPosition = (
 };
 
 export const metricsLogarithmization = (data: ExecutionMetrics[], minValueDivider: number) => {
-  return data
-    .map(item => {
-      // items with no duration set to 1 sec execution
-      if (!item.durationMs || item.durationMs <= secondInMs) {
-        return {
-          ...item,
-          logDuration: 1,
-          durationS: 1,
-        };
-      }
-      /*
-        Division each value by some number makes chart look more proportional
-      */
-      const durationS = item.durationMs / secondInMs;
-      const logDuration = Math.log(item.durationMs / minValueDivider);
-
+  return data.map(item => {
+    // items with no duration set to 1 sec execution
+    if (!item.durationMs || item.durationMs <= secondInMs) {
       return {
         ...item,
-        logDuration,
-        durationS,
+        logDuration: 1,
+        durationS: 1,
       };
-    })
-    .reverse();
+    }
+    /*
+        Division each value by some number makes chart look more proportional
+      */
+    const durationS = item.durationMs / secondInMs;
+    const logDuration = Math.log(item.durationMs / minValueDivider);
+
+    return {
+      ...item,
+      logDuration,
+      durationS,
+    };
+  });
 };

--- a/packages/web/src/components/organisms/EntityDetails/ExecutionDetailsLayer.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/ExecutionDetailsLayer.tsx
@@ -4,12 +4,14 @@ import {UseQuery} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import {QueryDefinition} from '@reduxjs/toolkit/query';
 
 import {useDashboardNavigate} from '@hooks/useDashboardNavigate';
+import {useLastCallback} from '@hooks/useLastCallback';
 import {SystemAccess, useSystemAccess} from '@hooks/useSystemAccess';
 
 import {Entity} from '@models/entity';
 
 import {notificationCall} from '@molecules';
 
+import {useEntityDetailsPick} from '@store/entityDetails';
 import {useExecutionDetailsPick, useExecutionDetailsReset, useExecutionDetailsSync} from '@store/executionDetails';
 
 import {isExecutionFinished} from '@utils/isExecutionFinished';
@@ -30,10 +32,18 @@ const ExecutionDetailsLayer: FC<PropsWithChildren<ExecutionDetailsLayerProps>> =
   useGetExecutionDetails,
   children,
 }) => {
+  const {executions} = useEntityDetailsPick('executions');
+  const open = useDashboardNavigate((targetId: string) => `/${entity}/${id}/executions/${targetId}`);
   useExecutionDetailsReset(
     {
       id: execId,
-      open: useDashboardNavigate((targetId: string) => `/${entity}/${id}/executions/${targetId}`),
+      open,
+      openByName: useLastCallback((name: string) => {
+        const targetRecord = executions.results?.find((item: any) => item.name === name);
+        if (targetRecord) {
+          open(targetRecord.id);
+        }
+      }),
       close: useDashboardNavigate(`/${entity}/${id}`),
     },
     [execId, useGetExecutionDetails]

--- a/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {memo, useCallback, useMemo} from 'react';
 
 import {Table, TablePaginationConfig} from 'antd';
 import {TableRowSelection} from 'antd/lib/table/interface';
@@ -102,4 +102,4 @@ const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecuti
   );
 };
 
-export default ExecutionsTable;
+export default memo(ExecutionsTable);

--- a/packages/web/src/components/organisms/ExecutionsTable/TableRow/TableRow.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/TableRow/TableRow.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import {FC, memo} from 'react';
 
 import {Permissions, usePermission} from '@permissions/base';
 
 import TableRowPure from './TableRowPure';
 
-const TableRow: React.FC<{data: any; onAbortExecution?: any}> = props => {
+const TableRow: FC<{data: any; onAbortExecution?: any}> = props => {
   const mayManageExecution = usePermission(Permissions.manageEntityExecution);
   return <TableRowPure {...props} mayManageExecution={mayManageExecution} />;
 };
 
-export default TableRow;
+export default memo(TableRow);

--- a/packages/web/src/store/executionDetails.ts
+++ b/packages/web/src/store/executionDetails.ts
@@ -10,6 +10,7 @@ export interface ExecutionDetailsSlice {
   data: Execution | TestSuiteExecution | null;
   error: any;
   open: (id: string) => void;
+  openByName: (name: string) => void;
   close: () => void;
 }
 
@@ -17,6 +18,7 @@ const createExecutionDetailsSlice: StateCreator<ExecutionDetailsSlice> = set => 
   data: null,
   error: null,
   open: () => {},
+  openByName: () => {},
   close: () => {},
 });
 


### PR DESCRIPTION
## Changes

- improve `ExecutionsTable`
- improve `Chart`
- improve callback to open execution by its name

## Fixes

- [**TKC-789**](https://linear.app/kubeshop/issue/TKC-789/%5Bui%5D-log-screen-causes-a-chrome-crash) - Log screen causes a Chrome crash

## How to test it

- Compare profiler information for the test with 1000+ executions, after clicking "Run" button

## Screenshots

| Description | Screenshot |
|-|-|
| Before | <img width="902" alt="Zrzut ekranu 2023-11-8 o 09 09 10" src="https://github.com/kubeshop/testkube-dashboard/assets/3843526/288743ce-368b-4fbe-b5b5-7273fcbe5a73"> |
| After | <img width="940" alt="Zrzut ekranu 2023-11-8 o 09 32 25" src="https://github.com/kubeshop/testkube-dashboard/assets/3843526/3d2806c2-5e68-401c-a04b-667dddd7050e"> |

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
