### PR TITLE
feat: add syncSubscribe() method for plugins

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -132,6 +132,12 @@ export default createPlugin('some-plugin-name')
         // Using .provider() is more convenient though.
         const isLoading = tk.sync(() => useSomeStoreData('loading'));
         tk.slots.somePluginStub.someOtherSlot.add(<>Loading...</>, {enabled: isLoading});
+        
+        // When you need to ensure that the slot usage will be updated immediately after .sync() change,
+        // you may use .syncSubscribe() function instead.
+        // It's a bit slower, as it will emit the change to all scopes.
+        const isLoadingAsap = tk.sync(() => useSomeStoreData('loading'));
+        tk.slots.somePluginStub.someOtherSlot.add(<>Loading...</>, {enabled: isLoadingAsap});
     });
 ```
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -136,7 +136,7 @@ export default createPlugin('some-plugin-name')
         // When you need to ensure that the slot usage will be updated immediately after .sync() change,
         // you may use .syncSubscribe() function instead.
         // It's a bit slower, as it will emit the change to all scopes.
-        const isLoadingAsap = tk.sync(() => useSomeStoreData('loading'));
+        const isLoadingAsap = tk.syncSubscribe(() => useSomeStoreData('loading'));
         tk.slots.somePluginStub.someOtherSlot.add(<>Loading...</>, {enabled: isLoadingAsap});
     });
 ```

--- a/packages/plugins/src/internal/PluginScope.ts
+++ b/packages/plugins/src/internal/PluginScope.ts
@@ -201,10 +201,10 @@ export class PluginScope<T extends PluginScopeState> {
   public syncSubscribe<U>(fn: () => U, defaultValue?: undefined): () => U | undefined;
   public syncSubscribe<U>(fn: () => U, defaultValue?: U): () => U | undefined {
     if (this[PluginScopeDisableNewSyncStatus]) {
-      throw new Error('The sync() factory may be executed only during initialization.');
+      throw new Error('The syncSubscribe() factory may be executed only during initialization.');
     }
 
-    const wrappedFn = (prevValue: U | undefined) => {
+    const wrappedFn = (prevValue: U | undefined = defaultValue) => {
       const nextValue = fn();
       let root: PluginScope<any> = this;
       while (root[PluginScopeParentScope]) {

--- a/packages/plugins/src/internal/PluginScope.ts
+++ b/packages/plugins/src/internal/PluginScope.ts
@@ -125,7 +125,7 @@ export class PluginScope<T extends PluginScopeState> {
 
   public [PluginScopeCallSync](): void {
     Array.from(this[PluginScopeSyncData].keys()).forEach(fn => {
-      this[PluginScopeSyncData].set(fn, fn());
+      this[PluginScopeSyncData].set(fn, fn(this[PluginScopeSyncData].get(fn)));
     });
   }
 
@@ -185,6 +185,36 @@ export class PluginScope<T extends PluginScopeState> {
     }
 
     const wrappedFn = () => fn();
+    this[PluginScopeSyncData].set(wrappedFn, undefined);
+    return () => this[PluginScopeSyncData].get(wrappedFn) ?? defaultValue;
+  }
+
+  /**
+   * Transfer data from React to the plugin context.
+   *
+   * The difference from sync() is, that it will emit change in the scope when the value is different.
+   * It's a bit slower, as it's trigger a change on the root scope afterward.
+   *
+   * TODO: Consider using Observables instead, that could be passed to Slot.enabled?
+   */
+  public syncSubscribe<U>(fn: () => U, defaultValue: U): () => U;
+  public syncSubscribe<U>(fn: () => U, defaultValue?: undefined): () => U | undefined;
+  public syncSubscribe<U>(fn: () => U, defaultValue?: U): () => U | undefined {
+    if (this[PluginScopeDisableNewSyncStatus]) {
+      throw new Error('The sync() factory may be executed only during initialization.');
+    }
+
+    const wrappedFn = (prevValue: U | undefined) => {
+      const nextValue = fn();
+      let root: PluginScope<any> = this;
+      while (root[PluginScopeParentScope]) {
+        root = root[PluginScopeParentScope];
+      }
+      if (prevValue !== nextValue) {
+        root[PluginScopeEmitChange]();
+      }
+      return nextValue;
+    };
     this[PluginScopeSyncData].set(wrappedFn, undefined);
     return () => this[PluginScopeSyncData].get(wrappedFn) ?? defaultValue;
   }


### PR DESCRIPTION
## Changes

- add `syncSubscribe()` method for plugins
  - it will emit information about `sync`ed value change to all scopes

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
