### PR TITLE
fix: detecting definition change

### DIFF
--- a/packages/web/src/components/molecules/Definition/Definition.tsx
+++ b/packages/web/src/components/molecules/Definition/Definition.tsx
@@ -70,6 +70,7 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
 
   useEffect(() => {
     setValue(definition);
+    setWasTouched(false);
   }, [definition]);
 
   const onSave = async () => {

--- a/packages/web/src/components/molecules/Definition/Definition.tsx
+++ b/packages/web/src/components/molecules/Definition/Definition.tsx
@@ -11,6 +11,7 @@ import {Pre} from '@atoms';
 import {FullWidthSpace} from '@custom-antd';
 
 import useClusterVersionMatch from '@hooks/useClusterVersionMatch';
+import {useLastCallback} from '@hooks/useLastCallback';
 import {SystemAccess, useSystemAccess} from '@hooks/useSystemAccess';
 
 import {InlineNotification, notificationCall} from '@molecules';
@@ -64,14 +65,16 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
     skip: !isReadable,
   });
 
+  const resetValue = useLastCallback(() => {
+    setValue(definition);
+    setWasTouched(false);
+  });
+
   useEffect(() => {
     safeRefetch(refetch);
   }, []);
 
-  useEffect(() => {
-    setValue(definition);
-    setWasTouched(false);
-  }, [definition]);
+  useEffect(resetValue, [definition]);
 
   const onSave = async () => {
     const monaco = await import('react-monaco-editor').then(editor => editor.monaco);
@@ -123,10 +126,7 @@ const Definition: React.FC<PropsWithChildren<DefinitionProps>> = props => {
         title="Definition"
         description={`Validate and update your ${label} configuration`}
         onConfirm={onSave}
-        onCancel={() => {
-          setValue(definition);
-          setWasTouched(false);
-        }}
+        onCancel={resetValue}
         readOnly={!isSupported || readOnly}
         wasTouched={wasTouched}
       >


### PR DESCRIPTION
## Changes

- Change the Definition's form state to untouched when using a new value from back-end

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
