### PR TITLE
fix: escape arguments containing spaces

### DIFF
--- a/packages/web/src/components/pages/Tests/TestDetails/TestSettings/SettingsVariables/Arguments.tsx
+++ b/packages/web/src/components/pages/Tests/TestDetails/TestSettings/SettingsVariables/Arguments.tsx
@@ -48,17 +48,21 @@ const Arguments: React.FC<ArgumentsProps> = ({readOnly}) => {
   const initialArgs = useMemo(() => entityArgs?.join('\n') || '', [entityArgs]);
 
   const currentArgs = Form.useWatch('args', form) || '';
-  const currentArgsArray =
-    currentArgs
-      .split('\n')
-      .map(arg => (arg.includes(' ') ? `"${arg}"` : arg))
-      .filter(Boolean) || [];
+
+  const formattedArgs = useMemo(() => {
+    const currentArgsArray = currentArgs.split('\n').filter(Boolean);
+    return currentArgsArray.map(arg => {
+      const trimmedArg = arg.replace(/\s+/g, ' ').trim();
+
+      return arg.includes(' ') ? `"${trimmedArg}"` : trimmedArg;
+    });
+  }, [currentArgs]);
 
   const isPrettified = useMemo(() => currentArgs === prettifyArguments(currentArgs), [currentArgs]);
 
   const onSaveForm = async () => {
     // Reset the form when there is no actual change
-    if (currentArgsArray.join('\n') === initialArgs) {
+    if (formattedArgs.join('\n') === initialArgs) {
       form.resetFields();
     }
 
@@ -66,7 +70,7 @@ const Arguments: React.FC<ArgumentsProps> = ({readOnly}) => {
       ...details,
       executionRequest: {
         ...details.executionRequest,
-        args: currentArgsArray,
+        args: formattedArgs,
       },
     };
 
@@ -104,7 +108,7 @@ const Arguments: React.FC<ArgumentsProps> = ({readOnly}) => {
       onCancel={onCancel}
     >
       <ArgumentsWrapper>
-        <CopyCommand command={currentArgsArray.join(' ')} isBordered additionalPrefix="executor-binary" />
+        <CopyCommand command={formattedArgs.join(' ')} isBordered additionalPrefix="executor-binary" />
         <FullWidthSpace size={16} direction="vertical">
           <Text className="regular middle" color={Colors.slate400}>
             Arguments passed to the executor (concat and passed directly to the executor)


### PR DESCRIPTION
## Fixes
 
- Escape arguments in textarea with spaces

## How to test it

- Add arguments to a test that contain space characters

## screenshots

![image](https://github.com/kubeshop/testkube-dashboard/assets/47887589/d4e2e3e0-a2ea-4190-90e4-4eda691bb113)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
