### PR TITLE
feat: add telemetry events and IDs for the promo banners

### DIFF
--- a/packages/web/src/components/molecules/MessagePanel/MessagePanel.tsx
+++ b/packages/web/src/components/molecules/MessagePanel/MessagePanel.tsx
@@ -26,6 +26,7 @@ interface ButtonWithLinkConfig extends ButtonConfig {
 }
 
 export interface MessagePanelProps {
+  id?: string;
   title: string;
   description: React.ReactNode;
   type?: 'warning' | 'error' | 'default';
@@ -50,10 +51,10 @@ const textColorForType: Record<string, Record<string, Colors>> = {
 };
 
 const MessagePanel: React.FC<MessagePanelProps> = props => {
-  const {type = 'error', title, description, position = 'inline', buttons, onClose} = props;
+  const {id, type = 'error', title, description, position = 'inline', buttons, onClose} = props;
 
   return (
-    <MessagePanelWrapper className={`${type} ${position}`}>
+    <MessagePanelWrapper id={id} className={`${type} ${position}`}>
       <MessageDescription>
         <Text className="bold middle" color={textColorForType[type].header}>
           {title}
@@ -68,6 +69,7 @@ const MessagePanel: React.FC<MessagePanelProps> = props => {
             if ('isLink' in button) {
               return (
                 <a
+                  id={button.id}
                   key={button.linkConfig.href}
                   href={button.linkConfig.href}
                   target={button.linkConfig.target}
@@ -81,7 +83,7 @@ const MessagePanel: React.FC<MessagePanelProps> = props => {
             }
 
             return (
-              <Button $customType={button.type} key={button.type} onClick={button.onClick}>
+              <Button $customType={button.type} key={button.type} id={button.id} onClick={button.onClick}>
                 {button.text}
               </Button>
             );

--- a/packages/web/src/plugins/promo-banners/components/PromoBanner.tsx
+++ b/packages/web/src/plugins/promo-banners/components/PromoBanner.tsx
@@ -7,6 +7,8 @@ import {MessagePanel} from '@molecules';
 
 import {usePromoBannersPlugin} from '@plugins/promo-banners/hooks';
 
+import {useTelemetry} from '@telemetry/hooks';
+
 import {PromoBannerPosition} from '../config';
 import {useDisplayedPromoBanner} from '../hooks/useDisplayedPromoBanner';
 import {applyUrlParams} from '../utils/applyUrlParams';
@@ -18,11 +20,17 @@ export interface PromoBannerProps {
 }
 
 export const PromoBanner: FC<PromoBannerProps> = ({position, style, className}) => {
+  const telemetry = useTelemetry();
   const navigate = useNavigate();
   const params = useParams();
   const {bannersClose} = usePromoBannersPlugin.pick('bannersClose');
   const close = useLastCallback(() => bannersClose(banner!.id));
+  const trackAndClose = useLastCallback(() => {
+    telemetry.event('promoBannerCloseClick', {id: banner?.id});
+    close();
+  });
   const banner = useDisplayedPromoBanner(position);
+  const id = banner?.id ? banner.id.replace(/[^a-zA-Z0-9-_]/g, '-') : null;
 
   const buttons = useMemo(
     () => [
@@ -31,12 +39,14 @@ export const PromoBanner: FC<PromoBannerProps> = ({position, style, className}) 
             {
               type: 'secondary' as const,
               text: banner!.secondaryLink.label,
+              id: `promo-banner-secondary_${id}`,
               isLink: true,
               linkConfig: {
                 href: applyUrlParams(banner!.secondaryLink.url, params),
                 target: banner!.secondaryLink!.target,
               },
               onClick: (event: any) => {
+                telemetry.event('promoBannerSecondaryClick', {id: banner.id});
                 if (banner!.secondaryLink!.url.startsWith('/') && banner!.secondaryLink!.target === '_top') {
                   event.preventDefault();
                   navigate(applyUrlParams(banner!.secondaryLink!.url, params));
@@ -50,9 +60,11 @@ export const PromoBanner: FC<PromoBannerProps> = ({position, style, className}) 
             {
               type: 'primary' as const,
               text: banner!.primaryLink.label,
+              id: `promo-banner-primary_${id}`,
               isLink: true,
               linkConfig: {href: applyUrlParams(banner!.primaryLink.url, params), target: banner!.primaryLink!.target},
               onClick: (event: any) => {
+                telemetry.event('promoBannerPrimaryClick', {id: banner.id});
                 close();
                 if (banner!.primaryLink!.url.startsWith('/') && banner!.primaryLink!.target === '_top') {
                   event.preventDefault();
@@ -69,12 +81,13 @@ export const PromoBanner: FC<PromoBannerProps> = ({position, style, className}) 
   return banner ? (
     <div style={style} className={className}>
       <MessagePanel
+        id={`promo-banner-container_${id}`}
         key={banner.id}
         title={banner.title}
         description={banner.description}
         type={banner.type}
         buttons={buttons}
-        onClose={banner.permanent ? undefined : close}
+        onClose={banner.permanent ? undefined : trackAndClose}
       />
     </div>
   ) : null;

--- a/telemetry.md
+++ b/telemetry.md
@@ -116,17 +116,6 @@
     </tr>
     <tr valign="top">
       <td>
-        <strong>promoBannerCloseClick</strong><br>
-        <code>tk.ui.promoBannerCloseClick</code>
-      </td>
-      <td>
-        Fired when the user clicks "X" button in promo banner.
-      </td>
-      <td><code>eventModel.id</code></td>
-      <td>The unique ID for the promo banner</td>
-    </tr>
-    <tr valign="top">
-      <td>
         <strong>promoBannerPrimaryClick</strong><br>
         <code>tk.ui.promoBannerPrimaryClick</code>
       </td>

--- a/telemetry.md
+++ b/telemetry.md
@@ -103,5 +103,49 @@
       <td><code>eventModel.duration</code></td>
       <td>Time spent on the page (in ms)</td>
     </tr>
+    <tr valign="top">
+      <td>
+        <strong>promoBannerCloseClick</strong><br>
+        <code>tk.ui.promoBannerCloseClick</code>
+      </td>
+      <td>
+        Fired when the user clicks "X" button in promo banner.
+      </td>
+      <td><code>eventModel.id</code></td>
+      <td>The unique ID for the promo banner</td>
+    </tr>
+    <tr valign="top">
+      <td>
+        <strong>promoBannerCloseClick</strong><br>
+        <code>tk.ui.promoBannerCloseClick</code>
+      </td>
+      <td>
+        Fired when the user clicks "X" button in promo banner.
+      </td>
+      <td><code>eventModel.id</code></td>
+      <td>The unique ID for the promo banner</td>
+    </tr>
+    <tr valign="top">
+      <td>
+        <strong>promoBannerPrimaryClick</strong><br>
+        <code>tk.ui.promoBannerPrimaryClick</code>
+      </td>
+      <td>
+        Fired when the user clicks the primary button in the promo banner.
+      </td>
+      <td><code>eventModel.id</code></td>
+      <td>The unique ID for the promo banner</td>
+    </tr>
+    <tr valign="top">
+      <td>
+        <strong>promoBannerSecondaryClick</strong><br>
+        <code>tk.ui.promoBannerSecondaryClick</code>
+      </td>
+      <td>
+        Fired when the user clicks the secondary button in the promo banner.
+      </td>
+      <td><code>eventModel.id</code></td>
+      <td>The unique ID for the promo banner</td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Changes

- add telemetry events for the promo banners
- add IDs for the promo banners

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
