### PR TITLE
fix: show modal error instead of closing modal

### DIFF
--- a/packages/web/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
+++ b/packages/web/src/components/pages/Executors/ExecutorsList/AddExecutorsModal.tsx
@@ -55,16 +55,16 @@ const AddExecutorsModal: React.FC = () => {
 
     createExecutor(body)
       .then(displayDefaultNotificationFlow)
-      .then(res => openDetails(res.data.metadata.name))
+      .then(res => {
+        openDetails(res.data.metadata.name);
+        close();
+      })
       .catch(err => {
         setError(err);
 
         if (!inTopInViewport && topRef && topRef.current) {
           topRef.current.scrollIntoView();
         }
-      })
-      .finally(() => {
-        close();
       });
   };
 

--- a/packages/web/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
+++ b/packages/web/src/components/pages/Sources/SourcesList/AddSourceModal.tsx
@@ -61,16 +61,16 @@ const AddSourceModal: React.FC = () => {
 
     createSource(body)
       .then(displayDefaultNotificationFlow)
-      .then(res => openDetails(res.data.metadata.name))
+      .then(res => {
+        openDetails(res.data.metadata.name);
+        close();
+      })
       .catch(err => {
         setError(err);
 
         if (!inTopInViewport && topRef && topRef.current) {
           topRef.current.scrollIntoView();
         }
-      })
-      .finally(() => {
-        close();
       });
   };
 

--- a/packages/web/src/components/pages/Triggers/TriggersList/AddTriggerModal/AddTriggerModal.tsx
+++ b/packages/web/src/components/pages/Triggers/TriggersList/AddTriggerModal/AddTriggerModal.tsx
@@ -82,16 +82,16 @@ const AddTriggerModal: React.FC = () => {
     };
     createTrigger(body)
       .then(displayDefaultNotificationFlow)
-      .then(res => openDetails(res.data.name))
+      .then(res => {
+        openDetails(res.data.name);
+        close();
+      })
       .catch(err => {
         setError(err);
 
         if (!inTopInViewport && topRef && topRef.current) {
           topRef.current.scrollIntoView();
         }
-      })
-      .finally(() => {
-        close();
       });
   };
 


### PR DESCRIPTION
## Changes

- Do not close the modal when there is an error ( on create )

## Fixes

- https://github.com/kubeshop/testkube/issues/4427

## How to test it

- Try to create a trigger with the same name as one existing
- Notice the modal won't close and the error will be shown

## screenshots

![image](https://github.com/kubeshop/testkube-dashboard/assets/47887589/993ade4f-e6f1-4bd5-a272-5ec55d2a75d3)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
