### PR TITLE
refactor: mark execution step item as anchor link

### DIFF
--- a/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
+++ b/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
@@ -42,7 +42,7 @@ export const ExecutionStepsListItem = styled.ul`
   }
 `;
 
-export const ExecutionStepsListItemExecution = styled.a`
+export const ExecutionStepsListItemExecution = styled.li`
   display: flex;
   align-items: center;
 

--- a/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
+++ b/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
@@ -1,3 +1,5 @@
+import {NavLink} from 'react-router-dom';
+
 import {Space} from 'antd';
 
 import styled from 'styled-components';
@@ -42,7 +44,7 @@ export const ExecutionStepsListItem = styled.ul`
   }
 `;
 
-export const ExecutionStepsListItemExecution = styled.li`
+export const ExecutionStepsListItemExecution = styled(NavLink)`
   display: flex;
   align-items: center;
 

--- a/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
+++ b/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.styled.tsx
@@ -42,7 +42,7 @@ export const ExecutionStepsListItem = styled.ul`
   }
 `;
 
-export const ExecutionStepsListItemExecution = styled.li`
+export const ExecutionStepsListItemExecution = styled.a`
   display: flex;
   align-items: center;
 

--- a/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -1,4 +1,5 @@
 import {FC, memo, useMemo} from 'react';
+import {NavLink} from 'react-router-dom';
 
 import {ClockCircleOutlined} from '@ant-design/icons';
 
@@ -9,8 +10,6 @@ import {ExecutorIcon, StatusIcon} from '@atoms';
 import {TestSuiteStepExecutionResult} from '@models/testSuite';
 
 import {ExecutionName} from '@molecules';
-
-import {useRouterPlugin} from '@plugins/router/hooks';
 
 import {getTestExecutorIcon} from '@redux/utils/executorIcon';
 
@@ -30,8 +29,6 @@ type ExecutionStepsListProps = {
 
 const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
   const {executionSteps} = props;
-
-  const {baseUrl, navigate} = useRouterPlugin.pick('baseUrl', 'navigate');
 
   const {executors = []} = useExecutorsPick('executors');
 
@@ -67,17 +64,15 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
             };
           })
           .map(({status, icon, name, url}, index) => (
-            <ExecutionStepsListItemExecution
-              key={url}
-              className={classNames({clickable: url})}
-              href={url ? `${baseUrl}${url}` : '#'}
-            >
-              <StyledSpace size={15}>
-                {status ? <StatusIcon status={status} /> : null}
-                {icon}
-                <ExecutionName name={name} />
-                {url ? <StyledExternalLinkIcon /> : <div />}
-              </StyledSpace>
+            <ExecutionStepsListItemExecution key={url ?? index} className={classNames({clickable: url})}>
+              <NavLink to={url ?? ''}>
+                <StyledSpace size={15}>
+                  {status ? <StatusIcon status={status} /> : null}
+                  {icon}
+                  <ExecutionName name={name} />
+                  {url ? <StyledExternalLinkIcon /> : <div />}
+                </StyledSpace>
+              </NavLink>
             </ExecutionStepsListItemExecution>
           ));
 

--- a/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -31,7 +31,7 @@ type ExecutionStepsListProps = {
 const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
   const {executionSteps} = props;
 
-  const {navigate} = useRouterPlugin.pick('navigate');
+  const {baseUrl, navigate} = useRouterPlugin.pick('baseUrl', 'navigate');
 
   const {executors = []} = useExecutorsPick('executors');
 
@@ -68,10 +68,9 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
           })
           .map(({status, icon, name, url}, index) => (
             <ExecutionStepsListItemExecution
-              // eslint-disable-next-line react/no-array-index-key
-              key={`item-${index}`}
+              key={url}
               className={classNames({clickable: url})}
-              onClick={url ? () => navigate(url) : undefined}
+              href={url ? `${baseUrl}${url}` : '#'}
             >
               <StyledSpace size={15}>
                 {status ? <StatusIcon status={status} /> : null}

--- a/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
+++ b/packages/web/src/components/molecules/ExecutionStepsList/ExecutionStepsList.tsx
@@ -1,5 +1,4 @@
 import {FC, memo, useMemo} from 'react';
-import {NavLink} from 'react-router-dom';
 
 import {ClockCircleOutlined} from '@ant-design/icons';
 
@@ -64,15 +63,14 @@ const ExecutionStepsList: FC<ExecutionStepsListProps> = props => {
             };
           })
           .map(({status, icon, name, url}, index) => (
-            <ExecutionStepsListItemExecution key={url ?? index} className={classNames({clickable: url})}>
-              <NavLink to={url ?? ''}>
-                <StyledSpace size={15}>
-                  {status ? <StatusIcon status={status} /> : null}
-                  {icon}
-                  <ExecutionName name={name} />
-                  {url ? <StyledExternalLinkIcon /> : <div />}
-                </StyledSpace>
-              </NavLink>
+            // eslint-disable-next-line react/no-array-index-key
+            <ExecutionStepsListItemExecution key={index} to={url ?? ''} className={classNames({clickable: url})}>
+              <StyledSpace size={15}>
+                {status ? <StatusIcon status={status} /> : null}
+                {icon}
+                <ExecutionName name={name} />
+                {url ? <StyledExternalLinkIcon /> : <div />}
+              </StyledSpace>
             </ExecutionStepsListItemExecution>
           ));
 


### PR DESCRIPTION
Issue https://github.com/kubeshop/testkube/issues/4624

## Changes

- Have test suite execution step as anchor link so that people could cmd/ctrl click to open in a new tab

## screenshots

https://github.com/kubeshop/testkube-dashboard/assets/47887589/19b6525c-f2e8-48ea-913a-b7bb0cf8cb58

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
