### PR TITLE
fix: executions bar chart popover alignment

### DIFF
--- a/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltipPure.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltipPure.tsx
@@ -27,7 +27,7 @@ type BarConfigPure = BarConfig & {
 };
 
 const BarWithTooltipPure: React.FC<BarConfigPure> = memo(props => {
-  const {width, height, color, status, duration, name, startTime, chartHeight, hoverColor, date, onSelect} = props;
+  const {width, height, color, status, duration, name, startTime, hoverColor, date, onSelect} = props;
 
   const onBarClicked = useCallback(() => onSelect(name), [onSelect, name]);
 

--- a/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltipPure.tsx
+++ b/packages/web/src/components/molecules/MetricsBarChart/components/BarWithTooltipPure.tsx
@@ -52,7 +52,7 @@ const BarWithTooltipPure: React.FC<BarConfigPure> = memo(props => {
   );
 
   return (
-    <Popover content={popoverContent} align={{offset: [0, chartHeight - height - tooltipYOffsetMargin]}}>
+    <Popover content={popoverContent} align={{offset: [0, tooltipYOffsetMargin]}}>
       <ClickableBar style={{height, width}} $color={color} hoverColor={hoverColor} onClick={onBarClicked}>
         {date ? <BarDate $height={height}>{date}</BarDate> : undefined}
       </ClickableBar>


### PR DESCRIPTION


## Fixes

- Alignment of executions chart bar popover 

## How to test it

-

## screenshots

Before:

![image](https://github.com/kubeshop/testkube-dashboard/assets/47887589/7afe582a-0748-4633-a596-db05271ce46f)

After:

![image](https://github.com/kubeshop/testkube-dashboard/assets/47887589/9757bebd-15f5-4353-9506-824688840fd9)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
