### PR TITLE
refactor: filter tests/testSuites based on action TKC-871

### DIFF
--- a/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
@@ -14,11 +14,11 @@ import TriggerSelectorSwitcher from './TriggerSelectorSwitcher';
 const ActionFormItems = () => {
   const {keyMap} = useTriggersPick('keyMap');
 
-  const [actionValue, setActionValue] = useState<string>('');
   const [switcherValue, setSwitcherValue] = useState('label');
 
   const form = Form.useFormInstance();
 
+  const actionValue = Form.useWatch('action', form);
   const nameSelector = form.getFieldValue('testNameSelector');
 
   useEffect(() => {
@@ -47,12 +47,7 @@ const ActionFormItems = () => {
         name="action"
         rules={[required]}
       >
-        <Select
-          value={actionValue}
-          onChange={value => setActionValue(value)}
-          options={actionOptions}
-          placeholder="Select a testkube related action"
-        />
+        <Select options={actionOptions} placeholder="Select a testkube related action" />
       </Form.Item>
       <Space size={16} direction="vertical" style={{width: '100%'}}>
         <TriggerSelectorSwitcher
@@ -79,8 +74,8 @@ const ActionFormItems = () => {
             rules={[required]}
           >
             <ResourceTriggerSelect
-              $allowTests={actionValue === 'run test'}
-              $allowTestSuites={actionValue === 'run testsuite'}
+              allowTests={actionValue === 'run test'}
+              allowTestSuites={actionValue === 'run testsuite'}
             />
           </Form.Item>
         )}

--- a/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
@@ -17,11 +17,17 @@ const ActionFormItems = () => {
   const [actionValue, setActionValue] = useState<string>('');
   const [switcherValue, setSwitcherValue] = useState('label');
 
-  const nameSelector = Form.useFormInstance().getFieldValue('testNameSelector');
+  const form = Form.useFormInstance();
+
+  const nameSelector = form.getFieldValue('testNameSelector');
 
   useEffect(() => {
     setSwitcherValue(nameSelector ? 'name' : 'label');
   }, [nameSelector]);
+
+  useEffect(() => {
+    form.resetFields(['testNameSelector']);
+  }, [actionValue]);
 
   const actionOptions = keyMap?.actions
     .map((actionItem: string) =>
@@ -72,7 +78,10 @@ const ActionFormItems = () => {
             name="testNameSelector"
             rules={[required]}
           >
-            <ResourceTriggerSelect actionValue={actionValue} />
+            <ResourceTriggerSelect
+              $allowTests={actionValue === 'run test'}
+              $allowTestSuites={actionValue === 'run testsuite'}
+            />
           </Form.Item>
         )}
       </Space>

--- a/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
@@ -14,6 +14,7 @@ import TriggerSelectorSwitcher from './TriggerSelectorSwitcher';
 const ActionFormItems = () => {
   const {keyMap} = useTriggersPick('keyMap');
 
+  const [actionValue, setActionValue] = useState<string>('');
   const [switcherValue, setSwitcherValue] = useState('label');
 
   const nameSelector = Form.useFormInstance().getFieldValue('testNameSelector');
@@ -40,7 +41,12 @@ const ActionFormItems = () => {
         name="action"
         rules={[required]}
       >
-        <Select options={actionOptions} placeholder="Select a testkube related action" />
+        <Select
+          value={actionValue}
+          onChange={value => setActionValue(value)}
+          options={actionOptions}
+          placeholder="Select a testkube related action"
+        />
       </Form.Item>
       <Space size={16} direction="vertical" style={{width: '100%'}}>
         <TriggerSelectorSwitcher
@@ -66,7 +72,7 @@ const ActionFormItems = () => {
             name="testNameSelector"
             rules={[required]}
           >
-            <ResourceTriggerSelect />
+            <ResourceTriggerSelect actionValue={actionValue} />
           </Form.Item>
         )}
       </Space>

--- a/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ActionFormItems.tsx
@@ -19,7 +19,7 @@ const ActionFormItems = () => {
   const form = Form.useFormInstance();
 
   const actionValue = Form.useWatch('action', form);
-  const nameSelector = form.getFieldValue('testNameSelector');
+  const nameSelector = Form.useWatch('testNameSelector', form);
 
   useEffect(() => {
     setSwitcherValue(nameSelector ? 'name' : 'label');

--- a/packages/web/src/components/organisms/TriggersFormItems/ConditionFormItems.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ConditionFormItems.tsx
@@ -33,7 +33,7 @@ const ConditionFormItems = () => {
         name="resource"
         rules={[required]}
       >
-        <Select options={resourcesOptions} placeholder="Select a K8s resource" />
+        <Select options={resourcesOptions} placeholder="Select a K8s resource" showSearch />
       </Form.Item>
       <Space size={16} direction="vertical" style={{width: '100%'}}>
         <TriggerSelectorSwitcher

--- a/packages/web/src/components/organisms/TriggersFormItems/ConditionFormItems.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ConditionFormItems.tsx
@@ -88,6 +88,7 @@ const ConditionFormItems = () => {
                 options={eventsOptions}
                 disabled={eventsOptions.length === 0 ? true : undefined}
                 placeholder="Select cluster event"
+                showSearch
               />
             </Form.Item>
           );

--- a/packages/web/src/components/organisms/TriggersFormItems/ResourceTriggerSelect/ResourceTriggerSelect.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ResourceTriggerSelect/ResourceTriggerSelect.tsx
@@ -24,6 +24,7 @@ import {StyledResourceOptionWrapper} from './ResourceTriggerSelect.styled';
 const {Option, OptGroup} = Select;
 
 interface ResourceTriggerSelectProps {
+  actionValue: string;
   disabled?: boolean;
   value?: string;
   onChange?: (value: string) => void;
@@ -55,8 +56,8 @@ const ResourceTriggerSelect: FC<ResourceTriggerSelectProps> = ({...props}) => {
   }, [testSuites]);
 
   return (
-    <Select optionLabelProp="key" placeholder="Your testkube resource" {...props}>
-      {testsData.length > 0 ? (
+    <Select optionLabelProp="key" placeholder="Your testkube resource" showSearch {...props}>
+      {testsData.length > 0 && props.actionValue === 'run test' ? (
         <OptGroup label="Tests">
           {testsData.map(item => (
             <Option key={item.name} title={item.name}>
@@ -68,7 +69,7 @@ const ResourceTriggerSelect: FC<ResourceTriggerSelectProps> = ({...props}) => {
           ))}
         </OptGroup>
       ) : null}
-      {testSuitesData.length > 0 ? (
+      {testSuitesData.length > 0 && props.actionValue === 'run testsuite' ? (
         <OptGroup label="Test Suites">
           {testSuitesData.map(item => (
             <Option key={item.name} title={item.name}>

--- a/packages/web/src/components/organisms/TriggersFormItems/ResourceTriggerSelect/ResourceTriggerSelect.tsx
+++ b/packages/web/src/components/organisms/TriggersFormItems/ResourceTriggerSelect/ResourceTriggerSelect.tsx
@@ -24,46 +24,43 @@ import {StyledResourceOptionWrapper} from './ResourceTriggerSelect.styled';
 const {Option, OptGroup} = Select;
 
 interface ResourceTriggerSelectProps {
-  $allowTests: boolean;
-  $allowTestSuites: boolean;
-  disabled?: boolean;
-  value?: string;
-  onChange?: (value: string) => void;
+  allowTests: boolean;
+  allowTestSuites: boolean;
 }
 
 const ResourceTriggerSelect: FC<ResourceTriggerSelectProps> = props => {
-  const {$allowTestSuites, $allowTests, disabled, value, onChange, ...rest} = props;
+  const {allowTestSuites, allowTests, ...rest} = props;
 
   const isClusterAvailable = useSystemAccess(SystemAccess.agent);
 
   const {executors = []} = useExecutorsPick('executors');
 
-  const {data: tests = []} = useGetAllTestsQuery(null, {skip: !isClusterAvailable || !$allowTests});
-  const {data: testSuites = []} = useGetAllTestSuitesQuery(null, {
-    skip: !isClusterAvailable || !$allowTestSuites,
+  const {data: tests} = useGetAllTestsQuery(null, {skip: !isClusterAvailable || !allowTests});
+  const {data: testSuites} = useGetAllTestSuitesQuery(null, {
+    skip: !isClusterAvailable || !allowTestSuites,
   });
 
   const testsData = useMemo(() => {
-    if (!$allowTests) return [];
+    if (!allowTests || !tests) return [];
 
     return tests.map(item => ({
       name: item.test.name,
       namespace: item.test.namespace,
       type: item.test.type,
     }));
-  }, [tests, $allowTests]);
+  }, [tests, allowTests]);
 
   const testSuitesData = useMemo(() => {
-    if (!$allowTestSuites) return [];
+    if (!allowTestSuites || !testSuites) return [];
 
     return testSuites.map(item => ({
       name: item.testSuite.name,
       namespace: item.testSuite.namespace,
     }));
-  }, [testSuites, $allowTestSuites]);
+  }, [testSuites, allowTestSuites]);
 
   return (
-    <Select optionLabelProp="key" placeholder="Your testkube resource" showSearch {...props}>
+    <Select optionLabelProp="key" placeholder="Your testkube resource" showSearch {...rest}>
       {testsData.length > 0 ? (
         <OptGroup label="Tests">
           {testsData.map(item => (


### PR DESCRIPTION
## Changes

- Filter resources based on the action ( `run test` or `run testsuite` )
- Searchable resource selector
- Searchable K8s resource selector from conditions

## Fixes

- [**TKC-871:** Trigger action not filtering corresponding resources](https://linear.app/kubeshop/issue/TKC-871/%5Bui%5D-trigger-action-not-filtering-corresponding-resources)

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
