### PR TITLE
Search & Status filters for Executions

### DIFF
--- a/packages/web/src/components/atoms/EmptyDataWithFilters/EmptyDataWithFilters.styled.tsx
+++ b/packages/web/src/components/atoms/EmptyDataWithFilters/EmptyDataWithFilters.styled.tsx
@@ -1,0 +1,18 @@
+import {Space} from 'antd';
+
+import styled from 'styled-components';
+
+export const EmptyTestsDataContainer = styled(Space)`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+`;

--- a/packages/web/src/components/atoms/EmptyDataWithFilters/EmptyDataWithFilters.tsx
+++ b/packages/web/src/components/atoms/EmptyDataWithFilters/EmptyDataWithFilters.tsx
@@ -1,7 +1,3 @@
-import {Space} from 'antd';
-
-import styled from 'styled-components';
-
 import {ReactComponent as EmptySearch} from '@assets/empty-search.svg';
 
 import {Button, Text, Title} from '@custom-antd';
@@ -10,15 +6,7 @@ import {SystemAccess, useSystemAccess} from '@hooks/useSystemAccess';
 
 import Colors from '@styles/Colors';
 
-import {StyledButtonContainer} from './EntityListContent.styled';
-
-const StyledEmptyTestsDataContainer = styled(Space)`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
+import * as S from './EmptyDataWithFilters.styled';
 
 const EmptyDataWithFilters: React.FC<any> = props => {
   const {resetFilters} = props;
@@ -26,18 +14,18 @@ const EmptyDataWithFilters: React.FC<any> = props => {
   const isClusterAvailable = useSystemAccess(SystemAccess.agent);
 
   return (
-    <StyledEmptyTestsDataContainer size={30} direction="vertical">
+    <S.EmptyTestsDataContainer size={30} direction="vertical">
       <EmptySearch />
       <Title className="text-center">No results found</Title>
       <Text className="regular middle text-center" color={Colors.slate400}>
         We couldn’t find any results for your filters.
       </Text>
-      <StyledButtonContainer>
+      <S.ButtonContainer>
         <Button type="primary" onClick={() => resetFilters()} disabled={!isClusterAvailable}>
           Reset all filters
         </Button>
-      </StyledButtonContainer>
-    </StyledEmptyTestsDataContainer>
+      </S.ButtonContainer>
+    </S.EmptyTestsDataContainer>
   );
 };
 

--- a/packages/web/src/components/atoms/EmptyDataWithFilters/index.ts
+++ b/packages/web/src/components/atoms/EmptyDataWithFilters/index.ts
@@ -1,0 +1,1 @@
+export {default} from './EmptyDataWithFilters';

--- a/packages/web/src/components/molecules/FilterMenu/FilterMenuFooter/FilterMenuFooter.tsx
+++ b/packages/web/src/components/molecules/FilterMenu/FilterMenuFooter/FilterMenuFooter.tsx
@@ -4,7 +4,7 @@ import {StyledSpace} from './FilterMenuFooter.styled';
 
 type FilterMenuFooterProps = {
   onReset: () => void;
-  onOk: () => void;
+  onOk?: () => void;
   onCancel?: () => void;
 };
 
@@ -20,9 +20,11 @@ const FilterMenuFooter: React.FC<FilterMenuFooterProps> = props => {
       <Button $customType="secondary" onClick={onReset}>
         Reset
       </Button>
-      <Button $customType="primary" onClick={onOk}>
-        Ok
-      </Button>
+      {onOk && (
+        <Button $customType="primary" onClick={onOk}>
+          Ok
+        </Button>
+      )}
     </StyledSpace>
   );
 };

--- a/packages/web/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
+++ b/packages/web/src/components/organisms/EntityList/EntityListContent/EntityListContent.tsx
@@ -3,6 +3,8 @@ import {useSearchParams} from 'react-router-dom';
 
 import {isEqual, merge} from 'lodash';
 
+import EmptyDataWithFilters from '@atoms/EmptyDataWithFilters';
+
 import {Button} from '@custom-antd';
 
 import {SystemAccess, useSystemAccess} from '@hooks/useSystemAccess';
@@ -24,7 +26,6 @@ import {useApiEndpoint} from '@services/apiEndpoint';
 
 import Filters from '../EntityListFilters';
 
-import EmptyDataWithFilters from './EmptyDataWithFilters';
 import {StyledFiltersSection} from './EntityListContent.styled';
 
 const EntityListContent: React.FC<EntityListBlueprint> = props => {

--- a/packages/web/src/components/organisms/ExecutionsTable/ExecutionStatusFilter.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/ExecutionStatusFilter.tsx
@@ -1,0 +1,100 @@
+import {useCallback, useMemo, useState} from 'react';
+
+import {FilterFilled} from '@ant-design/icons';
+
+import {capitalize} from 'lodash';
+
+import {FilterProps} from '@models/filters';
+
+import {
+  FilterMenuFooter,
+  StyledFilterCheckbox,
+  StyledFilterDropdown,
+  StyledFilterLabel,
+  StyledFilterMenu,
+  StyledFilterMenuItem,
+} from '@molecules/FilterMenu';
+
+import {initialPageSize} from '@redux/initialState';
+
+import Colors from '@styles/Colors';
+
+const statusList = ['queued', 'running', 'passed', 'failed', 'aborted', 'cancelled'];
+
+// TODO: this was copied from another StatusFilter component which should become a reusable atom component in a following PR
+const StatusFilter: React.FC<FilterProps> = props => {
+  const {filters, setFilters, isFiltersDisabled} = props;
+
+  const [isVisible, setVisibilityState] = useState(false);
+
+  const onOpenChange = (flag: boolean) => {
+    setVisibilityState(flag);
+  };
+
+  const handleClick = useCallback(
+    (status: string) => {
+      if (filters.status.includes(status)) {
+        setFilters({
+          ...filters,
+          status: filters.status.filter((currentStatus: string) => {
+            return status !== currentStatus;
+          }),
+        });
+      } else {
+        setFilters({...filters, status: [...filters.status, status], pageSize: initialPageSize});
+      }
+    },
+    [setFilters, filters]
+  );
+
+  const renderedStatuses = useMemo(() => {
+    return statusList.map(status => {
+      return (
+        <StyledFilterMenuItem key={status}>
+          <StyledFilterCheckbox
+            checked={filters.status.includes(status)}
+            onChange={() => handleClick(status)}
+            data-cy={status}
+          >
+            {capitalize(status)}
+          </StyledFilterCheckbox>
+        </StyledFilterMenuItem>
+      );
+    });
+  }, [filters.status, handleClick]);
+
+  const resetFilter = () => {
+    setFilters({...filters, status: [], pageSize: initialPageSize});
+    onOpenChange(false);
+  };
+
+  const menu = (
+    <StyledFilterMenu data-cy="status-filter-dropdown">
+      {renderedStatuses}
+      <FilterMenuFooter onReset={resetFilter} />
+    </StyledFilterMenu>
+  );
+
+  const isFilterApplied = filters.status.length > 0;
+
+  return (
+    <StyledFilterDropdown
+      overlay={menu}
+      trigger={['click']}
+      placement="bottom"
+      onOpenChange={onOpenChange}
+      open={isVisible}
+      disabled={isFiltersDisabled}
+    >
+      <StyledFilterLabel
+        onClick={e => e.preventDefault()}
+        data-cy="status-filter-button"
+        isFiltersDisabled={isFiltersDisabled}
+      >
+        Status <FilterFilled style={{color: isFilterApplied ? Colors.purple : Colors.slate500}} />
+      </StyledFilterLabel>
+    </StyledFilterDropdown>
+  );
+};
+
+export default StatusFilter;

--- a/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.styled.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.styled.tsx
@@ -1,0 +1,17 @@
+import {Input} from 'antd';
+
+import styled from 'styled-components';
+
+export const FiltersContainer = styled.div`
+  margin-bottom: 24px;
+  display: flex;
+`;
+
+export const StatusFilterContainer = styled.div`
+  margin-left: 8px;
+  width: 100px;
+`;
+
+export const SearchInput = styled(Input)`
+  width: 300px;
+`;

--- a/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
@@ -1,14 +1,18 @@
-import React, {memo, useCallback, useMemo} from 'react';
+import React, {memo, useCallback, useMemo, useState} from 'react';
 
-import {Table, TablePaginationConfig} from 'antd';
+import {Input, Table, TablePaginationConfig} from 'antd';
 import {TableRowSelection} from 'antd/lib/table/interface';
 
 import {UseMutation} from '@reduxjs/toolkit/dist/query/react/buildHooks';
 import {MutationDefinition} from '@reduxjs/toolkit/query';
 
+import debounce from 'lodash.debounce';
+
 import {Skeleton} from '@custom-antd';
 
 import {SystemAccess, useSystemAccess} from '@hooks/useSystemAccess';
+
+import {useGetTestExecutionsByIdQuery} from '@services/tests';
 
 import {useEntityDetailsField, useEntityDetailsPick} from '@store/entityDetails';
 import {useExecutionDetailsPick} from '@store/executionDetails';
@@ -24,10 +28,29 @@ interface ExecutionsTableProps {
 const getKey = (record: any) => record.id;
 
 const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecution}) => {
+  const [textSearch, _setTextSearch] = useState<string>();
+  const setTextSearch = useCallback(debounce(_setTextSearch, 300), [_setTextSearch]);
+
   const [currentPage, setCurrentPage] = useEntityDetailsField('currentPage');
-  const {executions, id, isFirstTimeLoading} = useEntityDetailsPick('executions', 'id', 'isFirstTimeLoading');
+  const {
+    executions: entityExecutions,
+    id,
+    isFirstTimeLoading,
+  } = useEntityDetailsPick('executions', 'id', 'isFirstTimeLoading');
   const {id: execId, open} = useExecutionDetailsPick('id', 'open');
   const isWritable = useSystemAccess(SystemAccess.agent);
+
+  const {data: filteredExecutions} = useGetTestExecutionsByIdQuery(
+    {
+      id: id!,
+      textSearch,
+    },
+    {
+      skip: !id || !textSearch || !textSearch.trim().length,
+    }
+  );
+
+  const executions = useMemo(() => filteredExecutions || entityExecutions, [filteredExecutions, entityExecutions]);
 
   const rowSelection: TableRowSelection<any> = useMemo(
     () => ({
@@ -89,16 +112,19 @@ const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecuti
   }
 
   return (
-    <Table
-      className="custom-table"
-      showHeader={false}
-      dataSource={executions?.results}
-      columns={columns}
-      onRow={onRow}
-      rowSelection={rowSelection}
-      rowKey={getKey}
-      pagination={pagination}
-    />
+    <>
+      <Input value={textSearch} onChange={e => setTextSearch(e.target.value)} />
+      <Table
+        className="custom-table"
+        showHeader={false}
+        dataSource={executions?.results}
+        columns={columns}
+        onRow={onRow}
+        rowSelection={rowSelection}
+        rowKey={getKey}
+        pagination={pagination}
+      />
+    </>
   );
 };
 

--- a/packages/web/src/models/execution.ts
+++ b/packages/web/src/models/execution.ts
@@ -66,3 +66,17 @@ export type ExecutionRequest = {
   httpsProxy: string;
   activeDeadlineSeconds?: number;
 };
+
+export type ExecutionTotals = {
+  results: number;
+  passed: number;
+  failed: number;
+  queued: number;
+  running: number;
+};
+
+export type TextExecutionsResponse = {
+  results: Execution[];
+  totals: ExecutionTotals;
+  filtered: ExecutionTotals;
+};

--- a/packages/web/src/services/tests.ts
+++ b/packages/web/src/services/tests.ts
@@ -1,7 +1,7 @@
 import {createApi} from '@reduxjs/toolkit/query/react';
 
 import {Artifact} from '@models/artifact';
-import {ExecutionStatusEnum} from '@models/execution';
+import {ExecutionStatusEnum, TextExecutionsResponse} from '@models/execution';
 import {MetadataResponse, YamlEditBody} from '@models/fetch';
 import {Test, TestFilters, TestWithExecution} from '@models/test';
 
@@ -38,20 +38,11 @@ export const testsApi = createApi({
       }),
       providesTags: (res, err, id) => [{type: 'Test', id}],
     }),
-    getTestExecutionsById: builder.query({
-      query: ({
-        id,
-        last = 7,
-        pageSize = 1000,
-        textSearch,
-        status,
-      }: {
-        id: string;
-        last?: number;
-        pageSize?: number;
-        textSearch?: string;
-        status?: ExecutionStatusEnum;
-      }) => {
+    getTestExecutionsById: builder.query<
+      TextExecutionsResponse,
+      {id: string; last?: number; pageSize?: number; textSearch?: string; status?: ExecutionStatusEnum}
+    >({
+      query: ({id, last = 7, pageSize = 1000, textSearch, status}) => {
         const queryParams = new URLSearchParams({
           last: last.toString(),
           pageSize: pageSize.toString(),

--- a/packages/web/src/services/tests.ts
+++ b/packages/web/src/services/tests.ts
@@ -40,7 +40,7 @@ export const testsApi = createApi({
     }),
     getTestExecutionsById: builder.query<
       TextExecutionsResponse,
-      {id: string; last?: number; pageSize?: number; textSearch?: string; status?: ExecutionStatusEnum}
+      {id: string; last?: number; pageSize?: number; textSearch?: string; status?: ExecutionStatusEnum[]}
     >({
       query: ({id, last = 7, pageSize = 1000, textSearch, status}) => {
         const queryParams = new URLSearchParams({
@@ -52,8 +52,8 @@ export const testsApi = createApi({
           queryParams.append('textSearch', textSearch);
         }
 
-        if (status) {
-          queryParams.append('status', status);
+        if (status?.length) {
+          status.forEach(s => queryParams.append('status', s));
         }
 
         return {

--- a/packages/web/src/services/tests.ts
+++ b/packages/web/src/services/tests.ts
@@ -1,6 +1,7 @@
 import {createApi} from '@reduxjs/toolkit/query/react';
 
 import {Artifact} from '@models/artifact';
+import {ExecutionStatusEnum} from '@models/execution';
 import {MetadataResponse, YamlEditBody} from '@models/fetch';
 import {Test, TestFilters, TestWithExecution} from '@models/test';
 
@@ -38,11 +39,31 @@ export const testsApi = createApi({
       providesTags: (res, err, id) => [{type: 'Test', id}],
     }),
     getTestExecutionsById: builder.query({
-      query: ({id, last = 7, pageSize = 1000}) => {
+      query: ({
+        id,
+        last = 7,
+        pageSize = 1000,
+        textSearch,
+        status,
+      }: {
+        id: string;
+        last?: number;
+        pageSize?: number;
+        textSearch?: string;
+        status?: ExecutionStatusEnum;
+      }) => {
         const queryParams = new URLSearchParams({
-          last,
-          pageSize,
+          last: last.toString(),
+          pageSize: pageSize.toString(),
         });
+
+        if (textSearch) {
+          queryParams.append('textSearch', textSearch);
+        }
+
+        if (status) {
+          queryParams.append('status', status);
+        }
 
         return {
           url: `/tests/${id}/executions?${queryParams.toString()}`,


### PR DESCRIPTION
This PR...

## Changes

- Created types for `getTestExecutionsById` to get better dev experience when using `useGetTestExecutionsByIdQuery`
   - Other queries could be updated to use the types as well, maybe out of scope for this PR
- Added filters for `getTestExecutionsById`
- Refactored `ExecutionsTable` to fetch filtered executions when filters are applied
- Extracted `EmptyDataWithFilters` to be reused when there are no results based on filters

## Screenshots

![image](https://github.com/kubeshop/testkube-dashboard/assets/20538711/999cde44-0ccb-4add-9ebb-ac238da40de6)

## TODO

- [ ] PR code cleanup
- [ ] Test multiple scenarios with multiple execution types
- [ ] Extract the filter components as atoms which can be reused for filtering tests as well 
   - [ ] Pending merging PR from Razvan which has refactored the components containing the filters
   - [ ] Filters types need to be adjusted in multiple places
   - [ ] Can be done in a follow-up PR, will create separate issue

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
