### PR TITLE
refactor: executions timestamp filter

### DIFF
--- a/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
@@ -61,28 +61,6 @@ const EntityDetailsHeader: FC<EntityDetailsHeaderProps> = ({
   const [daysFilterValue, setDaysFilterValue] = useEntityDetailsField('daysFilterValue');
   const testIcon = useExecutorIcon(details);
 
-  useEffect(() => {
-    if (!details) return;
-
-    const latestExecutionStartTime = details.status?.latestExecution.startTime;
-
-    if (!latestExecutionStartTime) return;
-
-    const latestExecutionStartTimeDate = new Date(latestExecutionStartTime);
-    const differenceInDays = Math.round((Date.now() - latestExecutionStartTimeDate.getTime()) / (1000 * 3600 * 24));
-
-    for (let i = 0; i < filterOptions.length; i += 1) {
-      if (Number(filterOptions[i].value) >= differenceInDays) {
-        setDaysFilterValue(Number(filterOptions[i].value));
-        return;
-      }
-
-      if (filterOptions[i].value === 0) {
-        setDaysFilterValue(0);
-      }
-    }
-  }, [details, setDaysFilterValue]);
-
   const {executions} = useEntityDetailsPick('executions');
 
   const isTestSuiteEmpty = entity === 'test-suites' && !details.steps?.length;
@@ -104,6 +82,28 @@ const EntityDetailsHeader: FC<EntityDetailsHeaderProps> = ({
       ].filter(Boolean),
     [executions?.totals?.running]
   );
+
+  useEffect(() => {
+    if (!details) return;
+
+    const latestExecutionStartTime = details.status?.latestExecution.startTime;
+
+    if (!latestExecutionStartTime) return;
+
+    const latestExecutionStartTimeDate = new Date(latestExecutionStartTime);
+    const differenceInDays = Math.round((Date.now() - latestExecutionStartTimeDate.getTime()) / (1000 * 3600 * 24));
+
+    for (let i = 0; i < filterOptions.length; i += 1) {
+      if (Number(filterOptions[i].value) >= differenceInDays) {
+        setDaysFilterValue(Number(filterOptions[i].value));
+        return;
+      }
+
+      if (filterOptions[i].value === 0) {
+        setDaysFilterValue(0);
+      }
+    }
+  }, [details, setDaysFilterValue]);
 
   return (
     <PageHeader

--- a/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import {FC, useMemo} from 'react';
+import {FC, useEffect, useMemo} from 'react';
 
 import {Select, Space} from 'antd';
 
@@ -60,6 +60,28 @@ const EntityDetailsHeader: FC<EntityDetailsHeaderProps> = ({
   const {entity, details} = useEntityDetailsPick('entity', 'details');
   const [daysFilterValue, setDaysFilterValue] = useEntityDetailsField('daysFilterValue');
   const testIcon = useExecutorIcon(details);
+
+  useEffect(() => {
+    if (!details) return;
+
+    const latestExecutionStartTime = details.status?.latestExecution.startTime;
+
+    if (!latestExecutionStartTime) return;
+
+    const latestExecutionStartTimeDate = new Date(latestExecutionStartTime);
+    const differenceInDays = Math.round((Date.now() - latestExecutionStartTimeDate.getTime()) / (1000 * 3600 * 24));
+
+    for (let i = 0; i < filterOptions.length; i += 1) {
+      if (Number(filterOptions[i].value) >= differenceInDays) {
+        setDaysFilterValue(Number(filterOptions[i].value));
+        return;
+      }
+
+      if (filterOptions[i].value === 0) {
+        setDaysFilterValue(0);
+      }
+    }
+  }, [details, setDaysFilterValue]);
 
   const {executions} = useEntityDetailsPick('executions');
 

--- a/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
@@ -88,7 +88,10 @@ const EntityDetailsHeader: FC<EntityDetailsHeaderProps> = ({
 
     const latestExecutionStartTime = details.status?.latestExecution.startTime;
 
-    if (!latestExecutionStartTime) return;
+    if (!latestExecutionStartTime) {
+      setDaysFilterValue(0);
+      return;
+    }
 
     const latestExecutionStartTimeDate = new Date(latestExecutionStartTime);
     const differenceInDays = Math.round((Date.now() - latestExecutionStartTimeDate.getTime()) / (1000 * 3600 * 24));

--- a/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/EntityDetailsHeader.tsx
@@ -30,7 +30,7 @@ const filterOptions: OptionType[] = [
   {value: 7, label: 'Timeframe: last 7 days', key: 'last7Days'},
   {value: 30, label: 'Timeframe: last 30 days', key: 'last30Days'},
   {value: 90, label: 'Timeframe: last 90 days', key: 'last90Days'},
-  {value: 365, label: 'Timeframe: this year', key: 'thisYear'},
+  {value: 365, label: 'Timeframe: last 12 months', key: 'last12Months'},
   {value: 0, label: 'See all executions', key: 'allDays'},
 ];
 

--- a/packages/web/src/components/organisms/EntityDetails/EntityDetailsLayer.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/EntityDetailsLayer.tsx
@@ -72,7 +72,7 @@ const EntityDetailsLayer: FC<PropsWithChildren<EntityDetailsLayerProps>> = ({
     {id, last: daysFilterValue, ...executionsFilters},
     {
       pollingInterval: PollingIntervals.long,
-      skip: !isSystemAvailable || !daysFilterValue,
+      skip: !isSystemAvailable || daysFilterValue === undefined,
     }
   );
 

--- a/packages/web/src/components/organisms/EntityDetails/EntityDetailsLayer.tsx
+++ b/packages/web/src/components/organisms/EntityDetails/EntityDetailsLayer.tsx
@@ -72,7 +72,7 @@ const EntityDetailsLayer: FC<PropsWithChildren<EntityDetailsLayerProps>> = ({
     {id, last: daysFilterValue, ...executionsFilters},
     {
       pollingInterval: PollingIntervals.long,
-      skip: !isSystemAvailable,
+      skip: !isSystemAvailable || !daysFilterValue,
     }
   );
 

--- a/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
@@ -29,11 +29,12 @@ const getKey = (record: any) => record.id;
 const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecution}) => {
   const [currentPage, setCurrentPage] = useEntityDetailsField('currentPage');
   const [executionsFilters, setExecutionsFilters] = useEntityDetailsField('executionsFilters');
-  const {executions, executionsLoading, id, isFirstTimeLoading} = useEntityDetailsPick(
+  const {daysFilterValue, executions, executionsLoading, id, isFirstTimeLoading} = useEntityDetailsPick(
     'executions',
     'id',
     'isFirstTimeLoading',
-    'executionsLoading'
+    'executionsLoading',
+    'daysFilterValue'
   );
   const {id: execId, open} = useExecutionDetailsPick('id', 'open');
   const isWritable = useSystemAccess(SystemAccess.agent);
@@ -99,7 +100,7 @@ const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecuti
     <>
       <ExecutionsFilters />
 
-      {isFiltering && executionsLoading ? (
+      {(isFiltering && executionsLoading) || !daysFilterValue ? (
         <LoadingSkeleton />
       ) : isFiltering && !executionsLoading && !executions?.results.length ? (
         <EmptyDataWithFilters resetFilters={() => setExecutionsFilters({textSearch: '', status: []})} />

--- a/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
+++ b/packages/web/src/components/organisms/ExecutionsTable/ExecutionsTable.tsx
@@ -29,12 +29,11 @@ const getKey = (record: any) => record.id;
 const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecution}) => {
   const [currentPage, setCurrentPage] = useEntityDetailsField('currentPage');
   const [executionsFilters, setExecutionsFilters] = useEntityDetailsField('executionsFilters');
-  const {daysFilterValue, executions, executionsLoading, id, isFirstTimeLoading} = useEntityDetailsPick(
+  const {executions, executionsLoading, id, isFirstTimeLoading} = useEntityDetailsPick(
     'executions',
     'id',
     'isFirstTimeLoading',
-    'executionsLoading',
-    'daysFilterValue'
+    'executionsLoading'
   );
   const {id: execId, open} = useExecutionDetailsPick('id', 'open');
   const isWritable = useSystemAccess(SystemAccess.agent);
@@ -100,7 +99,7 @@ const ExecutionsTable: React.FC<ExecutionsTableProps> = ({onRun, useAbortExecuti
     <>
       <ExecutionsFilters />
 
-      {(isFiltering && executionsLoading) || !daysFilterValue ? (
+      {isFiltering && executionsLoading ? (
         <LoadingSkeleton />
       ) : isFiltering && !executionsLoading && !executions?.results.length ? (
         <EmptyDataWithFilters resetFilters={() => setExecutionsFilters({textSearch: '', status: []})} />

--- a/packages/web/src/store/entityDetails.ts
+++ b/packages/web/src/store/entityDetails.ts
@@ -8,10 +8,10 @@ import {connectStore, createStoreFactory} from './utils';
 
 export interface EntityDetailsSlice {
   currentPage: number;
-  daysFilterValue: number;
   entity: Entity;
   isFirstTimeLoading: boolean;
   isV2: boolean;
+  daysFilterValue?: number;
   details?: any;
   error?: any;
   executions?: any;
@@ -26,7 +26,7 @@ export interface EntityDetailsSlice {
 
 const createEntityDetailsSlice: StateCreator<EntityDetailsSlice> = set => ({
   currentPage: 1,
-  daysFilterValue: 7,
+  daysFilterValue: undefined,
   entity: 'tests',
   isFirstTimeLoading: true,
   isV2: false,


### PR DESCRIPTION
## Changes

- Calculate the corresponding executions timestamp depending on when the latest execution happened

## screenshots

https://github.com/kubeshop/testkube-dashboard/assets/47887589/6c97c926-b2d9-4929-ba4e-dfde845dc696

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
