### PR TITLE
fix: display next execution time for scheduled executions after time passes

### DIFF
--- a/packages/web/src/components/organisms/EntityDetails/Settings/SettingsScheduling/NextExecution.spec.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/Settings/SettingsScheduling/NextExecution.spec.tsx
@@ -1,0 +1,47 @@
+import {act, render} from '@testing-library/react';
+import parser from 'cron-parser';
+
+import NextExecution from './NextExecution';
+
+describe('organisms', () => {
+  describe('SettingsScheduling', () => {
+    describe('NextExecution', () => {
+      beforeEach(() => {
+        jest.useFakeTimers('modern').setSystemTime(new Date('2023-11-24T10:03:33'));
+      });
+
+      const expression = parser.parseExpression('*/1 * * * *');
+
+      it('should display error', () => {
+        const result = render(<NextExecution error />);
+        expect(result.container.textContent).toEqual('Invalid cron format');
+      });
+
+      it('should display information about no schedule', () => {
+        const result = render(<NextExecution />);
+        expect(result.container.textContent).toEqual('Not scheduled');
+      });
+
+      it('should display time', () => {
+        const result = render(<NextExecution expression={expression} />);
+        expect(result.container.textContent).toEqual('in 27 seconds');
+      });
+
+      it('should show now when the time is very near', () => {
+        const result = render(<NextExecution expression={expression} />);
+        act(() => {
+          jest.advanceTimersByTime(26999);
+        });
+        expect(result.container.textContent).toEqual('now');
+      });
+
+      it('should iterate with next value after queue passed', () => {
+        const result = render(<NextExecution expression={expression} />);
+        act(() => {
+          jest.advanceTimersByTime(30000);
+        });
+        expect(result.container.textContent).toEqual('in 57 seconds');
+      });
+    });
+  });
+});

--- a/packages/web/src/components/organisms/EntityDetails/Settings/SettingsScheduling/Schedule.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/Settings/SettingsScheduling/Schedule.tsx
@@ -75,17 +75,14 @@ const Schedule: React.FC<ScheduleProps> = ({label, useUpdateEntity}) => {
     setWasTouched(true);
   };
 
-  const [nextExecution, isValidFormat] = useMemo(() => {
+  const [cronExpression, isValidFormat] = useMemo(() => {
     if (!cronString) {
-      return ['Not scheduled', true];
+      return [undefined, true];
     }
-
     try {
-      const nextDate = parser.parseExpression(cronString).next().toDate();
-
-      return [nextDate, true];
+      return [parser.parseExpression(cronString), true];
     } catch (e) {
-      return ['Invalid cron format', false];
+      return [undefined, false];
     }
   }, [cronString]);
 
@@ -158,7 +155,7 @@ const Schedule: React.FC<ScheduleProps> = ({label, useUpdateEntity}) => {
             <StyledColumn>
               <Text className="middle regular">Next Execution</Text>
               <Text style={{color: Colors.slate400}} className="middle regular">
-                <NextExecution value={nextExecution} />
+                <NextExecution expression={cronExpression} error={!isValidFormat} />
               </Text>
             </StyledColumn>
           </StyledRow>


### PR DESCRIPTION
## Changes

- fix: display next execution time for scheduled executions after time passes

## Fixes

- https://github.com/kubeshop/testkube/issues/4682

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
