### PR TITLE
feat: sanitize quotes in env-config.js

### DIFF
--- a/packages/web/scripts/env.sh
+++ b/packages/web/scripts/env.sh
@@ -17,7 +17,7 @@ VARIABLES="$(env | grep '^REACT_APP_' | sed 's/=.*//')"
 set -- $VARIABLES
 echo "window._env_ = {" > "$OUT"
 while [ -n "$1" ]; do
-  value="$(eval "echo \"\$$1\"")"
+  value="$(eval "echo \"\$$1\" | sed \"s/'/\\\\\\'/g\"")"
   echo "$1: '$value'," >> "$OUT"
   shift
 done


### PR DESCRIPTION
## Changes

- Sanitize quotes in `env.config.js`

## Fixes

Syntax error in `env-config.js`, like here because of `REACT_APP_VERCEL_GIT_COMMIT_MESSAGE`:

```js
window._env_ = {
REACT_APP_VERSION: 'dev:vercel-preview',
REACT_APP_VERCEL_GIT_COMMIT_SHA: '7a85f0bc7042c8f851a644ca2582fb2b049ef9fd',
REACT_APP_VERCEL_URL: 'testkube-cloud-czwoia4vi-testkube-cloud.vercel.app',
REACT_APP_VERCEL_ENV: 'preview',
REACT_APP_VERCEL_GIT_PREVIOUS_SHA: '',
REACT_APP_VERCEL_GIT_COMMIT_AUTHOR_LOGIN: 'haneabogdan',
REACT_APP_VERCEL_GIT_PROVIDER: 'github',
REACT_APP_VERCEL_GIT_COMMIT_AUTHOR_NAME: 'haneabogdan',
REACT_APP_DISABLE_TELEMETRY: 'true',
REACT_APP_VERCEL_GIT_REPO_OWNER: 'kubeshop',
REACT_APP_VERCEL_GIT_REPO_SLUG: 'testkube-cloud-ui',
REACT_APP_VERCEL_GIT_PULL_REQUEST_ID: '',
REACT_APP_API_SERVER_ENDPOINT: 'https://api.testkube.dev',
REACT_APP_VERCEL_GIT_COMMIT_MESSAGE: '"Merge branch 'bogdan/feat/unsaved-changes-popup' of github.com:kubeshop/testkube-cloud-ui into bogdan/feat/unsaved-changes-popup"',
REACT_APP_VERCEL_GIT_REPO_ID: '',
REACT_APP_VERCEL_GIT_COMMIT_REF: 'bogdan/feat/unsaved-changes-popup',
};
```

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
