### PR TITLE
feat: optional test source for container executors

### DIFF
--- a/packages/web/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationForm.tsx
+++ b/packages/web/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationForm.tsx
@@ -99,6 +99,11 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
     return executors.find((executor: Executor) => executor.executor?.types?.includes(form.getFieldValue('testType')));
   }, [form.getFieldValue('testType')]);
 
+  const isContainerExecutor = useMemo(
+    () => selectedExecutor?.executor.executorType === 'container',
+    [selectedExecutor]
+  );
+
   return (
     <Form form={form} layout="vertical" name="test-creation" onFinish={onSave} style={{flex: 1}} labelAlign="right">
       <div ref={topRef} />
@@ -114,7 +119,14 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
           <Input placeholder="e.g.: my-test" autoComplete="off" />
         </FormItem>
         <FormItem name="testType" label="Type" rules={[required]} required>
-          <Select placeholder="Select from available executors..." showSearch options={remappedExecutors} />
+          <Select
+            onChange={() => {
+              form.validateFields(['testSource']);
+            }}
+            placeholder="Select from available executors..."
+            showSearch
+            options={remappedExecutors}
+          />
         </FormItem>
         <FormItem
           noStyle
@@ -135,7 +147,12 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
             ];
 
             return (
-              <FormItem rules={[required]} label="Source" name="testSource" required>
+              <FormItem
+                rules={!isContainerExecutor ? [required] : []}
+                label="Source"
+                name="testSource"
+                required={!isContainerExecutor}
+              >
                 <Select placeholder="Select a source..." options={options} showSearch />
               </FormItem>
             );

--- a/packages/web/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationForm.tsx
+++ b/packages/web/src/components/pages/Tests/TestsList/TestCreationModalContent/TestCreationForm.tsx
@@ -148,7 +148,7 @@ const TestCreationForm: React.FC<TestCreationFormProps> = props => {
 
             return (
               <FormItem
-                rules={!isContainerExecutor ? [required] : []}
+                rules={isContainerExecutor ? [] : [required]}
                 label="Source"
                 name="testSource"
                 required={!isContainerExecutor}

--- a/packages/web/src/utils/sources.ts
+++ b/packages/web/src/utils/sources.ts
@@ -85,6 +85,11 @@ export const getTestSourceSpecificFields = (values: any, isCustomGit?: boolean) 
 
 export const getSourcePayload = (values: any, testSources: SourceWithRepository[]) => {
   const {testSource} = values;
+
+  if (!testSource) {
+    return {};
+  }
+
   const isCustomGit = testSource.includes(customGitSourceString);
 
   const testSourceSpecificFields = getTestSourceSpecificFields(values, isCustomGit);
@@ -107,7 +112,7 @@ export const getSourcePayload = (values: any, testSources: SourceWithRepository[
 };
 
 export const getCustomSourceField = (testSource: string) => {
-  const isCustomTestSource = testSource.includes(customGitSourceString);
+  const isCustomTestSource = testSource?.includes(customGitSourceString);
 
   return isCustomTestSource ? {source: testSource.replace(customGitSourceString, '')} : {source: ''};
 };


### PR DESCRIPTION
## Changes

- Make `Test source` input optional for container executors

## Fixes

- https://github.com/kubeshop/testkube/issues/3201

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
