### PR TITLE
fix: prettifying escaped arguments

### DIFF
--- a/packages/web/src/components/pages/Tests/TestDetails/TestSettings/SettingsVariables/Arguments.tsx
+++ b/packages/web/src/components/pages/Tests/TestDetails/TestSettings/SettingsVariables/Arguments.tsx
@@ -22,6 +22,7 @@ import Colors from '@styles/Colors';
 
 import {externalLinks} from '@utils/externalLinks';
 import {displayDefaultNotificationFlow} from '@utils/notification';
+import {prettifyArguments} from '@utils/prettifyArguments';
 
 import {ArgumentsWrapper} from './Arguments.styled';
 
@@ -83,12 +84,7 @@ const Arguments: React.FC<ArgumentsProps> = ({readOnly}) => {
   };
 
   const prettifyArgs = () => {
-    const args = form
-      .getFieldValue('args')
-      .replace(/(".*?")|('.*?')|\s/g, (_: string, str1: string, str2: string) => str1 || str2 || '\n')
-      .replace(/\n{2,}/g, '\n')
-      .trim();
-    form.setFieldValue('args', args);
+    form.setFieldValue('args', prettifyArguments(form.getFieldValue('args')));
     setPrettifiedState(true);
   };
 

--- a/packages/web/src/utils/prettifyArguments.spec.ts
+++ b/packages/web/src/utils/prettifyArguments.spec.ts
@@ -1,0 +1,78 @@
+import {prettifyArguments} from './prettifyArguments';
+
+describe('utils', () => {
+  describe('prettifyArguments', () => {
+    it('should handle empty string', () => {
+      expect(prettifyArguments('')).toBe('');
+      expect(prettifyArguments('  \t \n  ')).toBe('');
+    });
+
+    it('should support options with no quoted arguments', () => {
+      expect(prettifyArguments(`-c . --dash-value --value abc`)).toBe(`-c
+.
+--dash-value
+--value
+abc`);
+    });
+
+    it('should support options with no quoted arguments', () => {
+      expect(prettifyArguments(`-c . --dash-value --value abc`)).toBe(`-c
+.
+--dash-value
+--value
+abc`);
+    });
+
+    it('should handle quoted simple arguments', () => {
+      expect(prettifyArguments(`-c 'abc' --value "abc" --value2="abc" --value3='def'`)).toBe(`-c
+'abc'
+--value
+"abc"
+--value2="abc"
+--value3='def'`);
+    });
+
+    it('should handle quoted arguments with spaces', () => {
+      expect(prettifyArguments(`-c 'ab c' --value "ab c" --value2="ab c" --value3='de f'`)).toBe(`-c
+'ab c'
+--value
+"ab c"
+--value2="ab c"
+--value3='de f'`);
+    });
+
+    it('should handle quoted arguments with different quotes inside', () => {
+      expect(prettifyArguments(`-c 'ab "c' --value "ab 'c" --value2="ab 'c" --value3='de "f'`)).toBe(`-c
+'ab "c'
+--value
+"ab 'c"
+--value2="ab 'c"
+--value3='de "f'`);
+    });
+
+    it('should handle quoted arguments with escaped quotes inside', () => {
+      expect(prettifyArguments(`-c 'ab \\'c' --value "ab \\"c" --value2="ab \\"c" --value3='de \\'f'`)).toBe(`-c
+'ab \\'c'
+--value
+"ab \\"c"
+--value2="ab \\"c"
+--value3='de \\'f'`);
+    });
+
+    it('should handle quoted arguments with escaped quotes inside', () => {
+      expect(prettifyArguments(`-c 'ab \\'c' --value "ab \\"c" --value2="ab \\"c" --value3='de \\'f'`)).toBe(`-c
+'ab \\'c'
+--value
+"ab \\"c"
+--value2="ab \\"c"
+--value3='de \\'f'`);
+    });
+
+    it('should handle escaped spaces', () => {
+      expect(prettifyArguments(`-c ab\\ c\\ def\\\tghi another\\\nabcdef`)).toBe(`-c
+ab\\ c\\ def\\\tghi
+another\\
+abcdef`);
+    });
+  });
+});

--- a/packages/web/src/utils/prettifyArguments.ts
+++ b/packages/web/src/utils/prettifyArguments.ts
@@ -1,0 +1,5 @@
+export const prettifyArguments = (args: string) =>
+  args
+    .replace(/(".*?")|('.*?')|\s/g, (_: string, str1: string, str2: string) => str1 || str2 || '\n')
+    .replace(/\n{2,}/g, '\n')
+    .trim();

--- a/packages/web/src/utils/prettifyArguments.ts
+++ b/packages/web/src/utils/prettifyArguments.ts
@@ -1,5 +1,4 @@
 export const prettifyArguments = (args: string) =>
-  args
-    .replace(/(".*?")|('.*?')|\s/g, (_: string, str1: string, str2: string) => str1 || str2 || '\n')
-    .replace(/\n{2,}/g, '\n')
-    .trim();
+  Array.from(args.match(/(\\.|("(\\.|[^"])*")|('(\\.|[^'])*')|\S)+/g) || [])
+    .map(x => x.trim())
+    .join('\n');


### PR DESCRIPTION
## Changes

- Move prettifying arguments helper to a separate file
- Support escaping arguments there
- Add unit tests

## Fixes

<img width="1294" alt="Zrzut ekranu 2023-11-17 o 10 11 54" src="https://github.com/kubeshop/testkube-dashboard/assets/3843526/5ca9cf85-1364-47d8-a259-e13a03d28986">


## How to test it

- Unit tests or Test Details > Arguments

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
