### PR TITLE
fix: E2E tests for Triggers in Cloud

### DIFF
--- a/packages/e2e-tests/fixtures/triggers.ts
+++ b/packages/e2e-tests/fixtures/triggers.ts
@@ -11,7 +11,7 @@ export default {
     concurrencyPolicy: '',
     testSelector: {
       name: 'postman-executor-smoke',
-      namespace: 'testkube',
+      ...(config.cloudContext ? {} : {namespace: config.namespace}),
     },
     resourceSelector: {
       name: 'non-existant-resource',


### PR DESCRIPTION
## Changes

- fix: E2E tests for Triggers in Cloud

## Fixes

- https://github.com/kubeshop/testkube-cloud-ui/actions/runs/6809143770/job/18519121294

```
2) [chromium] › triggers.spec.ts:15:5 › Create Trigger ───────────────────────────────────────────

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

    @@ -10,7 +10,8 @@
          "name": "non-existant-resource",
          "namespace": "namespace-name",
        },
        "testSelector": Object {
          "name": "postman-executor-smoke",
    +     "namespace": "testkube",
        },
      }

       at ../helpers/common.ts:61

      [59](https://github.com/kubeshop/testkube-cloud-ui/actions/runs/6809143770/job/18519121294#step:2:60) |
      [60](https://github.com/kubeshop/testkube-cloud-ui/actions/runs/6809143770/job/18519121294#step:2:61) | export function validateTrigger(triggerData: Partial<TriggerData>, createdTriggerData: TriggerData): void {
    > [61](https://github.com/kubeshop/testkube-cloud-ui/actions/runs/6809143770/job/18519121294#step:2:62) |   expect(triggerData).toEqual(createdTriggerData);
         |                       ^
      [62](https://github.com/kubeshop/testkube-cloud-ui/actions/runs/6809143770/job/18519121294#step:2:63) | }
      [63](https://github.com/kubeshop/testkube-cloud-ui/actions/runs/6809143770/job/18519121294#step:2:64) |

        at validateTrigger (/data/repo/packages/e2e-tests/helpers/common.ts:61:23)
        at /data/repo/packages/e2e-tests/tests/triggers.spec.ts:36:24
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
