### PR TITLE
fix: avoid using external Babel replacement in the worker function

### DIFF
--- a/packages/web/src/components/molecules/LogOutput/createSearchScannerFn.ts
+++ b/packages/web/src/components/molecules/LogOutput/createSearchScannerFn.ts
@@ -93,6 +93,8 @@ export const createSearchScannerFn = (
   `
   );
   return (content: string) => {
-    [currentLineNumber, lineStartIndex] = scan(currentLineNumber, lineStartIndex, content, push);
+    const result = scan(currentLineNumber, lineStartIndex, content, push);
+    currentLineNumber = result[0];
+    lineStartIndex = result[1];
   };
 };


### PR DESCRIPTION
## Changes

- fix: avoid need to use external Babel replacement in the worker function

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
