### PR TITLE
CLI Commands for Test & TestSuite update

### DIFF
--- a/packages/web/src/components/molecules/CLICommands/CLICommands.tsx
+++ b/packages/web/src/components/molecules/CLICommands/CLICommands.tsx
@@ -16,7 +16,12 @@ import {useTelemetry} from '@telemetry/hooks';
 
 import CopyCommand from './CopyCommand';
 
-type CLIScriptModifier = 'isFinished' | 'canHaveArtifacts' | 'isRunPermission' | 'isDeletePermission';
+type CLIScriptModifier =
+  | 'isFinished'
+  | 'canHaveArtifacts'
+  | 'isRunPermission'
+  | 'isDeletePermission'
+  | 'isEditPermission';
 
 type CLIScript = {
   label: string;
@@ -44,6 +49,11 @@ const testSuiteScripts: CLIScript[] = [
     command: (name: string, args: string[]) => `kubectl testkube run testsuite ${name} ${args.join(' ')}`,
   },
   {
+    label: 'Update test suite',
+    modify: 'isEditPermission',
+    command: (name: string, args: string[]) => `kubectl testkube update testsuite --name ${name} ${args.join(' ')}`,
+  },
+  {
     label: 'Delete test suite',
     command: (name: string, args: string[]) => `kubectl testkube delete testsuite ${name} ${args.join(' ')}`,
     modify: 'isDeletePermission',
@@ -59,6 +69,11 @@ const testScripts: CLIScript[] = [
   {
     label: 'Get test',
     command: (name: string, args: string[]) => `kubectl testkube get test ${name} ${args.join(' ')}`,
+  },
+  {
+    label: 'Update test',
+    command: (name: string, args: string[]) => `kubectl testkube update test --name ${name} ${args.join(' ')}`,
+    modify: 'isEditPermission',
   },
   {
     label: 'List executions',
@@ -107,12 +122,16 @@ const modifyActions: Record<CLIScriptModifier, (arg: boolean | string) => boolea
   isDeletePermission: hasPermission => {
     return !hasPermission;
   },
+  isEditPermission: hasPermission => {
+    return !hasPermission;
+  },
 };
 
 const CLICommands: React.FC<CLICommandsProps> = props => {
   const {isExecutions, type, name, id, modifyMap, bg} = props;
   const mayRun = usePermission(Permissions.runEntity);
   const mayDelete = usePermission(Permissions.deleteEntity);
+  const mayEdit = usePermission(Permissions.editEntity);
 
   const {entity} = useEntityDetailsPick('entity');
   const telemetry = useTelemetry();
@@ -126,6 +145,7 @@ const CLICommands: React.FC<CLICommandsProps> = props => {
     isFinished: modifyMap?.status,
     isRunPermission: mayRun,
     isDeletePermission: mayDelete,
+    isEditPermission: mayEdit,
   };
 
   const renderedCLICommands = useMemo(() => {


### PR DESCRIPTION
This PR...

## Changes

Closes the following issue: https://github.com/kubeshop/testkube/issues/1617

## Notes

- We have a `literalToColor` map that defines colors for each literal, and the color for the `update` literal within the commands is set to `amber300` , which is different from the color that `get` and `delete` have. Not sure if we want to align the colors as it might break the design in other places? @fivenp 

- The `update` commands require passing `--name`, they do not work like the other commands.

## Screenshots

![image](https://github.com/kubeshop/testkube-dashboard/assets/20538711/6a50bb79-cdfd-4104-928d-e305d6514ca8)

![image](https://github.com/kubeshop/testkube-dashboard/assets/20538711/673f99aa-cd07-4a7c-b9ee-ff9190d353dd)

