### PR TITLE
fix: catch validate fields so app doesn't crash TKC-863

### DIFF
--- a/packages/web/src/components/pages/Triggers/TriggersList/AddTriggerModal/ModalFirstStep.tsx
+++ b/packages/web/src/components/pages/Triggers/TriggersList/AddTriggerModal/ModalFirstStep.tsx
@@ -37,10 +37,12 @@ const ModalFirstStep: React.FC<ModalFirstStepProps> = props => {
             data-test="triggers-add-modal-next:first"
             $customType="primary"
             onClick={() => {
-              validateFields().then(() => {
-                setCurrentStep(StepsEnum.action);
-                setFirstStepValues(getFieldsValue());
-              });
+              validateFields()
+                .then(() => {
+                  setCurrentStep(StepsEnum.action);
+                  setFirstStepValues(getFieldsValue());
+                })
+                .catch(() => {});
             }}
           >
             Next

--- a/packages/web/src/components/pages/Webhooks/WebhookCreationModal/WebhookCreationModal.tsx
+++ b/packages/web/src/components/pages/Webhooks/WebhookCreationModal/WebhookCreationModal.tsx
@@ -48,9 +48,12 @@ const WebhookCreationModal: FC = () => {
       return;
     }
 
-    form.validateFields().then(() => {
-      setStep(WebhookCreationModalSteps.Action);
-    });
+    form
+      .validateFields()
+      .then(() => {
+        setStep(WebhookCreationModalSteps.Action);
+      })
+      .catch(() => {});
   };
 
   const onFinish = () => {


### PR DESCRIPTION
## Changes

- Handle validateFields and don't crash the app on error

## Fixes

- https://linear.app/kubeshop/issue/TKC-863/%5Bui%5D-creating-triggerwebhook-with-empty-required-valued-would-crash

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
