### PR TITLE
feat: add option to provide base slot items for slot hooks / feat: add slots for Test/Test Suite Details

### DIFF
--- a/packages/plugins/src/hooks.spec.tsx
+++ b/packages/plugins/src/hooks.spec.tsx
@@ -357,6 +357,29 @@ describe('plugins', () => {
         });
         expect(result.current).toEqual([1, ['value1']]);
       });
+
+      it('should use defaults', async () => {
+        const root = createPluginScopeMock({slots: {slot1: []}});
+        root.slots.slot1.add('value1', {order: 30});
+
+        const {result} = renderHook(
+          () => [
+            useRenderCount(),
+            useSlot('slot1', [
+              {value: 'value2', metadata: {order: 28, enabled: () => false}},
+              {value: 'value3', metadata: {order: 29}},
+              {value: 'value4', metadata: {order: 30}},
+              {value: 'value5', metadata: {order: 31}},
+            ]),
+          ],
+          {
+            wrapper: ({children}) => (
+              <PluginScopeContext.Provider value={{root}}>{children}</PluginScopeContext.Provider>
+            ),
+          }
+        );
+        expect(result.current).toEqual([1, ['value3', 'value4', 'value1', 'value5']]);
+      });
     });
 
     describe('useSlotFirst', () => {
@@ -433,6 +456,48 @@ describe('plugins', () => {
           root.slots.slot1[PluginScopeDestroy](root);
           await frame();
         });
+        expect(result.current).toEqual([1, 'value1']);
+      });
+
+      it('should use defaults (first in default)', async () => {
+        const root = createPluginScopeMock({slots: {slot1: []}});
+        root.slots.slot1.add('value1', {order: 30});
+
+        const {result} = renderHook(
+          () => [
+            useRenderCount(),
+            useSlotFirst('slot1', [
+              {value: 'value3', metadata: {order: 31}},
+              {value: 'value2', metadata: {order: 30}},
+            ]),
+          ],
+          {
+            wrapper: ({children}) => (
+              <PluginScopeContext.Provider value={{root}}>{children}</PluginScopeContext.Provider>
+            ),
+          }
+        );
+        expect(result.current).toEqual([1, 'value2']);
+      });
+
+      it('should use defaults (first in own)', async () => {
+        const root = createPluginScopeMock({slots: {slot1: []}});
+        root.slots.slot1.add('value1', {order: 30});
+
+        const {result} = renderHook(
+          () => [
+            useRenderCount(),
+            useSlotFirst('slot1', [
+              {value: 'value2', metadata: {order: 31}},
+              {value: 'value3', metadata: {order: 32}},
+            ]),
+          ],
+          {
+            wrapper: ({children}) => (
+              <PluginScopeContext.Provider value={{root}}>{children}</PluginScopeContext.Provider>
+            ),
+          }
+        );
         expect(result.current).toEqual([1, 'value1']);
       });
     });

--- a/packages/plugins/src/hooks.ts
+++ b/packages/plugins/src/hooks.ts
@@ -79,12 +79,16 @@ export const createUseData = <T extends Plugin<any>>() => {
 
 export const createUseSlot = <T extends Plugin<any>>() => {
   const useSubscription = createUseSubscription();
-  return <K extends keyof GetSlots<GetPluginState<T>>>(key: K): GetSlots<GetPluginState<T>>[K][] => {
+  return <K extends keyof GetSlots<GetPluginState<T>>>(
+    key: K,
+    defaults: PluginSlotContainer<GetSlots<GetPluginState<T>>[K]>[] = []
+  ): GetSlots<GetPluginState<T>>[K][] => {
     const [incr, setIncr] = useState(0);
     const scope = usePluginScope<T>();
     const resultsRef = useRef<PluginSlotContainer<T>[]>();
     const updateResults = () => {
-      const results = scope.slots[key]?.allRaw();
+      // @ts-ignore: FIXME something is wrong with types
+      const results = scope.slots[key]?.allRaw(defaults);
       if (results?.length !== resultsRef.current?.length || resultsRef.current?.some((x, i) => results![i] !== x)) {
         resultsRef.current = results;
       }
@@ -104,13 +108,18 @@ export const createUseSlot = <T extends Plugin<any>>() => {
 
 export const createUseSlotFirst = <T extends Plugin<any>>() => {
   const useSubscription = createUseSubscription();
-  return <K extends keyof GetSlots<GetPluginState<T>>>(key: K): GetSlots<GetPluginState<T>>[K] | undefined => {
+  return <K extends keyof GetSlots<GetPluginState<T>>>(
+    key: K,
+    defaults: PluginSlotContainer<GetSlots<GetPluginState<T>>[K]>[] = []
+  ): GetSlots<GetPluginState<T>>[K] | undefined => {
     const [incr, setIncr] = useState(0);
     const prevRef = useRef<GetSlots<GetPluginState<T>>[K] | undefined>();
     const scope = usePluginScope<T>();
-    prevRef.current = scope.slots[key]?.first();
+    // @ts-ignore: FIXME something is wrong with types
+    prevRef.current = scope.slots[key]?.first(defaults);
     useSubscription(() => {
-      const nextValue = scope.slots[key]?.first();
+      // @ts-ignore: FIXME something is wrong with types
+      const nextValue = scope.slots[key]?.first(defaults);
       if (nextValue !== prevRef.current) {
         prevRef.current = nextValue;
         setIncr((incr + 1) % 10000);

--- a/packages/plugins/src/internal/PluginSlot.ts
+++ b/packages/plugins/src/internal/PluginSlot.ts
@@ -62,17 +62,24 @@ export class PluginSlot<T> {
     this.storage.set(this.key, slot);
   }
 
-  public allRaw(): PluginSlotContainer<T>[] {
+  public allRaw(defaults: PluginSlotContainer<T>[] = []): PluginSlotContainer<T>[] {
     const all = this.storage.get(this.key) || [];
-    return all.filter(item => isSlotEnabled(item.metadata));
+    const filtered = all.filter(item => isSlotEnabled(item.metadata));
+    defaults.forEach(item => {
+      if (isSlotEnabled(item.metadata || {})) {
+        const order = item.metadata.order || 0;
+        const index = filtered.findIndex(x => x.metadata.order! >= order);
+        filtered.splice(index === -1 ? filtered.length : index, 0, item);
+      }
+    });
+    return filtered;
   }
 
   public all(): T[] {
     return this.allRaw().map(item => item.value);
   }
 
-  public first(): T | undefined {
-    const all = this.storage.get(this.key) || [];
-    return all.find(item => isSlotEnabled(item.metadata))?.value;
+  public first(defaults: PluginSlotContainer<T>[] = []): T | undefined {
+    return this.allRaw(defaults)[0]?.value;
   }
 }

--- a/packages/web/src/components/pages/TestSuites/TestSuiteDetails/TestSuiteDetailsContent.tsx
+++ b/packages/web/src/components/pages/TestSuites/TestSuiteDetails/TestSuiteDetailsContent.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react';
+import React, {FC, useMemo} from 'react';
 
 import {Tabs} from 'antd';
 
@@ -15,6 +15,8 @@ import {EntityDetailsHeader, EntityDetailsWrapper, RecentExecutionsTab} from '@o
 
 import {Error, Loading} from '@pages';
 import PageMetadata from '@pages/PageMetadata';
+
+import {useTestsSlot} from '@plugins/tests-and-test-suites/hooks';
 
 import {useAbortAllTestSuiteExecutionsMutation, useAbortTestSuiteExecutionMutation} from '@services/testSuites';
 
@@ -46,6 +48,37 @@ const TestSuiteDetailsContent: FC<TestSuiteDetailsContentProps> = ({tab, setting
     setSettingsTab('tests');
   });
 
+  const defaultTabs = useMemo(
+    () => [
+      {
+        value: {
+          key: 'executions',
+          label: 'Recent executions',
+          children: <RecentExecutionsTab onRun={run} useAbortExecution={useAbortTestSuiteExecutionMutation} />,
+        },
+        metadata: {order: -Infinity},
+      },
+      {
+        value: {
+          key: 'commands',
+          label: 'CLI Commands',
+          children: <CLICommands name={details?.name!} bg={Colors.slate800} />,
+        },
+        metadata: {order: -100},
+      },
+      {
+        value: {
+          key: 'settings',
+          label: 'Settings',
+          children: <TestSuiteSettings active={settingsTab} onChange={setSettingsTab} />,
+        },
+        metadata: {order: 50},
+      },
+    ],
+    [details, run, settingsTab, setSettingsTab]
+  );
+  const tabs = useTestsSlot('testSuiteDetailsTabs', defaultTabs);
+
   if (error) {
     return <Error title={error?.data?.title || 'Error'} description={error?.data?.detail || ''} />;
   }
@@ -69,32 +102,7 @@ const TestSuiteDetailsContent: FC<TestSuiteDetailsContentProps> = ({tab, setting
           entityLabel="test suite"
         />
         <SummaryGrid metrics={metrics} />
-        <Tabs
-          activeKey={tab}
-          onChange={setTab}
-          destroyInactiveTabPane
-          items={[
-            {
-              key: 'executions',
-              label: 'Recent executions',
-              children: <RecentExecutionsTab onRun={run} useAbortExecution={useAbortTestSuiteExecutionMutation} />,
-            },
-            ...(details.readOnly
-              ? []
-              : [
-                  {
-                    key: 'commands',
-                    label: 'CLI Commands',
-                    children: <CLICommands name={details!.name} bg={Colors.slate800} />,
-                  },
-                ]),
-            {
-              key: 'settings',
-              label: 'Settings',
-              children: <TestSuiteSettings active={settingsTab} onChange={setSettingsTab} />,
-            },
-          ]}
-        />
+        <Tabs activeKey={tab} onChange={setTab} destroyInactiveTabPane items={tabs} />
       </PageWrapper>
       <TestSuiteExecutionDrawer />
     </EntityDetailsWrapper>

--- a/packages/web/src/components/pages/Tests/TestDetails/TestDetailsContent.tsx
+++ b/packages/web/src/components/pages/Tests/TestDetails/TestDetailsContent.tsx
@@ -1,8 +1,6 @@
-import React, {FC} from 'react';
+import React, {FC, useMemo} from 'react';
 
 import {Tabs} from 'antd';
-
-import {Tab} from 'rc-tabs/lib/interface';
 
 import {useDashboardNavigate} from '@hooks/useDashboardNavigate';
 import {useLastCallback} from '@hooks/useLastCallback';
@@ -17,6 +15,8 @@ import {EntityDetailsHeader, EntityDetailsWrapper, RecentExecutionsTab} from '@o
 
 import {Error, Loading} from '@pages';
 import PageMetadata from '@pages/PageMetadata';
+
+import {useTestsSlot} from '@plugins/tests-and-test-suites/hooks';
 
 import {useAbortAllTestExecutionsMutation, useAbortTestExecutionMutation} from '@services/tests';
 
@@ -48,6 +48,40 @@ const TestDetailsContent: FC<TestDetailsContentProps> = ({tab, settingsTab}) => 
     setSettingsTab('test');
   });
 
+  const defaultTabs = useMemo(
+    () => [
+      {
+        value: {
+          key: 'executions',
+          label: 'Recent executions',
+          children: <RecentExecutionsTab onRun={run} useAbortExecution={useAbortTestExecutionMutation} />,
+        },
+        metadata: {order: -Infinity},
+      },
+      {
+        value: {
+          key: 'commands',
+          label: 'CLI Commands',
+          children: <CLICommands name={details?.name!} bg={Colors.slate800} />,
+        },
+        metadata: {
+          order: -100,
+          enabled: details && !details.readOnly,
+        },
+      },
+      {
+        value: {
+          key: 'settings',
+          label: 'Settings',
+          children: <TestSettings active={settingsTab} onChange={setSettingsTab} />,
+        },
+        metadata: {order: 50},
+      },
+    ],
+    [details, run, settingsTab, setSettingsTab]
+  );
+  const tabs = useTestsSlot('testDetailsTabs', defaultTabs);
+
   if (error) {
     return <Error title={error?.data?.title || 'Error'} description={error?.data?.detail || ''} />;
   }
@@ -71,30 +105,7 @@ const TestDetailsContent: FC<TestDetailsContentProps> = ({tab, settingsTab}) => 
           entityLabel="test"
         />
         <SummaryGrid metrics={metrics} />
-        <Tabs
-          activeKey={tab}
-          onChange={setTab}
-          destroyInactiveTabPane
-          items={
-            [
-              {
-                key: 'executions',
-                label: 'Recent executions',
-                children: <RecentExecutionsTab onRun={run} useAbortExecution={useAbortTestExecutionMutation} />,
-              },
-              !details.readOnly && {
-                key: 'commands',
-                label: 'CLI Commands',
-                children: <CLICommands name={details!.name} bg={Colors.slate800} />,
-              },
-              {
-                key: 'settings',
-                label: 'Settings',
-                children: <TestSettings active={settingsTab} onChange={setSettingsTab} />,
-              },
-            ].filter(Boolean) as Tab[]
-          }
-        />
+        <Tabs activeKey={tab} onChange={setTab} destroyInactiveTabPane items={tabs} />
       </PageWrapper>
       <TestExecutionDrawer />
     </EntityDetailsWrapper>

--- a/packages/web/src/plugins/tests-and-test-suites/plugin.tsx
+++ b/packages/web/src/plugins/tests-and-test-suites/plugin.tsx
@@ -100,6 +100,8 @@ export default createPlugin('oss/tests-and-test-suites')
 
   .define(data<(tab: string) => void>()('setExecutionTab'))
   .define(slot<{key: string; label: ReactNode; children: ReactNode}>()('testExecutionTabs'))
+  .define(slot<{key: string; label: ReactNode; children: ReactNode}>()('testDetailsTabs'))
+  .define(slot<{key: string; label: ReactNode; children: ReactNode}>()('testSuiteDetailsTabs'))
   .define(slot<ReactNode>()('logOutputTop'))
   .define(slot<ReactNode>()('deleteTestExtension'))
   .define(slot<ReactNode>()('deleteTestSuiteExtension'))


### PR DESCRIPTION
## Changes

- feat: add an option to provide base slot items for slot hooks
   - which may be treated as a fallback, or just basic values
- feat: add slots for Test/Test Suite Details

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
